### PR TITLE
fix '--seneca.print.tree' flag (fixes #235)

### DIFF
--- a/lib/print.js
+++ b/lib/print.js
@@ -3,9 +3,11 @@
 
 var _ = require('lodash')
 var archy = require('archy')
+var minimist = require('minimist')
 
 /** Handle command line specific functionality */
-module.exports = function (seneca, argv) {
+module.exports = function (seneca) {
+  var argv = minimist(process.argv.slice(2))
   if (!argv || !argv.seneca) {
     return
   }


### PR DESCRIPTION
Print was always called without the 'argv' argument causing
the tree to never be printed.