### PR TITLE
Use `setImmediate` instead of `process.nextTick`

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -58,7 +58,7 @@ function Executor( options ) {
   function work( task, done ) {
     tr('work',task.id)
 
-    process.nextTick( function(){
+    setImmediate( function(){
       var completed = false
       var timedout  = false
 


### PR DESCRIPTION
`setImmediate` yields to the event loop after callback is called to
avoid the possibility of I/O starvation, which could happen with
`process.nextTick`.

I discovered this when working on `seneca-loadbalance-transport`, it was
causing 'Maximum call stack size exceeded' errors, related to the limit
of recursive `process.nextTick` calls.
