### PR TITLE
pass all arguments to seneca.act callback

### DIFF
--- a/seneca.js
+++ b/seneca.js
@@ -1228,7 +1228,7 @@ function make_seneca (initial_options) {
 
         try {
           if (call_cb) {
-            actdone.apply(delegate, result.slice(0, 2)) // note: err == result[0]
+            actdone.apply(delegate, result) // note: err == result[0]
           }
         }
 

--- a/test/seneca.test.js
+++ b/test/seneca.test.js
@@ -386,6 +386,21 @@ describe('seneca', function () {
     })
   })
 
+  it('action-callback-args', function (done) {
+    var si = Seneca(testopts).error(done)
+
+    function foo (args, next) {
+      next.apply(null, args.items)
+    }
+    si.add({ op: 'foo' }, foo)
+
+    var items = [null, { one: 1 }, { two: 2 }, { three: 3 }]
+    si.act('op:foo', { items: items }, function () {
+      assert.equal(arguments.length, items.length)
+      done()
+    })
+  })
+
   it('action-extend', function (done) {
     var si = Seneca(testopts).error(done)
 


### PR DESCRIPTION
This is one way to address #340. If there are concerns about more arguments there's probably a workaround for seneca-postgres-store's specific problem, but this seemed like the easiest thing to try first.