### PR TITLE
Fix listen function name

### DIFF
--- a/api.html
+++ b/api.html
@@ -94,7 +94,7 @@ layout: main
 
     <li>
       <a name="short-m-listen" href="#long-m-listen">
-        <h5><b>client</b>( <small>options</small> )</h5>
+        <h5><b>listen</b>( <small>options</small> )</h5>
         <p>Calls the <i>role:transport,cmd:listen</i> action from the transport plugin.</p>
       </a>
     </li>


### PR DESCRIPTION
Previous commit added two functions to the api list, both called "client".  The 2nd one linked to the "listen" content, but the name shown was "client".
