### PR TITLE
Use json-stringify-safe to prevent circular references

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,6 +1,7 @@
 /* Copyright (c) 2016 Richard Rodger and other contributors, MIT License */
 'use strict'
 
+var Stringify = require('json-stringify-safe')
 var LogFilter = require('seneca-log-filter')
 var _ = require('lodash')
 
@@ -42,7 +43,7 @@ logging.preload = function () {
 
   var logger = function (seneca, data) {
     if (logrouter && logrouter(data)) {
-      console.log(JSON.stringify(data))
+      console.log(Stringify(data))
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "eslint-config-seneca": "3.x.x",
     "eslint-plugin-hapi": "4.x.x",
     "eslint-plugin-standard": "2.x.x",
+    "json-stringify-safe": "^5.0.1",
     "lab": "11.0.x",
     "seneca-entity": "1.3.x",
     "seneca-error-test": "0.2.x"


### PR DESCRIPTION
Fixes #555 

There might be a cleaner way to fix this - this will at least ensure it doesn't explode in a fire without writing out logging details.

Down side of course is that the `console.log` of `request$` and `response$` is *massive*.  It should probably omit these.

