### PR TITLE
Fix a link to the Seneca website

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Licensed under __[MIT][Lic]__.
 [Lic]: ./LICENSE
 [Logo]: http://senecajs.org/files/assets/seneca-logo.jpg
 [Npm]: https://www.npmjs.com/package/seneca
-[Org]: https://github.com/senecajs/issues
+[Org]: http://senecajs.org/
 [Pull]: https://github.com/senecajs/seneca/pulls
 [Sponsor]: http://nearform.com
 [Travis]: https://travis-ci.org/senecajs/seneca?branch=master


### PR DESCRIPTION
For some reason, the link used when seneca.org is mentioned is the GitHub issues link, which I believe was not intentional.