### PR TITLE
Update lodash to 4.6.0 to fix an issue extending function properties with Common.deepextend()

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "gate-executor": "0.4.0",
     "gex": "0.2.2",
     "jsonic": "0.2.2",
-    "lodash": "4.5.0",
+    "lodash": "4.6.0",
     "lru-cache": "4.0.0",
     "minimist": "1.2.0",
     "nid": "0.3.2",

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -99,6 +99,25 @@ describe('common', function () {
     done()
   })
 
+  it('deepextend-objs with functions', function (done) {
+    function noop () {}
+    function f1 () {}
+
+    var defaults = {
+      a: noop,
+      b: noop
+    }
+    var options = {
+      a: f1
+    }
+
+    var out = Common.deepextend(defaults, options)
+
+    assert.strictEqual(out.a, f1)
+    assert.strictEqual(out.b, noop)
+    done()
+  })
+
   it('pattern', function (done) {
     assert.equal('a:1', Common.pattern({a: 1}))
     assert.equal('a:1,b:2', Common.pattern({a: 1, b: 2}))


### PR DESCRIPTION
I ran into an issue providing middleware functions for the seneca-web plugin through the jsonrest-api plugin. The provided startware function got called twice. I found that there is a problem extending the default options object. One function was extended to every function property (see screenshot).

![screenshot from 2016-07-27 12-54-58](https://cloud.githubusercontent.com/assets/849548/17165281/83a3702e-53f9-11e6-8909-29d218a3b2b8.png)

This bug doesn't only happen in the seneca-web or jsonrest-api plugin. I also successfully npm test'ed with the latest lodash version 4.14.0.
