### PR TITLE
Use lodash defaultsDeep to implement util.deepextend (fix #319).

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -147,70 +147,16 @@ exports.clean = clean
 
 function deepextend () {
   var args = arrayify(arguments)
-  args = _.reject(args, function (item) {
-    return _.isObject(args) && _.isEmpty(args)
-  })
-  var out = deepextend_impl.apply(null, args)
 
-  return out
+  // Lodash uses the reverse order to apply defaults than the deepextend API.
+  args = args.reverse()
+  // Add an empty object to the front of the args.  Defaults will be written
+  // to this empty object.
+  args.unshift({})
+
+  return _.defaultsDeep.apply(_, args)
 }
 exports.deepextend = deepextend
-
-// TODO: can still fail if objects are too deeply complex
-// need a finite bound on recursion
-function deepextend_impl (tar) {
-  tar = _.clone(tar)
-  _.each(Array.prototype.slice.call(arguments, 1), function (src) {
-    next_prop:
-    for (var p in src) {
-      var v = src[p]
-      if (v !== void 0) {
-        if (_.isString(v) ||
-          _.isNumber(v) ||
-          _.isBoolean(v) ||
-          _.isDate(v) ||
-          _.isFunction(v) ||
-          _.isArguments(v) ||
-          _.isRegExp(v)) {
-          tar[p] = v
-
-          // this also works for arrays - allows index-specific
-          // overrides if object used - see test/common-test.js
-        }
-        else if (_.isObject(v)) {
-          // don't descend into..
-
-          // entities
-          if (v.entity$) {
-            tar[p] = v
-          }
-
-          for (var f in v) {
-            if (_.isFunction(f)) {
-              tar[p] = v
-              break next_prop
-            }
-          }
-
-          tar[p] = _.isObject(tar[p]) ? tar[p] : (_.isArray(v) ? [] : {})
-
-          // for array/object mismatch, override completely
-          if ((_.isArray(v) && !_.isArray(tar[p])) ||
-            (!_.isArray(v) && _.isArray(tar[p]))) {
-            tar[p] = src[p]
-          }
-
-          tar[p] = deepextend_impl(tar[p], src[p])
-        }
-        else {
-          tar[p] = v
-        }
-      }
-    }
-  })
-
-  return tar
-}
 
 // loop over a list of items recursively
 // list can be an integer - number of times to recurse

--- a/test/seneca.util.test.js
+++ b/test/seneca.util.test.js
@@ -24,8 +24,8 @@ describe('seneca.util', function () {
   var si = Seneca(testopts)
 
   it('seneca.util.deepextend.happy', function (done) {
-    expect(Util.inspect(si.util.deepextend({}, {a: 1}, {b: {c: 2}}, {b: {c: 3, d: 4}}))).to.equal('{ a: 1, b: { c: 3, d: 4 } }')
-    expect(Util.inspect(si.util.deepextend({}, {a: 1}, {b: [11, 22]}, {b: [undefined, 222, 333]}))).to.equal('{ a: 1, b: [ 11, 222, 333 ] }')
+    expect(si.util.deepextend({}, {a: 1}, {b: {c: 2}}, {b: {c: 3, d: 4}})).to.deep.include({ a: 1, b: { c: 3, d: 4 } })
+    expect(si.util.deepextend({}, {a: 1}, {b: [11, 22]}, {b: [undefined, 222, 333]})).to.deep.include({ a: 1, b: [ 11, 222, 333 ] })
     done()
   })
 
@@ -85,28 +85,28 @@ describe('seneca.util', function () {
   })
 
   it('seneca.util.deepextend.mixed', function (done) {
-    var str = Util.inspect(si.util.deepextend(
+    var obj = si.util.deepextend(
       {}, {a: 1, b: {bb: 1}, c: 's', d: 'ss', e: [2, 3], f: {fa: 1, fb: 2}},
       {a: {aa: 1}, b: {bb: {bbb: 1}}, c: [1], d: {dd: 1}, e: {ee: 1}, f: [4, 5, 6]}
-    )).replace(/\s+/g, ' ')
+    )
 
-    expect(str).to.equal('{ a: { aa: 1 }, b: { bb: { bbb: 1 } }, c: [ 1 ], d: { dd: 1 }, e: { ee: 1 }, f: [ 4, 5, 6 ] }')
+    expect(obj).to.deep.include({ a: { aa: 1 }, b: { bb: { bbb: 1 } }, c: [ 1 ], d: { dd: 1 }, e: { ee: 1 }, f: [ 4, 5, 6 ] })
     done()
   })
 
   it('seneca.util.deepextend.entity', function (done) {
-    var str = Util.inspect(si.util.deepextend(
+    var obj = si.util.deepextend(
       {a: {x: 1}, b: {y: 1, entity$: 'a/b/c'}},
       {c: {z: 1}, b: {y: 2, entity$: 'a/b/c'}}
-    )).replace(/\s+/g, ' ')
+    )
 
-    expect(str).to.equal('{ a: { x: 1 }, b: { y: 2, \'entity$\': \'a/b/c\' }, c: { z: 1 } }')
+    expect(obj).to.deep.include({ a: { x: 1 }, b: { y: 2, 'entity$': 'a/b/c' }, c: { z: 1 } })
     done()
   })
 
   it('seneca.util.argprops', function (done) {
     var out = si.util.argprops({a: 1, b: 2, c: 3}, {b: 22, c: 33, d: 4}, {c: 333}, ['d'])
-    expect('{ a: 1, b: 22, c: 333 }').to.equal(Util.inspect(out))
+    expect(out).to.deep.include({ a: 1, b: 22, c: 333 })
 
     out = si.util.argprops({}, {d: 1}, {}, 'd')
     expect('{}').to.equal(Util.inspect(out))


### PR DESCRIPTION
This updates `util.deepextend` to internally use lodash's `defaultsDeep`.  The API to `deepextend` stays the same, only the internal implementation changes.    

The only slight difference is that the keys of the extended object may be in a different order than with the previous implementation.  That's why the tests in `test/seneca.util.test.js` no longer check against a string value.  I wouldn't imagine this is a breaking change, but thought it should be pointed out.