### PR TITLE
Pass seneca instance on add callback

### DIFF
--- a/seneca.js
+++ b/seneca.js
@@ -1185,6 +1185,8 @@ function make_seneca (initial_options) {
         },
 
         fn: function (cb) {
+          cb.seneca = delegate
+
           if (root.closed && !callargs.closing$) {
             return cb(internals.error('instance-closed', {args: Common.clean(callargs)}))
           }

--- a/test/seneca.test.js
+++ b/test/seneca.test.js
@@ -276,6 +276,18 @@ describe('seneca', function () {
     })
   })
 
+  it('passes seneca instance on callback function property', function (done) {
+    var si = seneca({ log: 'silent', bind: { act: true, add: true } }).error(done)
+    si.add({ cmd: 'foo' }, function (args, reply) {
+      reply(null, { did: reply.seneca.did })
+    })
+    si.act({ cmd: 'foo' }, function (err, result) {
+      expect(err).to.not.exist()
+      expect(result.did).to.equal(this.did)
+      done()
+    })
+  })
+
   it('action-act-invalid-args', function (done) {
     var si = seneca(testopts).error(done)
     si.options({debug: {fragile: true}})

--- a/test/seneca.test.js
+++ b/test/seneca.test.js
@@ -277,7 +277,7 @@ describe('seneca', function () {
   })
 
   it('passes seneca instance on callback function property', function (done) {
-    var si = seneca({ log: 'silent', bind: { act: true, add: true } }).error(done)
+    var si = seneca({ log: 'silent' }).error(done)
     si.add({ cmd: 'foo' }, function (args, reply) {
       reply(null, { did: reply.seneca.did })
     })


### PR DESCRIPTION
Closes #288 
Closes #194 

The result is

```js
    const seneca = Seneca({ log: 'silent' })

    seneca.add({ cmd: 'foo' }, (args, reply) => {
      reply(null, { did: reply.seneca.did })
    })

    seneca.act({ cmd: 'foo' }, function (err, result) {
      // result.did === this.did
    })
```