### PR TITLE
logging refactor: move existing logging to seneca-legacy-logging plug…

### DIFF
--- a/lib/legacy.js
+++ b/lib/legacy.js
@@ -1,9 +1,12 @@
 /* Copyright (c) 2010-2016 Richard Rodger and other contributors, MIT License */
 'use strict'
 
+var Fs = require('fs')
+
 var _ = require('lodash')
 var Eraro = require('eraro')
 var Errors = require('./errors')
+var Jsonic = require('jsonic')
 
 // Shortcuts
 var arrayify = Function.prototype.apply.bind(Array.prototype.slice)
@@ -49,4 +52,64 @@ exports.fail = function make_legacy_fail (so) {
 
     return err
   }
+}
+
+
+var handlers = exports.loghandler = {}
+
+
+var start_time = Date.now()
+
+handlers.pretty = function () {
+  var args = arrayify(arguments)
+  args[2] = args[2].toUpperCase()
+
+  if (args[0].short$) {
+    args[0] = '' + (args[0].getTime() - start_time)
+    args[0] = '        '.substring(0, 8 - args[0].length) + args[0]
+  }
+
+  var argstrs = []
+  args.forEach(function (a) {
+    var pstr = (a === null) ? a
+        : typeof (a) === 'string' ? a
+        : _.isDate(a) ? (a.toISOString())
+        : _.isObject(a) ? Jsonic.stringify(a) : a
+
+    argstrs.push(pstr)
+  })
+
+  return argstrs
+}
+
+handlers.silent = function silent () {
+  // does nothing!
+}
+
+handlers.print = function print () {
+  var arr = handlers.pretty.apply(null, arrayify(arguments))
+  console.log([arr.slice(0, 3).join(' ')].concat(arr.slice(3)).join('\t'))
+}
+
+handlers.stream = function stream (outstream, opts) {
+  opts = opts || {}
+  return function () {
+    var args = arrayify(arguments)
+    outstream.write(opts.format === 'json'
+      ? JSON.stringify(args) + '\n'
+      : handlers.pretty.apply(null, args).join('\t') + '\n')
+  }
+}
+
+handlers.emitter = function emitter (outemitter) {
+  return function () {
+    var args = arrayify(arguments)
+    outemitter.emit('log', args)
+  }
+}
+
+handlers.file = function file (filepath, opts) {
+  opts = opts || {}
+  var ws = Fs.createWriteStream(filepath, {flags: opts.flags || 'a'})
+  return handlers.stream(ws, opts)
 }

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,20 +1,18 @@
 /* Copyright (c) 2013-2015 Richard Rodger, MIT License */
 'use strict'
 
-var Fs = require('fs')
 var Util = require('util')
 var _ = require('lodash')
 var Patrun = require('patrun')
 var Jsonic = require('jsonic')
 var Eraro = require('eraro')
 var Common = require('./common')
+var Legacy = require('./legacy')
 
 // Shortcuts
 var arrayify = Function.prototype.apply.bind(Array.prototype.slice)
 
 var error = Eraro({ package: 'seneca', msgmap: ERRMSGMAP() })
-
-var start_time = Date.now()
 
 var log_index = {
   level: 2,
@@ -24,6 +22,42 @@ var log_index = {
   act: 6,
   pin: 7
 }
+
+var handlers = Legacy.loghandler
+
+
+function legacy_logging (options) {
+}
+
+legacy_logging.preload = function () {
+  var seneca = this
+
+  this.decorate('logroute', function api_logroute (entry, handler) {
+    if (arguments.length === 0) {
+      return seneca.log.router.toString()
+    }
+
+    entry.handler = handler || entry.handler
+    legacy_logging.makelogroute(entry, seneca.log.router)
+  }
+)
+
+  return {
+    exportmap: {
+      log_act_in: legacy_logging.log_act_in,
+      log_act_out: legacy_logging.log_act_out,
+      log_act_err: legacy_logging.log_act_err,
+      log_act_bad: legacy_logging.log_act_bad,
+      log_act_cache: legacy_logging.log_act_cache,
+      log_exec_err: legacy_logging.log_exec_err,
+      make_delegate_log: legacy_logging.make_delegate_log
+    }
+  }
+}
+
+
+module.exports = legacy_logging
+
 
 function multiplexhandler (a, b) {
   if (a.multiplex) {
@@ -52,10 +86,8 @@ function multiplexhandler (a, b) {
   }
 }
 
-var handlers = exports.handlers = {}
-
 // entry = single entry, from map:[]
-var makelogroute = exports.makelogroute = function (entry, logrouter) {
+var makelogroute = legacy_logging.makelogroute = function (entry, logrouter) {
   var propnames = ['level', 'type', 'plugin', 'tag', 'case']
   var loglevels = ['debug', 'info', 'warn', 'error', 'fatal']
 
@@ -229,7 +261,7 @@ logspec.map:
 
 */
 
-var makelogrouter = exports.makelogrouter = function (logspec) {
+var makelogrouter = legacy_logging.makelogrouter = function (logspec) {
   var map = []
 
   if (logspec === null ||
@@ -331,63 +363,8 @@ function make_pin_handler (pin, handler) {
   }
 }
 
-handlers.pretty = function () {
-  var args = arrayify(arguments)
-  args[2] = args[2].toUpperCase()
 
-  if (args[0].short$) {
-    args[0] = '' + (args[0].getTime() - start_time)
-    args[0] = '        '.substring(0, 8 - args[0].length) + args[0]
-  }
-
-  var argstrs = []
-  args.forEach(function (a) {
-    var pstr = (a === null) ? a
-        : typeof (a) === 'string' ? a
-        : _.isDate(a) ? (a.toISOString())
-        : _.isObject(a) ? Jsonic.stringify(a) : a
-
-    argstrs.push(pstr)
-  })
-
-  return argstrs
-}
-
-handlers.silent = function silent () {
-  // does nothing!
-}
-
-handlers.print = function print () {
-  var arr = handlers.pretty.apply(null, arrayify(arguments))
-  console.log([arr.slice(0, 3).join(' ')].concat(arr.slice(3)).join('\t'))
-}
-
-handlers.stream = function stream (outstream, opts) {
-  opts = opts || {}
-  return function () {
-    var args = arrayify(arguments)
-    outstream.write(opts.format === 'json'
-      ? JSON.stringify(args) + '\n'
-      : handlers.pretty.apply(null, args).join('\t') + '\n')
-  }
-}
-
-handlers.emitter = function emitter (outemitter) {
-  return function () {
-    var args = arrayify(arguments)
-    outemitter.emit('log', args)
-  }
-}
-
-handlers.file = function file (filepath, opts) {
-  opts = opts || {}
-  var ws = Fs.createWriteStream(filepath, {flags: opts.flags || 'a'})
-  return handlers.stream(ws, opts)
-}
-
-// TODO: HTTP logging as per node-logentries
-
-var makelogfuncs = exports.makelogfuncs = function (target) {
+var makelogfuncs = legacy_logging.makelogfuncs = function (target) {
   function makelogger (level) {
     return function () {
       var args = arrayify(arguments)
@@ -403,7 +380,7 @@ var makelogfuncs = exports.makelogfuncs = function (target) {
   target.log.fatal = makelogger('fatal')
 }
 
-exports.makelog = function (logspec, ctxt) {
+legacy_logging.makelog = function (logspec, ctxt) {
   var identifier = ctxt.id
   var short = ctxt.short || logspec.short
   var logrouter = makelogrouter(logspec)
@@ -534,9 +511,9 @@ function parse_command_line (spec, logspec, flags) {
   }
 }
 
-exports.parse_command_line = parse_command_line
+legacy_logging.parse_command_line = parse_command_line
 
-exports.log_act_in = function (instance, actinfo, actmeta, args, prior_ctxt, act_callpoint) {
+legacy_logging.log_act_in = function (instance, actinfo, actmeta, args, prior_ctxt, act_callpoint) {
   actmeta = actmeta || {}
   if (actmeta.sub) {
     return
@@ -565,7 +542,7 @@ exports.log_act_in = function (instance, actinfo, actmeta, args, prior_ctxt, act
     })
 }
 
-exports.log_act_out = function (instance, actinfo, actmeta, args, result, prior_ctxt, act_callpoint) {
+legacy_logging.log_act_out = function (instance, actinfo, actmeta, args, result, prior_ctxt, act_callpoint) {
   actmeta = actmeta || {}
   if (actmeta.sub) {
     return
@@ -598,7 +575,7 @@ exports.log_act_out = function (instance, actinfo, actmeta, args, result, prior_
   )
 }
 
-exports.log_act_err = function (instance, actinfo, actmeta, args, prior_ctxt, err, act_callpoint) {
+legacy_logging.log_act_err = function (instance, actinfo, actmeta, args, prior_ctxt, err, act_callpoint) {
   actmeta = actmeta || {}
   if (err && err.log === false) {
     return
@@ -628,7 +605,7 @@ exports.log_act_err = function (instance, actinfo, actmeta, args, prior_ctxt, er
   )
 }
 
-exports.log_act_cache = function (instance, actinfo, actmeta, args, prior_ctxt, act_callpoint) {
+legacy_logging.log_act_cache = function (instance, actinfo, actmeta, args, prior_ctxt, act_callpoint) {
   actmeta = actmeta || {}
 
   instance.log.debug(
@@ -652,7 +629,7 @@ exports.log_act_cache = function (instance, actinfo, actmeta, args, prior_ctxt, 
     })
 }
 
-exports.log_exec_err = function (instance, err) {
+legacy_logging.log_exec_err = function (instance, err) {
   if (err && err.log === false) {
     return
   }
@@ -671,7 +648,7 @@ exports.log_exec_err = function (instance, err) {
     err.stack)
 }
 
-exports.log_act_bad = function (instance, err, loglevel) {
+legacy_logging.log_act_bad = function (instance, err, loglevel) {
   if (err && err.log === false) {
     return
   }
@@ -697,7 +674,7 @@ exports.log_act_bad = function (instance, err, loglevel) {
     err.stack)
 }
 
-exports.make_delegate_log = function (actid, actmeta, instance) {
+legacy_logging.make_delegate_log = function (actid, actmeta, instance) {
   actmeta = actmeta || {}
   var log = actmeta.log
   var pattern = actmeta.pattern

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -13,7 +13,7 @@ var expect = Code.expect
 var testopts = { log: 'test', debug: { short_logs: true } }
 
 
-describe('seneca', function () {
+describe('close', function () {
   lab.beforeEach(function (done) {
     process.removeAllListeners('SIGHUP')
     process.removeAllListeners('SIGTERM')

--- a/test/seneca.test.js
+++ b/test/seneca.test.js
@@ -1200,7 +1200,7 @@ describe('seneca', function () {
             // --seneca.log.all and count INs
             // ... | grep act | grep IN | wc -l
             // sensitive to changes in plugin init and internal action calls
-            assert.equal('{ calls: 14, done: 14, fails: 0, cache: 1 }',
+            assert.equal('{ calls: 15, done: 15, fails: 0, cache: 1 }',
               Util.inspect(stats.act))
             done()
           })

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -122,8 +122,8 @@ describe('connect', function () {
           })
           res.once('end', function () {
             var parts = payload.split('/')
-            expect(parts.length).to.equal(4)
-            expect(parts[3]).to.contain('-')
+            expect(parts.length).to.equal(5)
+            expect(parts[4]).to.contain('-')
             done()
           })
         })


### PR DESCRIPTION
…in; partial validation of loading as plugin

The end goal here is to let Seneca log internally using plain old JS objects, and to impose semantics via plugins. The first step is to extract the legacy logging code into a plugin.

There are a number of load and init sequence issues, so this has to be done carefully. This PR establishes that a subset of the legacy Logging functions can be provided via a plugin, via the preload capability.