### PR TITLE
Remove 404 fatal.html link on error log

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -275,8 +275,7 @@ exports.makedie = function (instance, ctxt) {
 
       var fatalmodemsg = instance.fixedargs.fatal$
         ? '\n  ALL ERRORS FATAL: action called with argument fatal$:true ' +
-        '(probably a plugin init error, or using a plugin seneca instance' +
-        ', see senecajs.org/fatal.html)' : ''
+        '(probably a plugin init error, or using a plugin seneca instance)' : ''
 
       var stderrmsg =
       '\n\n' +


### PR DESCRIPTION
This removes the `senecajs.org/fatal.html` URL printed out on `FATAL` errors, which does not currently exist and responds with a `404`. Issue was reported [here](https://github.com/senecajs/senecajs.org/issues/236).

We should add it back when we have a working site page.
