### PR TITLE
Support strict.find setting

### DIFF
--- a/seneca.js
+++ b/seneca.js
@@ -109,7 +109,7 @@ var internals = {
       // Adding a pattern overrides existing pattern only if matches exactly.
       add: false,
 
-      // If an action found and strict.find is false, then no error returned with empty result
+      // If no action is found and find is false, then no error returned along with empty object
       find: true
     },
 

--- a/seneca.js
+++ b/seneca.js
@@ -107,7 +107,10 @@ var internals = {
       fixedargs: true,
 
       // Adding a pattern overrides existing pattern only if matches exactly.
-      add: false
+      add: false,
+
+      // If an action found and strict.find is false, then no error returned with empty result
+      find: true
     },
 
     // Action cache. Makes inbound messages idempotent.
@@ -1012,6 +1015,7 @@ function make_seneca (initial_options) {
     var callargs = args
     var actstats
     var act_callpoint = callpoint()
+    args.default$ = args.default$ || (!so.strict.find ? {} : args.default$)
 
     prior_ctxt = prior_ctxt || { chain: [], entry: true, depth: 1 }
 

--- a/test/seneca.test.js
+++ b/test/seneca.test.js
@@ -1615,4 +1615,31 @@ describe('seneca', function () {
       done()
     })
   })
+
+  it('supports strict.find for allowing not found actions', function (done) {
+    var seneca = Seneca({ log: 'silent', strict: { find: false } })
+    seneca.act({ a: 1 }, function (err, out) {
+      expect(err).to.not.exist()
+      expect(Object.keys(out).length).to.equal(0)
+      done()
+    })
+  })
+
+  it('supports strict.find for disabling not found actions', function (done) {
+    var seneca = Seneca({ log: 'silent', strict: { find: true } })
+    seneca.act({ a: 1 }, function (err, out) {
+      expect(err).to.exist()
+      expect(out).to.not.exist()
+      done()
+    })
+  })
+
+  it('supports strict.find not overriding existing default$', function (done) {
+    var seneca = Seneca({ log: 'silent', strict: { find: false } })
+    seneca.act({ a: 1, default$: { foo: 'bar' } }, function (err, out) {
+      expect(err).to.not.exist()
+      expect(Object.keys(out).length).to.equal(1)
+      done()
+    })
+  })
 })


### PR DESCRIPTION
When set to false, any not-found actions function as though they have a default$ passed in, and return an empty object.  The default is `strict.find = true`