### PR TITLE
Upgraded json-stringfy-safe to a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "gate-executor": "1.1.0",
     "gex": "0.2.2",
     "jsonic": "0.2.2",
+    "json-stringify-safe": "5.0.1",
     "lodash": "4.15.0",
     "lru-cache": "4.0.1",
     "minimist": "1.2.0",
@@ -105,7 +106,6 @@
     "eslint-config-seneca": "3.x.x",
     "eslint-plugin-hapi": "4.x.x",
     "eslint-plugin-standard": "2.x.x",
-    "json-stringify-safe": "5.x.x",
     "lab": "11.0.x",
     "seneca-entity": "1.3.x",
     "seneca-error-test": "0.2.x"


### PR DESCRIPTION
The module "json-stringify-safe": "5.x.x" is referenced in lib/logging.js and is currently a dev-dependency. I think it should be a regular dependency because lib/logging is required in seneca.js unless a logging plugin is specified.