### PR TITLE
fix for seneca crashing when http output is not an object

### DIFF
--- a/lib/seneca.js
+++ b/lib/seneca.js
@@ -697,35 +697,42 @@ function Seneca($, opts) {
 
 
     function defaultresponder(req,res,handlerspec,err,obj) {
-      var outobj = _.clone(obj)
+      var outobj;
 
-      // TODO: test filtering
+      if (obj !== null && typeof obj === 'object') {
+        outobj = _.clone(obj)
 
-      var remove_dollar = false
-      if( !_.isUndefined(handlerspec.filter) ) {
-        if( _.isFunction( handlerspec.filter ) ) {
-          outobj = handlerspec.filter(outobj)
+        // TODO: test filtering
+
+        var remove_dollar = false
+        if( !_.isUndefined(handlerspec.filter) ) {
+          if( _.isFunction( handlerspec.filter ) ) {
+            outobj = handlerspec.filter(outobj)
+          }
+          else if( _.isArray( handlerspec.filter ) ) {
+            _.each(handlerspec.filter,function(p){
+              delete outobj[p]
+              remove_dollar = remove_dollar || '$'==p
+            })
+          }
         }
-        else if( _.isArray( handlerspec.filter ) ) {
-          _.each(handlerspec.filter,function(p){ 
-            delete outobj[p] 
-            remove_dollar = remove_dollar || '$'==p
+
+        // default filter
+        // removes $ from entity objects
+        else {
+          remove_dollar = true
+        }
+
+        if( remove_dollar ) {
+          _.keys(outobj,function(k){
+            if(~k.indexOf('$')){
+              delete outobj[k]
+            }
           })
         }
       }
-
-      // default filter
-      // removes $ from entity objects
       else {
-        remove_dollar = true
-      }
-
-      if( remove_dollar ) {
-        _.keys(outobj,function(k){
-          if(~k.indexOf('$')){
-            delete outobj[k]
-          }
-        })
+        outobj = obj;
       }
 
 


### PR DESCRIPTION
http output filter should ignore non-objects. not clear about functions, if output is ever a function then does it need filtering.
