### PR TITLE
Support preloaded plugin information

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -180,7 +180,19 @@ module.exports.register = function (so, callpoint) {
       })
 
     // needed for seneca.export to operate for plugins like seneca-web
-    seneca.private$.exports[meta.name || plugin.name] = meta.export || plugin
+    var preloadName = meta.name || plugin.name
+    var preloadRef = preloadName + (plugin.tag ? '/' + plugin.tag : '')
+    seneca.private$.exports[preloadName] = meta.export || plugin
+
+    if (_.isObject(meta.exportmap) || _.isObject(meta.exports)) {
+      meta.exportmap = meta.exportmap || meta.exports
+      _.each(meta.exportmap, function (v, k) {
+        if (v !== void 0) {
+          var exportname = preloadRef + '/' + k
+          seneca.private$.exports[exportname] = v
+        }
+      })
+    }
   }
 }
 

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -45,23 +45,19 @@ module.exports.register = function (so, callpoint) {
 
     var preload = plugin.init.preload
     preload = _.isFunction(preload) ? preload : _.noop
-
-    preload.call(seneca, plugin)
+    var meta = preload.call(seneca, plugin) || {}
 
     function plugin_definition (msg, plugin_done) {
       var seneca = this
 
       var fullname = plugin.name + (plugin.tag ? '/' + plugin.tag : '')
-
       plugin.fullname = fullname
 
       var delegate = make_delegate(seneca, plugin)
-
       var plugin_options = resolve_options(fullname, plugin, seneca)
 
       seneca.log.debug('register', 'init', fullname, callpoint(), plugin_options)
 
-      var meta
       try {
         meta = define_plugin(delegate, plugin, plugin_options)
       }
@@ -182,6 +178,9 @@ module.exports.register = function (so, callpoint) {
         fatal$: true,
         local$: true
       })
+
+    // needed for seneca.export to operate for plugins like seneca-web
+    seneca.private$.exports[meta.name || plugin.name] = meta.export || plugin
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "seneca-mem-store": "0.4.0",
     "seneca-repl": "0.0.1",
     "seneca-transport": "0.9.1",
-    "seneca-web": "0.6.0",
+    "seneca-web": "0.7.0",
     "use-plugin": "0.3.1",
     "zig": "0.1.1"
   },

--- a/seneca.js
+++ b/seneca.js
@@ -517,7 +517,6 @@ function make_seneca (initial_options) {
       }
     }
 
-
     function make_pin (pattern) {
       var api = {
         toString: function () {
@@ -525,7 +524,7 @@ function make_seneca (initial_options) {
         }
       }
 
-      thispin.ready(function () {
+      var calcPin = function () {
         var methods = private$.actrouter.list(pattern)
 
         methods.forEach(function (method) {
@@ -557,7 +556,15 @@ function make_seneca (initial_options) {
             }
           }
         }
-      })
+      }
+
+      if (private$._isReady) {
+        calcPin()
+      }
+      else {
+        root.once('pin', calcPin)
+      }
+
       return api
     }
 
@@ -896,6 +903,8 @@ function make_seneca (initial_options) {
       seneca.removeAllListeners('act-in')
       seneca.removeAllListeners('act-out')
       seneca.removeAllListeners('act-err')
+      seneca.removeAllListeners('pin')
+      seneca.removeAllListeners('after-pin')
       seneca.removeAllListeners('ready')
     }
   }
@@ -923,6 +932,9 @@ function make_seneca (initial_options) {
     }
 
     function do_ready () {
+      private$._isReady = true
+      root.emit('pin')
+      root.emit('after-pin')
       try {
         ready.call(self)
       }

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -1,0 +1,49 @@
+'use strict'
+
+var Http = require('http')
+var Code = require('code')
+var Connect = require('connect')
+var Lab = require('lab')
+var Seneca = require('../')
+
+var lab = exports.lab = Lab.script()
+var describe = lab.describe
+var it = lab.it
+var expect = Code.expect
+
+
+describe('connect', function () {
+  it('can route to actions', function (done) {
+    var seneca = Seneca({ log: 'silent' })
+    seneca.add({ role: 'api', cmd: 'foo' }, function (args, cb) {
+      cb(null, { foo: 'bar' })
+    })
+
+    seneca.use(function () {
+      seneca.act({ role: 'web' }, { use: {
+        prefix: '/test',
+        pin: { role: 'api', cmd: '*' },
+        map: {
+          foo: {
+            GET: true
+          }
+        }
+      } })
+    })
+
+    var app = Connect()
+    app.use(seneca.export('web'))
+
+    var server = Http.createServer(app)
+    server.once('listening', function () {
+      var port = server.address().port
+
+      Http.get('http://localhost:' + port + '/test/foo', function (res) {
+        expect(res.statusCode).to.equal(200)
+        res.pipe(process.stdout)
+        done()
+      })
+    })
+    server.listen(0)
+  })
+})


### PR DESCRIPTION
Exposing `pin` and `after-pin` events for seneca-web, to allow pinning and route generation to occur at the appropriate times, before seneca.ready fires.