### PR TITLE
Add order does not matter in mesh/balance plugin

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -241,7 +241,7 @@ exports.client = function(callpoint) {
     _.each(pins, function(pin) {
       pin = _.clone(pin)
       pin.client$ = true
-
+      pin.strict$ = { add: true }
       sd.add(pin, transport_client)
     })
 


### PR DESCRIPTION
This solve a problem that makes the service behavior changes depending on the order services are announced.

In links bellow are more detailed information with runnable examples.

https://github.com/senecajs/seneca-mesh/issues/106

https://github.com/senecajs/seneca-balance-client/issues/35

This change seems do not affect the tests but I am not sure if it can cause any other side effects since I do not have a full knowledge of the framework internals.

What are your thoughts on it?

Thanks.

Congrats for your great work.

Aloha!

Rafael Sobral