### PR TITLE
chore: remove Node.js 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 sudo: false
 
 node_js:
-  - '4'
   - '6'
   - '8'
   - '10'


### PR DESCRIPTION
Node.js 4 reached its EOL.