### PR TITLE
Add tests to check actions timeout behaviour

### DIFF
--- a/test/timeout.test.js
+++ b/test/timeout.test.js
@@ -13,9 +13,7 @@ var describe = lab.describe
 var it = lab.it
 var expect = Code.expect
 
-
 describe('timeout', function () {
-
   it('returns error', function (fin) {
     Seneca({timeout: 100})
       .add('a:1', function (msg, done) {
@@ -43,5 +41,4 @@ describe('timeout', function () {
       })
       .act('a:1')
   })
-
 })

--- a/test/timeout.test.js
+++ b/test/timeout.test.js
@@ -1,0 +1,47 @@
+/* Copyright (c) 2016 Richard Rodger, MIT License */
+'use strict'
+
+var Lab = require('lab')
+var Code = require('code')
+
+
+var Seneca = require('..')
+
+
+var lab = exports.lab = Lab.script()
+var describe = lab.describe
+var it = lab.it
+var expect = Code.expect
+
+
+describe('timeout', function () {
+
+  it('returns error', function (fin) {
+    Seneca({timeout: 100})
+      .add('a:1', function (msg, done) {
+        setTimeout(function () {
+          done(null, {a: 2})
+        }, 300)
+      })
+      .act('a:1', function (err, out) {
+        expect(err).to.exist()
+        expect(out).to.not.exist()
+        fin()
+      })
+  })
+
+  it('still call error if callback not present', function (fin) {
+    Seneca({timeout: 100})
+      .error(function (err) {
+        expect(err).to.exist()
+        fin()
+      })
+      .add('a:1', function (msg, done) {
+        setTimeout(function () {
+          done(null, {a: 2})
+        }, 300)
+      })
+      .act('a:1')
+  })
+
+})


### PR DESCRIPTION
Relates to https://github.com/senecajs/seneca/issues/517

@rjrodger the behaviour was broken on seneca 3.2.0, it is now fixed with the update of gate-executor