### PR TITLE
Exposing Seneca prototype for easier monkey-patching

### DIFF
--- a/seneca.js
+++ b/seneca.js
@@ -198,6 +198,9 @@ module.exports = function init (seneca_options, more_options) {
   return seneca
 }
 
+// Expose Seneca prototype for easier monkey-patching
+module.exports.Seneca = Seneca
+
 // To reference builtin loggers when defining logging options.
 module.exports.loghandler = Logging.handlers
 


### PR DESCRIPTION
I was recently writing a few monkey-patches around `Seneca.use` and `Seneca.act` to support promises, and found out that having access to Seneca prototype would make it so much easier.