### PR TITLE
api_delegate client|listen bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,9 @@ node_modules*
 README.html
 *.off
 *-off
-.DS_Store
 npm-debug.log
 mem.json
 out
 test/coverage.html
 test/report.html
-
+.idea

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,2 @@
+#!/usr/bin/env bash
 ./node_modules/.bin/jshint seneca.js lib/*.js

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "Jake Pruitt",
     "Marian Radulescu",
     "Alexandru Mircea",
-    "Adrian Rossouw (http://daemon.co.za)"
+    "Adrian Rossouw (http://daemon.co.za)",
+    "Aleksandar Ostojić"
   ],
   "dependencies": {
     "archy": "1.0.0",
@@ -68,7 +69,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/rjrodger/seneca.git"
+    "url": "git+ssh://git@github.com:Beats/seneca.git"
   },
   "scripts": {
     "test": "./node_modules/.bin/lab -v -P test -L",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:Beats/seneca.git"
+    "url": "https://github.com/rjrodger/seneca.git"
   },
   "scripts": {
     "test": "./node_modules/.bin/lab -v -P test -L",

--- a/seneca.js
+++ b/seneca.js
@@ -1913,11 +1913,11 @@ function make_seneca (initial_options) {
     delegate.context = {}
 
     delegate.client = function () {
-      return self.client.call(this, arguments)
+      return self.client.apply(this, arguments)
     }
 
     delegate.listen = function () {
-      return self.listen.call(this, arguments)
+      return self.listen.apply(this, arguments)
     }
 
     return delegate

--- a/seneca.js
+++ b/seneca.js
@@ -1557,7 +1557,7 @@ function make_seneca (initial_options) {
 
         // for exceptions thrown inside the callback
         catch(ex) {
-          var err = ex
+          err = ex
 
           // handle throws of non-Error values
           if (!util.isError(ex)) {


### PR DESCRIPTION
I've noticed the bug while implementing a amqp transport plugin.
It seems that __parseConfig__ is not able to handle the argument parsing when invoking __api_client__ through __api_delegate__, which resulted in always returning the default options (_web_ transport).

The fix is located in commit 2b8dc0b, where it seems to me to be a common mistake (call vs apply). 

Once changed everything started working again

I also did some general code cleanup located in all the other commits 

I haven't seen any specific documentation regarding the changes to package.json (wouldn't hurt to include something more elaborate in the contributing section on senecajs.org) so I took the liberty of adding myself to the contributors and changed the NPM repository since I'll be using the forked version on the project I'm working on. 

