### PR TITLE
Updated seneca-transport to prevent tcp no timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "toolkit",
     "startup"
   ],
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "MIT",
   "homepage": "http://senecajs.org",
   "author": "Richard Rodger (http://richardrodger.com/)",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "seneca-cluster": "0.0.1",
     "seneca-mem-store": "0.5.0",
     "seneca-repl": "0.2.0",
-    "seneca-transport": "1.2.0",
+    "seneca-transport": "2.1.0",
     "seneca-web": "0.7.1",
     "use-plugin": "0.3.1",
     "zig": "0.1.1"


### PR DESCRIPTION
This is a collage of seneca 2.1.0 with seneca-transport at 2.1.0 to get working TCP with timeouts properly.

| Feature | Timeouts | TCP |
| :-- | :-: | :-: |
| seneca 2.1.0 / seneca-transport 1.2.0 | ✓ | x |
| seneca 3.x / seneca-transport 2.1.0 | x | ✓ |
| seneca 2.1.0 / seneca-transport 2.1.0 | ✓ | ✓ |
