### PR TITLE
Fix basemodule with jest execution

### DIFF
--- a/lib/optioner.js
+++ b/lib/optioner.js
@@ -21,7 +21,14 @@ module.exports = function(callmodule, defaults, orig_initial) {
   // Must be defined here as prepare depends on it.
   var options = {}
 
-  var basemodule = orig_initial.module || callmodule.parent || callmodule
+  var basemodule
+  if (orig_initial.module && orig_initial.module.require) {
+    basemodule = orig_initial.module
+  } else if (callmodule.parent && callmodule.parent.require) {
+    basemodule = callmodule.parent
+  } else {
+    basemodule = callmodule
+  }
   options = prepare(basemodule, defaults, orig_initial)
 
   // Not needed after this point, and screws up debug printing.


### PR DESCRIPTION
Jest with the default settings wraps the module in order to allow its mocking capabilities. That leads to a mock object being the basemodule.
A check if the basemodule also has a require function prevents that behaviour.

```
    TypeError: basemodule.require is not a function

      at prepare (node_modules/seneca/lib/optioner.js:62:43)
      at Object.<anonymous>.module.exports (node_modules/seneca/lib/optioner.js:27:13)
      at make_seneca (node_modules/seneca/seneca.js:297:23)
      at init (node_modules/seneca/seneca.js:215:16)
      at testSeneca (src/order/spec/create-order.spec.js:4:10)
      at Object.<anonymous>.done (src/order/spec/create-order.spec.js:10:18)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
      at process._tickCallback (internal/process/next_tick.js:103:7)
```