### PR TITLE
Moved lint rules to eslint-config-seneca

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,6 @@
 {
-  "extends": "standard",
   "rules": {
-    "no-labels": 0,
-    "no-multiple-empty-lines": 0,
-    "space-in-parens": 0,
-    no-return-assign: 0,
-    yoda: 0
+    "space-in-parens": 0
   },
   "extends": "seneca"
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,5 +1,4 @@
 /* Copyright (c) 2010-2015 Richard Rodger, MIT License */
-/* jshint node:true, asi:true, eqnull:true */
 'use strict'
 
 var util = require('util')

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -1,5 +1,4 @@
 /* Copyright (c) 2010-2015 Richard Rodger, MIT License */
-
 'use strict'
 
 var util = require('util')

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,6 +1,4 @@
 /* Copyright (c) 2013-2015 Richard Rodger, MIT License */
-/* jshint node:true, asi:true, eqnull:true */
-
 'use strict'
 
 var fs = require('fs')

--- a/lib/optioner.js
+++ b/lib/optioner.js
@@ -1,5 +1,4 @@
 /* Copyright (c) 2014-2015 Richard Rodger, MIT License */
-
 'use strict'
 
 var fs = require('fs')

--- a/lib/print.js
+++ b/lib/print.js
@@ -1,5 +1,4 @@
 /* Copyright (c) 2015 Richard Rodger, MIT License */
-/* jshint node:true, asi:true, eqnull:true */
 'use strict'
 
 var _ = require('lodash')

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,5 +1,4 @@
 /* Copyright (c) 2012-2015 Richard Rodger, MIT License */
-/* jshint node:true, asi:true, eqnull:true */
 'use strict'
 
 var _ = require('lodash')
@@ -173,5 +172,3 @@ module.exports = function () {
 
   return store
 }
-
-

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "eslint-config-seneca": "1.x.x",
     "eslint-plugin-hapi": "2.x.x",
     "eslint-plugin-standard": "1.x.x",
-    "jshint": "2.8.0",
     "lab": "6.0.0",
     "seneca-echo": "0.2.0",
     "seneca-error-test": "0.2.2"

--- a/seneca.js
+++ b/seneca.js
@@ -1,5 +1,4 @@
 /* Copyright (c) 2010-2015 Richard Rodger, MIT License */
-/* jshint node:true, asi:true, eqnull:true */
 // <style> p,ul,li { margin:5px !important; } </style>
 'use strict'
 


### PR DESCRIPTION
Rules in https://github.com/senecajs/seneca/commit/963d3f3b2f7285dda72b71377afc4aab8791e9d5 are now in v1.1.0 of eslint-config-seneca.  Removed jshint from deps and related comments.