### PR TITLE
Remove Entities as a default plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "semver": "5.1.0",
     "seneca-basic": "0.4.0",
     "seneca-cluster": "0.0.1",
-    "seneca-entity": "0.0.1",
     "seneca-mem-store": "0.5.0",
     "seneca-repl": "0.2.0",
     "seneca-transport": "1.2.0",
@@ -110,6 +109,7 @@
     "lab": "6.2.x",
     "no-shadow-relaxed": "1.0.1",
     "seneca-echo": "0.3.0",
+    "seneca-entity": "0.0.1",
     "seneca-error-test": "0.2.2"
   }
 }

--- a/seneca.js
+++ b/seneca.js
@@ -66,7 +66,6 @@ var internals = {
     default_plugins: {
       basic: true,
       cluster: true,
-      entity: true,
       'mem-store': true,
       repl: true,
       transport: true,
@@ -212,7 +211,6 @@ module.exports = function init (seneca_options, more_options) {
 
   // Register default plugins, unless turned off by options.
   if (options.default_plugins.basic) { seneca.use(require('seneca-basic')) }
-  if (options.default_plugins.entity) { seneca.use(require('seneca-entity')) }
   if (options.default_plugins['mem-store']) { seneca.use(require('seneca-mem-store')) }
   if (options.default_plugins.transport) { seneca.use(require('seneca-transport')) }
   if (options.default_plugins.web) { seneca.use(require('seneca-web')) }

--- a/test/entity.plugin.test.js
+++ b/test/entity.plugin.test.js
@@ -43,6 +43,8 @@ describe('entity.plugin', function () {
         errhandler: done
       })
 
+    si.use('entity')
+
     // mem/foo
     var foo = si.make('foo')
     foo.a = 1

--- a/test/entity.test.js
+++ b/test/entity.test.js
@@ -21,6 +21,7 @@ var testopts = { log: 'silent' }
 describe('entity', function () {
   it('happy-mem', function (done) {
     var si = Seneca(testopts)
+    si.use('entity')
     si.options({errhandler: done})
 
     var fooent = si.make$('foo')
@@ -39,6 +40,7 @@ describe('entity', function () {
 
   it('setid-mem', function (done) {
     var si = Seneca(testopts).error(done)
+    si.use('entity')
 
     var z0 = si.make('zed')
     z0.id$ = 0
@@ -63,6 +65,7 @@ describe('entity', function () {
 
   it('mem-ops', function (done) {
     var si = Seneca(testopts)
+    si.use('entity')
     si.options({
       errhandler: function (err) { err && done(err); return true }
     })
@@ -164,6 +167,7 @@ describe('entity', function () {
 
   it('parsecanon', function (done) {
     var si = Seneca(testopts)
+    si.use('entity')
     function def (v, d) { return v == null ? d : v }
     function fmt (cn) { return def(cn.zone, '-') + '/' + def(cn.base, '-') + '/' + def(cn.name, '-') }
 
@@ -204,6 +208,7 @@ describe('entity', function () {
 
   it('make', function (done) {
     var si = Seneca(testopts)
+    si.use('entity')
 
     var foo = si.make$('foo')
     assert.equal('-/-/foo', foo.entity$)
@@ -256,6 +261,7 @@ describe('entity', function () {
 
   it('toString', function (done) {
     var si = Seneca(testopts)
+    si.use('entity')
 
     var f1 = si.make$('foo')
     f1.a = 1
@@ -276,6 +282,8 @@ describe('entity', function () {
       'bar': ['c', 'd']
     }}}))
 
+    si.use('entity')
+
     assert.equal('$-/-/foo;id=;{c:3,d:4}',
       si.make('foo', {a: 1, b: 2, c: 3, d: 4}).toString())
 
@@ -285,6 +293,7 @@ describe('entity', function () {
 
   it('isa', function (done) {
     var si = Seneca(testopts)
+    si.use('entity')
 
     var f1 = si.make$('foo')
 
@@ -321,6 +330,7 @@ describe('entity', function () {
 
   it('mem-store-import-export', function (done) {
     var si = Seneca(testopts).error(done)
+    si.use('entity')
 
     // NOTE: zone is NOT saved! by design!
 
@@ -346,6 +356,7 @@ describe('entity', function () {
           assert.equal(err, null)
 
           var si2 = Seneca(testopts)
+          si2.use('entity')
 
           si2.act('role:mem-store,cmd:import', {json: out.json}, function (err) {
             assert.equal(err, null)
@@ -390,6 +401,7 @@ describe('entity', function () {
 
   it('close', function (done) {
     var si = Seneca(testopts).error(done)
+    si.use('entity')
 
     var tmp = {s0: 0, s1: 0, s2: 0}
 

--- a/test/plugin/basic.test.js
+++ b/test/plugin/basic.test.js
@@ -37,6 +37,7 @@ describe('basic', function () {
   it('ensure_entity', function (fin) {
     var si = Seneca({log: 'test'})
     si.options({errhandler: fin})
+    si.use('entity')
 
     var foo_ent = si.make$('util_foo')
     var fooid = {}

--- a/test/seneca.test.js
+++ b/test/seneca.test.js
@@ -1154,6 +1154,8 @@ describe('seneca', function () {
     var si = Seneca(testopts)
     si.options({errhandler: done})
 
+    si.use('entity')
+
     var x = 0
 
     si.add({a: 1}, function (args, cb) {


### PR DESCRIPTION
@geek could you through a tasty eye over for sanity? Anything else to be done pre 2.0.0? anything you need changed?

- Removed entity as a default plugin
- Moved seneca-entity to devDeps to support tests
- Updated failing tests with .use('entity') to make em green

CC @naomifeehanmoran 