### PR TITLE
seneca.fail - allow the boolean first arg to trigger the error throw

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -168,13 +168,44 @@ exports.error = function (first) {
 }
 
 // NOTE: plugin error codes are in their own namespaces
-exports.fail = function (code, args) {
-  var error = this.error(code, args)
+exports.fail = function (...args) {
+  if (args.length === 2) {
+    return mustFail(this, ...args)
+  }
 
-  if (args && false === args.throw$) {
-    return error
-  } else {
-    throw error
+  if (args.length === 3) {
+    return failIf(this, ...args)
+  }
+
+  throw this.util.error('fail_wrong_number_of_args',
+    { num_args: args.length })
+
+
+  function mustFail(self, code, args) {
+    const error = self.error(code, args)
+
+    if (args && false === args.throw$) {
+      return error
+    } else {
+      throw error
+    }
+  }
+
+  function failIf(self, cond, code, args) {
+    Assert(typeof cond === 'boolean',
+      'Expected the `cond` param to be a boolean.')
+
+    if (!cond) {
+      return
+    }
+
+    const error = self.error(code, args)
+
+    if (args && false === args.throw$) {
+      return error
+    } else {
+      throw error
+    }
   }
 }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -182,8 +182,9 @@ exports.fail = function (...args) {
 
 
   function failIf(self, cond, code, args) {
-    Assert(typeof cond === 'boolean',
-      'Expected the `cond` param to be a boolean.')
+    if (typeof cond !== 'boolean') {
+      throw self.util.error('fail_cond_must_be_bool')
+    }
 
     if (!cond) {
       return

--- a/lib/api.js
+++ b/lib/api.js
@@ -170,7 +170,7 @@ exports.error = function (first) {
 // NOTE: plugin error codes are in their own namespaces
 exports.fail = function (...args) {
   if (args.length === 2) {
-    return mustFail(this, ...args)
+    return failIf(this, true, ...args)
   }
 
   if (args.length === 3) {
@@ -180,16 +180,6 @@ exports.fail = function (...args) {
   throw this.util.error('fail_wrong_number_of_args',
     { num_args: args.length })
 
-
-  function mustFail(self, code, args) {
-    const error = self.error(code, args)
-
-    if (args && false === args.throw$) {
-      return error
-    } else {
-      throw error
-    }
-  }
 
   function failIf(self, cond, code, args) {
     Assert(typeof cond === 'boolean',

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -142,6 +142,9 @@ module.exports = {
   no_error_code:
     'The Seneca.error or Seneca.fail method was called without an error code string as first argument.',
 
+  fail_wrong_number_of_args:
+    'The Seneca.fail method was called with the wrong number of arguments: <%=num_args%>',
+
   action_timeout:
     '<%=legacy_string%>Action <%=pattern%> timed out. Timeout was: <%=timeout%> (start: <%=start%>, end: <%=end%>. Message was: <%=message%>.',
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -145,6 +145,9 @@ module.exports = {
   fail_wrong_number_of_args:
     'The Seneca.fail method was called with the wrong number of arguments: <%=num_args%>',
 
+  fail_cond_must_be_bool:
+    'The Seneca.fail method expected the `cond` param to be a boolean.',
+
   action_timeout:
     '<%=legacy_string%>Action <%=pattern%> timed out. Timeout was: <%=timeout%> (start: <%=start%>, end: <%=end%>. Message was: <%=message%>.',
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -97,17 +97,22 @@ describe('api', function () {
       })
 
       describe('when the condition is not a boolean', function () {
-        it('throws an assertion error', function (fin) {
+        it('throws informing the client of the wrong type', function (fin) {
           try {
             si.fail(0, 'test_args', { arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
           } catch (err) {
-            expect(err).instanceOf(Assert.AssertionError)
-            expect(err.message).equal('Expected the `cond` param to be a boolean.')
+            expect(err.code).equal('fail_cond_must_be_bool')
+
+            expect(err.message).equal(
+              'seneca: The Seneca.fail method expected the `cond` param to be a boolean.'
+            )
+
+            expect(err.seneca).true()
 
             return fin()
           }
 
-          return fin(new Error('Expected an assertion to fail.'))
+          return fin(new Error('Expected the "fail" method to throw.'))
         })
       })
     })

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,6 +1,8 @@
 /* Copyright (c) 2010-2018 Richard Rodger, MIT License */
 'use strict'
 
+const Assert = require('assert')
+
 const Code = require('@hapi/code')
 const Lab = require('@hapi/lab')
 
@@ -48,17 +50,103 @@ describe('api', function () {
     fin()
   })
 
-  it('fail', function (fin) {
-    try {
-      si.fail('test_args', { arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
-    } catch (e0) {
-      expect(e0.code).equal('test_args')
-      expect(e0.message).equal('seneca: Test args foo { bar: 1 }.')
-      expect(e0.details).equal({ arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
-      expect(e0.seneca).true()
-    }
+  describe('fail', function () {
+    it('invoked with a code and details', function (fin) {
+      try {
+        si.fail('test_args', { arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
+      } catch (e0) {
+        expect(e0.code).equal('test_args')
+        expect(e0.message).equal('seneca: Test args foo { bar: 1 }.')
+        expect(e0.details).equal({ arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
+        expect(e0.seneca).true()
+      }
 
-    fin()
+      fin()
+    })
+
+    describe('invoked with a condition, code and details', function () {
+      describe('when the condition is true', function () {
+        it('throws', function (fin) {
+          try {
+            si.fail(true, 'test_args', { arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
+          } catch (e0) {
+            expect(e0.code).equal('test_args')
+            expect(e0.message).equal('seneca: Test args foo { bar: 1 }.')
+            expect(e0.details).equal({ arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
+            expect(e0.seneca).true()
+          }
+
+          return fin()
+        })
+      })
+
+      describe('when the condition is false', function () {
+        it('does not throw', function (fin) {
+          try {
+            si.fail(false, 'test_args', { arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
+          } catch (err) {
+            return fin(new Error('Expected the "fail" method to not throw.'))
+          }
+
+          return fin()
+        })
+      })
+
+      describe('when the condition is not a boolean', function () {
+        it('throws an assertion error', function (fin) {
+          try {
+            si.fail(0, 'test_args', { arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
+          } catch (err) {
+            expect(err).instanceOf(Assert.AssertionError)
+            expect(err.message).equal('Expected the `cond` param to be a boolean.')
+
+            return fin()
+          }
+
+          return fin(new Error('Expected an assertion to fail.'))
+        })
+      })
+    })
+
+    describe('when given no arguments', function () {
+      it('throws a seneca error', function (fin) {
+        try {
+          si.fail()
+        } catch (err) {
+          expect(err.code).equal('fail_wrong_number_of_args')
+
+          expect(err.message).equal(
+            'seneca: The Seneca.fail method was called with the wrong number of arguments: 0'
+          )
+
+          expect(err.seneca).true()
+
+          return fin()
+        }
+
+        return fin(new Error('Expected the "fail" method to throw.'))
+      })
+    })
+
+    describe('when given too many arguments', () => {
+      it('throws a seneca error', function (fin) {
+        try {
+          si.fail(true, 'test_args', { arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 }, 2)
+        } catch (err) {
+          expect(err.code).equal('fail_wrong_number_of_args')
+
+          expect(err.message).equal(
+            'seneca: The Seneca.fail method was called with the wrong number of arguments: 4'
+          )
+
+          expect(err.seneca).true()
+
+          return fin()
+        }
+
+        return fin(new Error('Expected the "fail" method to throw.'))
+      })
+    })
   })
 
   it('list', function (fin) {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -54,14 +54,16 @@ describe('api', function () {
     it('invoked with a code and details', function (fin) {
       try {
         si.fail('test_args', { arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
-      } catch (e0) {
-        expect(e0.code).equal('test_args')
-        expect(e0.message).equal('seneca: Test args foo { bar: 1 }.')
-        expect(e0.details).equal({ arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
-        expect(e0.seneca).true()
+      } catch (err) {
+        expect(err.code).equal('test_args')
+        expect(err.message).equal('seneca: Test args foo { bar: 1 }.')
+        expect(err.details).equal({ arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
+        expect(err.seneca).true()
+
+        return fin()
       }
 
-      fin()
+      return fin(new Error('Expected the "fail" method to throw.'))
     })
 
     describe('invoked with a condition, code and details', function () {
@@ -69,14 +71,16 @@ describe('api', function () {
         it('throws', function (fin) {
           try {
             si.fail(true, 'test_args', { arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
-          } catch (e0) {
-            expect(e0.code).equal('test_args')
-            expect(e0.message).equal('seneca: Test args foo { bar: 1 }.')
-            expect(e0.details).equal({ arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
-            expect(e0.seneca).true()
+          } catch (err) {
+            expect(err.code).equal('test_args')
+            expect(err.message).equal('seneca: Test args foo { bar: 1 }.')
+            expect(err.details).equal({ arg0: 'foo', arg1: { bar: 1 }, not_an_arg: 1 })
+            expect(err.seneca).true()
+
+            return fin()
           }
 
-          return fin()
+          return fin(new Error('Expected the "fail" method to throw.'))
         })
       })
 

--- a/test/coverage.html
+++ b/test/coverage.html
@@ -552,11 +552,11 @@
             <a href="#lib/add.js"><span class="dirname">lib/</span><span class="basename">add.js</span></a>
         </li>
         <li class="">
-            <span class="cov high">92.46</span>
+            <span class="cov high">92.42</span>
             <a href="#lib/api.js"><span class="dirname">lib/</span><span class="basename">api.js</span></a>
         </li>
         <li class="">
-            <span class="cov high">87.69</span>
+            <span class="cov high">87.86</span>
             <a href="#lib/common.js"><span class="dirname">lib/</span><span class="basename">common.js</span></a>
         </li>
         <li class="">
@@ -610,8 +610,8 @@
       <div class="stats high">
           <div class="failures">0</div>
           <div class="skipped">0</div>
-          <div class="test-count">346</div>
-          <div class="duration">36751</div>
+          <div class="test-count">351</div>
+          <div class="duration">42849</div>
       </div>
       <div id="filters">
           <input type="checkbox" checked="" onchange="filter(this)" value="success" id="show-success">
@@ -627,6 +627,20 @@
           <label for="show-add">add</label>
           <input type="checkbox" checked="" onchange="filter(this)" value="api" id="show-api">
           <label for="show-api">api</label>
+          <input type="checkbox" checked="" onchange="filter(this)" value="fail" id="show-fail">
+          <label for="show-fail">fail</label>
+          <input type="checkbox" checked="" onchange="filter(this)" value="invoked_with_a_condition,_code_and_details" id="show-invoked_with_a_condition,_code_and_details">
+          <label for="show-invoked_with_a_condition,_code_and_details">invoked with a condition, code and details</label>
+          <input type="checkbox" checked="" onchange="filter(this)" value="when_the_condition_is_true" id="show-when_the_condition_is_true">
+          <label for="show-when_the_condition_is_true">when the condition is true</label>
+          <input type="checkbox" checked="" onchange="filter(this)" value="when_the_condition_is_false" id="show-when_the_condition_is_false">
+          <label for="show-when_the_condition_is_false">when the condition is false</label>
+          <input type="checkbox" checked="" onchange="filter(this)" value="when_the_condition_is_not_a_boolean" id="show-when_the_condition_is_not_a_boolean">
+          <label for="show-when_the_condition_is_not_a_boolean">when the condition is not a boolean</label>
+          <input type="checkbox" checked="" onchange="filter(this)" value="when_given_no_arguments" id="show-when_given_no_arguments">
+          <label for="show-when_given_no_arguments">when given no arguments</label>
+          <input type="checkbox" checked="" onchange="filter(this)" value="when_given_too_many_arguments" id="show-when_given_too_many_arguments">
+          <label for="show-when_given_too_many_arguments">when given too many arguments</label>
           <input type="checkbox" checked="" onchange="filter(this)" value="close" id="show-close">
           <label for="show-close">close</label>
           <input type="checkbox" checked="" onchange="filter(this)" value="common" id="show-common">
@@ -714,2422 +728,2457 @@
               <td class="test-title">act make_actmsg
                   
               </td>
-              <td class="test-duration">12</td>
+              <td class="test-duration">8</td>
           </tr>
           <tr class="show act success">
               <td class="test-id">2</td>
               <td class="test-title">act process_outward
                   
               </td>
-              <td class="test-duration">63</td>
+              <td class="test-duration">60</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">3</td>
               <td class="test-title">actions cmd_ping
                   
               </td>
-              <td class="test-duration">290</td>
+              <td class="test-duration">256</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">4</td>
               <td class="test-title">actions cmd_stats
                   
               </td>
-              <td class="test-duration">40</td>
+              <td class="test-duration">43</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">5</td>
               <td class="test-title">actions cmd_close
                   
               </td>
-              <td class="test-duration">138</td>
+              <td class="test-duration">133</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">6</td>
               <td class="test-title">actions info_fatal
                   
               </td>
-              <td class="test-duration">128</td>
+              <td class="test-duration">134</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">7</td>
               <td class="test-title">actions get_options
                   
               </td>
-              <td class="test-duration">56</td>
+              <td class="test-duration">47</td>
           </tr>
           <tr class="show add success">
               <td class="test-id">8</td>
               <td class="test-title">add name
                   
               </td>
-              <td class="test-duration">28</td>
+              <td class="test-duration">40</td>
           </tr>
           <tr class="show add success">
               <td class="test-id">9</td>
               <td class="test-title">add action_modifier
                   
               </td>
-              <td class="test-duration">128</td>
+              <td class="test-duration">132</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">10</td>
               <td class="test-title">api error
                   
               </td>
-              <td class="test-duration">6</td>
+              <td class="test-duration">7</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">11</td>
-              <td class="test-title">api fail
-                  
-              </td>
-              <td class="test-duration">2</td>
-          </tr>
-          <tr class="show api success">
-              <td class="test-id">12</td>
               <td class="test-title">api list
                   
               </td>
-              <td class="test-duration">19</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show api success">
-              <td class="test-id">13</td>
+              <td class="test-id">12</td>
               <td class="test-title">api translate
-                  
-              </td>
-              <td class="test-duration">144</td>
-          </tr>
-          <tr class="show api success">
-              <td class="test-id">14</td>
-              <td class="test-title">api test-mode
-                  
-              </td>
-              <td class="test-duration">54</td>
-          </tr>
-          <tr class="show api success">
-              <td class="test-id">15</td>
-              <td class="test-title">api find_plugin
                   
               </td>
               <td class="test-duration">137</td>
           </tr>
           <tr class="show api success">
-              <td class="test-id">16</td>
+              <td class="test-id">13</td>
+              <td class="test-title">api test-mode
+                  
+              </td>
+              <td class="test-duration">45</td>
+          </tr>
+          <tr class="show api success">
+              <td class="test-id">14</td>
+              <td class="test-title">api find_plugin
+                  
+              </td>
+              <td class="test-duration">134</td>
+          </tr>
+          <tr class="show api success">
+              <td class="test-id">15</td>
               <td class="test-title">api has_plugin
                   
               </td>
-              <td class="test-duration">246</td>
+              <td class="test-duration">259</td>
           </tr>
           <tr class="show api success">
-              <td class="test-id">17</td>
+              <td class="test-id">16</td>
               <td class="test-title">api ignore_plugin
                   
               </td>
-              <td class="test-duration">364</td>
+              <td class="test-duration">430</td>
           </tr>
           <tr class="show api success">
-              <td class="test-id">18</td>
+              <td class="test-id">17</td>
               <td class="test-title">api has
                   
               </td>
-              <td class="test-duration">5</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show api success">
-              <td class="test-id">19</td>
+              <td class="test-id">18</td>
               <td class="test-title">api find
                   
               </td>
-              <td class="test-duration">17</td>
+              <td class="test-duration">35</td>
           </tr>
           <tr class="show api success">
-              <td class="test-id">20</td>
+              <td class="test-id">19</td>
               <td class="test-title">api status
-                  
-              </td>
-              <td class="test-duration">125</td>
-          </tr>
-          <tr class="show api success">
-              <td class="test-id">21</td>
-              <td class="test-title">api reply
-                  
-              </td>
-              <td class="test-duration">16</td>
-          </tr>
-          <tr class="show api success">
-              <td class="test-id">22</td>
-              <td class="test-title">api delegate
-                  
-              </td>
-              <td class="test-duration">11</td>
-          </tr>
-          <tr class="show close success">
-              <td class="test-id">23</td>
-              <td class="test-title">close happy
-                  
-              </td>
-              <td class="test-duration">124</td>
-          </tr>
-          <tr class="show close success">
-              <td class="test-id">24</td>
-              <td class="test-title">close add
                   
               </td>
               <td class="test-duration">130</td>
           </tr>
-          <tr class="show close success">
-              <td class="test-id">25</td>
-              <td class="test-title">close graceful
+          <tr class="show api success">
+              <td class="test-id">20</td>
+              <td class="test-title">api reply
                   
               </td>
-              <td class="test-duration">240</td>
+              <td class="test-duration">39</td>
           </tr>
-          <tr class="show close success">
-              <td class="test-id">26</td>
-              <td class="test-title">close timeout
+          <tr class="show api success">
+              <td class="test-id">21</td>
+              <td class="test-title">api delegate
                   
               </td>
-              <td class="test-duration">125</td>
+              <td class="test-duration">17</td>
           </tr>
-          <tr class="show close success">
-              <td class="test-id">27</td>
-              <td class="test-title">close handle-signal
-                  
-              </td>
-              <td class="test-duration">124</td>
-          </tr>
-          <tr class="show close success">
-              <td class="test-id">28</td>
-              <td class="test-title">close error
-                  
-              </td>
-              <td class="test-duration">125</td>
-          </tr>
-          <tr class="show close success">
-              <td class="test-id">29</td>
-              <td class="test-title">close no-promise
-                  
-              </td>
-              <td class="test-duration">125</td>
-          </tr>
-          <tr class="show close success">
-              <td class="test-id">30</td>
-              <td class="test-title">close with-promise
-                  
-              </td>
-              <td class="test-duration">125</td>
-          </tr>
-          <tr class="show close success">
-              <td class="test-id">31</td>
-              <td class="test-title">close with-async-await
-                  
-              </td>
-              <td class="test-duration">124</td>
-          </tr>
-          <tr class="show common success">
-              <td class="test-id">32</td>
-              <td class="test-title">common misc
-                  
-              </td>
-              <td class="test-duration">7</td>
-          </tr>
-          <tr class="show common success">
-              <td class="test-id">33</td>
-              <td class="test-title">common deepextend-empty
+          <tr class="show api fail success">
+              <td class="test-id">22</td>
+              <td class="test-title">api fail invoked with a code and details
                   
               </td>
               <td class="test-duration">1</td>
           </tr>
-          <tr class="show common success">
+          <tr class="show api fail invoked_with_a_condition,_code_and_details when_the_condition_is_true success">
+              <td class="test-id">23</td>
+              <td class="test-title">api fail invoked with a condition, code and details when the condition is true throws
+                  
+              </td>
+              <td class="test-duration">2</td>
+          </tr>
+          <tr class="show api fail invoked_with_a_condition,_code_and_details when_the_condition_is_false success">
+              <td class="test-id">24</td>
+              <td class="test-title">api fail invoked with a condition, code and details when the condition is false does not throw
+                  
+              </td>
+              <td class="test-duration">0</td>
+          </tr>
+          <tr class="show api fail invoked_with_a_condition,_code_and_details when_the_condition_is_not_a_boolean success">
+              <td class="test-id">25</td>
+              <td class="test-title">api fail invoked with a condition, code and details when the condition is not a boolean throws an assertion error
+                  
+              </td>
+              <td class="test-duration">1</td>
+          </tr>
+          <tr class="show api fail when_given_no_arguments success">
+              <td class="test-id">26</td>
+              <td class="test-title">api fail when given no arguments throws a seneca error
+                  
+              </td>
+              <td class="test-duration">2</td>
+          </tr>
+          <tr class="show api fail when_given_too_many_arguments success">
+              <td class="test-id">27</td>
+              <td class="test-title">api fail when given too many arguments throws a seneca error
+                  
+              </td>
+              <td class="test-duration">1</td>
+          </tr>
+          <tr class="show close success">
+              <td class="test-id">28</td>
+              <td class="test-title">close happy
+                  
+              </td>
+              <td class="test-duration">131</td>
+          </tr>
+          <tr class="show close success">
+              <td class="test-id">29</td>
+              <td class="test-title">close add
+                  
+              </td>
+              <td class="test-duration">156</td>
+          </tr>
+          <tr class="show close success">
+              <td class="test-id">30</td>
+              <td class="test-title">close graceful
+                  
+              </td>
+              <td class="test-duration">263</td>
+          </tr>
+          <tr class="show close success">
+              <td class="test-id">31</td>
+              <td class="test-title">close timeout
+                  
+              </td>
+              <td class="test-duration">149</td>
+          </tr>
+          <tr class="show close success">
+              <td class="test-id">32</td>
+              <td class="test-title">close handle-signal
+                  
+              </td>
+              <td class="test-duration">154</td>
+          </tr>
+          <tr class="show close success">
+              <td class="test-id">33</td>
+              <td class="test-title">close error
+                  
+              </td>
+              <td class="test-duration">153</td>
+          </tr>
+          <tr class="show close success">
               <td class="test-id">34</td>
+              <td class="test-title">close no-promise
+                  
+              </td>
+              <td class="test-duration">149</td>
+          </tr>
+          <tr class="show close success">
+              <td class="test-id">35</td>
+              <td class="test-title">close with-promise
+                  
+              </td>
+              <td class="test-duration">155</td>
+          </tr>
+          <tr class="show close success">
+              <td class="test-id">36</td>
+              <td class="test-title">close with-async-await
+                  
+              </td>
+              <td class="test-duration">149</td>
+          </tr>
+          <tr class="show common success">
+              <td class="test-id">37</td>
+              <td class="test-title">common misc
+                  
+              </td>
+              <td class="test-duration">27</td>
+          </tr>
+          <tr class="show common success">
+              <td class="test-id">38</td>
+              <td class="test-title">common deepextend-empty
+                  
+              </td>
+              <td class="test-duration">2</td>
+          </tr>
+          <tr class="show common success">
+              <td class="test-id">39</td>
               <td class="test-title">common deepextend-dups
                   
               </td>
               <td class="test-duration">0</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">35</td>
+              <td class="test-id">40</td>
               <td class="test-title">common deepextend-objs
                   
               </td>
-              <td class="test-duration">4</td>
+              <td class="test-duration">5</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">36</td>
+              <td class="test-id">41</td>
               <td class="test-title">common deepextend-objs with functions
                   
               </td>
               <td class="test-duration">0</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">37</td>
+              <td class="test-id">42</td>
               <td class="test-title">common pattern
                   
               </td>
               <td class="test-duration">1</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">38</td>
+              <td class="test-id">43</td>
               <td class="test-title">common nil
                   
               </td>
               <td class="test-duration">0</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">39</td>
+              <td class="test-id">44</td>
               <td class="test-title">common recurse
                   
               </td>
-              <td class="test-duration">0</td>
+              <td class="test-duration">1</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">40</td>
+              <td class="test-id">45</td>
               <td class="test-title">common pincanon
                   
               </td>
               <td class="test-duration">1</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">41</td>
+              <td class="test-id">46</td>
               <td class="test-title">common history
                   
               </td>
-              <td class="test-duration">7</td>
+              <td class="test-duration">6</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">42</td>
+              <td class="test-id">47</td>
               <td class="test-title">common clean
                   
               </td>
               <td class="test-duration">2</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">43</td>
+              <td class="test-id">48</td>
               <td class="test-title">common parse_jsonic
                   
               </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">3</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">44</td>
+              <td class="test-id">49</td>
               <td class="test-title">common make_plugin_key
                   
               </td>
-              <td class="test-duration">5</td>
-          </tr>
-          <tr class="show custom success">
-              <td class="test-id">45</td>
-              <td class="test-title">custom custom-basic
-                  
-              </td>
-              <td class="test-duration">32</td>
-          </tr>
-          <tr class="show custom success">
-              <td class="test-id">46</td>
-              <td class="test-title">custom custom-deep
-                  
-              </td>
-              <td class="test-duration">133</td>
-          </tr>
-          <tr class="show custom success">
-              <td class="test-id">47</td>
-              <td class="test-title">custom custom-reply
-                  
-              </td>
-              <td class="test-duration">132</td>
-          </tr>
-          <tr class="show custom success">
-              <td class="test-id">48</td>
-              <td class="test-title">custom custom-entity
-                  
-              </td>
-              <td class="test-duration">156</td>
-          </tr>
-          <tr class="show custom success">
-              <td class="test-id">49</td>
-              <td class="test-title">custom custom-prior
-                  
-              </td>
-              <td class="test-duration">23</td>
+              <td class="test-duration">6</td>
           </tr>
           <tr class="show custom success">
               <td class="test-id">50</td>
+              <td class="test-title">custom custom-basic
+                  
+              </td>
+              <td class="test-duration">29</td>
+          </tr>
+          <tr class="show custom success">
+              <td class="test-id">51</td>
+              <td class="test-title">custom custom-deep
+                  
+              </td>
+              <td class="test-duration">167</td>
+          </tr>
+          <tr class="show custom success">
+              <td class="test-id">52</td>
+              <td class="test-title">custom custom-reply
+                  
+              </td>
+              <td class="test-duration">129</td>
+          </tr>
+          <tr class="show custom success">
+              <td class="test-id">53</td>
+              <td class="test-title">custom custom-entity
+                  
+              </td>
+              <td class="test-duration">171</td>
+          </tr>
+          <tr class="show custom success">
+              <td class="test-id">54</td>
+              <td class="test-title">custom custom-prior
+                  
+              </td>
+              <td class="test-duration">48</td>
+          </tr>
+          <tr class="show custom success">
+              <td class="test-id">55</td>
               <td class="test-title">custom custom-simple-transport
+                  
+              </td>
+              <td class="test-duration">206</td>
+          </tr>
+          <tr class="show custom success">
+              <td class="test-id">56</td>
+              <td class="test-title">custom custom-bells-transport
+                  
+              </td>
+              <td class="test-duration">402</td>
+          </tr>
+          <tr class="show custom success">
+              <td class="test-id">57</td>
+              <td class="test-title">custom custom-add-basic
                   
               </td>
               <td class="test-duration">160</td>
           </tr>
           <tr class="show custom success">
-              <td class="test-id">51</td>
-              <td class="test-title">custom custom-bells-transport
-                  
-              </td>
-              <td class="test-duration">280</td>
-          </tr>
-          <tr class="show custom success">
-              <td class="test-id">52</td>
-              <td class="test-title">custom custom-add-basic
-                  
-              </td>
-              <td class="test-duration">135</td>
-          </tr>
-          <tr class="show custom success">
-              <td class="test-id">53</td>
+              <td class="test-id">58</td>
               <td class="test-title">custom custom-add-fix
                   
               </td>
-              <td class="test-duration">18</td>
+              <td class="test-duration">49</td>
           </tr>
           <tr class="show debug success">
-              <td class="test-id">54</td>
+              <td class="test-id">59</td>
               <td class="test-title">debug logroute
                   
               </td>
-              <td class="test-duration">11</td>
+              <td class="test-duration">12</td>
           </tr>
           <tr class="show delegation success">
-              <td class="test-id">55</td>
+              <td class="test-id">60</td>
               <td class="test-title">delegation happy
                   
               </td>
-              <td class="test-duration">149</td>
+              <td class="test-duration">169</td>
           </tr>
           <tr class="show delegation success">
-              <td class="test-id">56</td>
+              <td class="test-id">61</td>
               <td class="test-title">delegation dynamic
                   
               </td>
-              <td class="test-duration">134</td>
+              <td class="test-duration">182</td>
           </tr>
           <tr class="show delegation success">
-              <td class="test-id">57</td>
+              <td class="test-id">62</td>
               <td class="test-title">delegation prior.basic
                   
               </td>
-              <td class="test-duration">133</td>
+              <td class="test-duration">212</td>
           </tr>
           <tr class="show delegation success">
-              <td class="test-id">58</td>
+              <td class="test-id">63</td>
               <td class="test-title">delegation parent.plugin
                   
               </td>
-              <td class="test-duration">149</td>
+              <td class="test-duration">209</td>
           </tr>
           <tr class="show entity success">
-              <td class="test-id">59</td>
+              <td class="test-id">64</td>
               <td class="test-title">entity happy
                   
               </td>
-              <td class="test-duration">40</td>
+              <td class="test-duration">140</td>
           </tr>
           <tr class="show entity success">
-              <td class="test-id">60</td>
+              <td class="test-id">65</td>
               <td class="test-title">entity entity-msg
                   
               </td>
               <td class="test-duration">143</td>
           </tr>
           <tr class="show entity success">
-              <td class="test-id">61</td>
+              <td class="test-id">66</td>
               <td class="test-title">entity mem-ops
                   
               </td>
-              <td class="test-duration">179</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">62</td>
-              <td class="test-title">error fail
-                  
-              </td>
-              <td class="test-duration">10</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">63</td>
-              <td class="test-title">error response_is_error
-                  
-              </td>
-              <td class="test-duration">24</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">64</td>
-              <td class="test-title">error action_callback
-                  
-              </td>
-              <td class="test-duration">33</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">65</td>
-              <td class="test-title">error plugin_load
-                  
-              </td>
-              <td class="test-duration">20</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">66</td>
-              <td class="test-title">error act_not_found
-                  
-              </td>
-              <td class="test-duration">61</td>
+              <td class="test-duration">234</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">67</td>
-              <td class="test-title">error exec_action_throw_basic
+              <td class="test-title">error fail
                   
               </td>
-              <td class="test-duration">15</td>
+              <td class="test-duration">66</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">68</td>
-              <td class="test-title">error exec_action_throw_basic_legacy
-                  
-              </td>
-              <td class="test-duration">36</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">69</td>
-              <td class="test-title">error exec_action_throw_nolog
-                  
-              </td>
-              <td class="test-duration">17</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">70</td>
-              <td class="test-title">error exec_action_errhandler_throw
-                  
-              </td>
-              <td class="test-duration">53</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">71</td>
-              <td class="test-title">error exec_action_result
-                  
-              </td>
-              <td class="test-duration">14</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">72</td>
-              <td class="test-title">error exec_deep_action_result
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">73</td>
-              <td class="test-title">error exec_remote_action_result
-                  
-              </td>
-              <td class="test-duration">149</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">74</td>
-              <td class="test-title">error exec_action_result_legacy
-                  
-              </td>
-              <td class="test-duration">33</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">75</td>
-              <td class="test-title">error exec_action_result_nolog
-                  
-              </td>
-              <td class="test-duration">27</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">76</td>
-              <td class="test-title">error exec_action_errhandler_result
-                  
-              </td>
-              <td class="test-duration">58</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">77</td>
-              <td class="test-title">error action_callback
-                  
-              </td>
-              <td class="test-duration">173</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">78</td>
-              <td class="test-title">error legacy_fail
-                  
-              </td>
-              <td class="test-duration">10</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">79</td>
-              <td class="test-title">error types
-                  
-              </td>
-              <td class="test-duration">21</td>
-          </tr>
-          <tr class="show explain success">
-              <td class="test-id">80</td>
-              <td class="test-title">explain explain-basic
-                  
-              </td>
-              <td class="test-duration">42</td>
-          </tr>
-          <tr class="show explain success">
-              <td class="test-id">81</td>
-              <td class="test-title">explain explain-data
-                  
-              </td>
-              <td class="test-duration">46</td>
-          </tr>
-          <tr class="show explain success">
-              <td class="test-id">82</td>
-              <td class="test-title">explain explain-deep
+              <td class="test-title">error response_is_error
                   
               </td>
               <td class="test-duration">41</td>
           </tr>
-          <tr class="show explain success">
+          <tr class="show error success">
+              <td class="test-id">69</td>
+              <td class="test-title">error action_callback
+                  
+              </td>
+              <td class="test-duration">31</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">70</td>
+              <td class="test-title">error plugin_load
+                  
+              </td>
+              <td class="test-duration">26</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">71</td>
+              <td class="test-title">error act_not_found
+                  
+              </td>
+              <td class="test-duration">71</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">72</td>
+              <td class="test-title">error exec_action_throw_basic
+                  
+              </td>
+              <td class="test-duration">31</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">73</td>
+              <td class="test-title">error exec_action_throw_basic_legacy
+                  
+              </td>
+              <td class="test-duration">52</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">74</td>
+              <td class="test-title">error exec_action_throw_nolog
+                  
+              </td>
+              <td class="test-duration">29</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">75</td>
+              <td class="test-title">error exec_action_errhandler_throw
+                  
+              </td>
+              <td class="test-duration">89</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">76</td>
+              <td class="test-title">error exec_action_result
+                  
+              </td>
+              <td class="test-duration">25</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">77</td>
+              <td class="test-title">error exec_deep_action_result
+                  
+              </td>
+              <td class="test-duration">32</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">78</td>
+              <td class="test-title">error exec_remote_action_result
+                  
+              </td>
+              <td class="test-duration">195</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">79</td>
+              <td class="test-title">error exec_action_result_legacy
+                  
+              </td>
+              <td class="test-duration">71</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">80</td>
+              <td class="test-title">error exec_action_result_nolog
+                  
+              </td>
+              <td class="test-duration">38</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">81</td>
+              <td class="test-title">error exec_action_errhandler_result
+                  
+              </td>
+              <td class="test-duration">95</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">82</td>
+              <td class="test-title">error action_callback
+                  
+              </td>
+              <td class="test-duration">214</td>
+          </tr>
+          <tr class="show error success">
               <td class="test-id">83</td>
+              <td class="test-title">error legacy_fail
+                  
+              </td>
+              <td class="test-duration">16</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">84</td>
+              <td class="test-title">error types
+                  
+              </td>
+              <td class="test-duration">40</td>
+          </tr>
+          <tr class="show explain success">
+              <td class="test-id">85</td>
+              <td class="test-title">explain explain-basic
+                  
+              </td>
+              <td class="test-duration">74</td>
+          </tr>
+          <tr class="show explain success">
+              <td class="test-id">86</td>
+              <td class="test-title">explain explain-data
+                  
+              </td>
+              <td class="test-duration">75</td>
+          </tr>
+          <tr class="show explain success">
+              <td class="test-id">87</td>
+              <td class="test-title">explain explain-deep
+                  
+              </td>
+              <td class="test-duration">81</td>
+          </tr>
+          <tr class="show explain success">
+              <td class="test-id">88</td>
               <td class="test-title">explain explain-toplevel
                   
               </td>
-              <td class="test-duration">131</td>
+              <td class="test-duration">148</td>
           </tr>
           <tr class="show explain success">
-              <td class="test-id">84</td>
+              <td class="test-id">89</td>
               <td class="test-title">explain explain-transport
                   
               </td>
-              <td class="test-duration">297</td>
+              <td class="test-duration">330</td>
           </tr>
           <tr class="show exports success">
-              <td class="test-id">85</td>
+              <td class="test-id">90</td>
               <td class="test-title">exports happy
                   
               </td>
-              <td class="test-duration">122</td>
+              <td class="test-duration">135</td>
           </tr>
           <tr class="show exports success">
-              <td class="test-id">86</td>
+              <td class="test-id">91</td>
               <td class="test-title">exports with-init
                   
               </td>
-              <td class="test-duration">122</td>
+              <td class="test-duration">134</td>
           </tr>
           <tr class="show exports success">
-              <td class="test-id">87</td>
+              <td class="test-id">92</td>
               <td class="test-title">exports with-preload
                   
               </td>
-              <td class="test-duration">125</td>
+              <td class="test-duration">144</td>
           </tr>
           <tr class="show exports success">
-              <td class="test-id">88</td>
+              <td class="test-id">93</td>
               <td class="test-title">exports with-preload-and-init
                   
               </td>
-              <td class="test-duration">123</td>
+              <td class="test-duration">147</td>
           </tr>
           <tr class="show outward success">
-              <td class="test-id">89</td>
+              <td class="test-id">94</td>
               <td class="test-title">outward act_error
                   
               </td>
               <td class="test-duration">1</td>
           </tr>
           <tr class="show inward success">
-              <td class="test-id">90</td>
+              <td class="test-id">95</td>
               <td class="test-title">inward announce
                   
               </td>
-              <td class="test-duration">120</td>
+              <td class="test-duration">135</td>
           </tr>
           <tr class="show inward success">
-              <td class="test-id">91</td>
+              <td class="test-id">96</td>
               <td class="test-title">inward arg-check
                   
               </td>
               <td class="test-duration">3</td>
           </tr>
           <tr class="show legacy success">
-              <td class="test-id">92</td>
-              <td class="test-title">legacy fail
-                  
-              </td>
-              <td class="test-duration">1</td>
-          </tr>
-          <tr class="show legacy success">
-              <td class="test-id">93</td>
-              <td class="test-title">legacy argprops
-                  
-              </td>
-              <td class="test-duration">1</td>
-          </tr>
-          <tr class="show legacy success">
-              <td class="test-id">94</td>
-              <td class="test-title">legacy router
-                  
-              </td>
-              <td class="test-duration">1</td>
-          </tr>
-          <tr class="show legacy success">
-              <td class="test-id">95</td>
-              <td class="test-title">legacy no-default-transport
-                  
-              </td>
-              <td class="test-duration">118</td>
-          </tr>
-          <tr class="show legacy success">
-              <td class="test-id">96</td>
-              <td class="test-title">legacy actdef
-                  
-              </td>
-              <td class="test-duration">9</td>
-          </tr>
-          <tr class="show logging success">
               <td class="test-id">97</td>
-              <td class="test-title">logging happy
-                  
-              </td>
-              <td class="test-duration">122</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">98</td>
-              <td class="test-title">logging happy-ng
-                  
-              </td>
-              <td class="test-duration">122</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">99</td>
-              <td class="test-title">logging level-text-values
-                  
-              </td>
-              <td class="test-duration">10</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">100</td>
-              <td class="test-title">logging build_log_spec
+              <td class="test-title">legacy fail
                   
               </td>
               <td class="test-duration">2</td>
           </tr>
-          <tr class="show logging success">
-              <td class="test-id">101</td>
-              <td class="test-title">logging event
+          <tr class="show legacy success">
+              <td class="test-id">98</td>
+              <td class="test-title">legacy argprops
                   
               </td>
-              <td class="test-duration">132</td>
+              <td class="test-duration">2</td>
+          </tr>
+          <tr class="show legacy success">
+              <td class="test-id">99</td>
+              <td class="test-title">legacy router
+                  
+              </td>
+              <td class="test-duration">0</td>
+          </tr>
+          <tr class="show legacy success">
+              <td class="test-id">100</td>
+              <td class="test-title">legacy no-default-transport
+                  
+              </td>
+              <td class="test-duration">123</td>
+          </tr>
+          <tr class="show legacy success">
+              <td class="test-id">101</td>
+              <td class="test-title">legacy actdef
+                  
+              </td>
+              <td class="test-duration">21</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">102</td>
-              <td class="test-title">logging quiet
+              <td class="test-title">logging happy
                   
               </td>
-              <td class="test-duration">124</td>
+              <td class="test-duration">127</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">103</td>
-              <td class="test-title">logging bad_logspec
+              <td class="test-title">logging happy-ng
                   
               </td>
-              <td class="test-duration">7</td>
+              <td class="test-duration">128</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">104</td>
-              <td class="test-title">logging basic
+              <td class="test-title">logging level-text-values
                   
               </td>
-              <td class="test-duration">121</td>
+              <td class="test-duration">14</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">105</td>
-              <td class="test-title">logging logger-output
+              <td class="test-title">logging build_log_spec
                   
               </td>
-              <td class="test-duration">854</td>
+              <td class="test-duration">3</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">106</td>
-              <td class="test-title">logging shortcuts
+              <td class="test-title">logging event
                   
               </td>
-              <td class="test-duration">1487</td>
+              <td class="test-duration">127</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">107</td>
-              <td class="test-title">logging test-mode-basic
+              <td class="test-title">logging quiet
                   
               </td>
               <td class="test-duration">121</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">108</td>
-              <td class="test-title">logging test-mode-option
+              <td class="test-title">logging bad_logspec
                   
               </td>
-              <td class="test-duration">121</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">109</td>
-              <td class="test-title">logging test-mode-argv
+              <td class="test-title">logging basic
                   
               </td>
-              <td class="test-duration">127</td>
+              <td class="test-duration">147</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">110</td>
-              <td class="test-title">logging test-mode-argv-opts
+              <td class="test-title">logging logger-output
                   
               </td>
-              <td class="test-duration">124</td>
+              <td class="test-duration">807</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">111</td>
-              <td class="test-title">logging test-mode-env
+              <td class="test-title">logging shortcuts
                   
               </td>
-              <td class="test-duration">152</td>
+              <td class="test-duration">1441</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">112</td>
-              <td class="test-title">logging quiet-mode-basic
+              <td class="test-title">logging test-mode-basic
                   
               </td>
-              <td class="test-duration">136</td>
+              <td class="test-duration">123</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">113</td>
-              <td class="test-title">logging quiet-mode-option
-                  
-              </td>
-              <td class="test-duration">123</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">114</td>
-              <td class="test-title">logging quiet-mode-argv
-                  
-              </td>
-              <td class="test-duration">123</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">115</td>
-              <td class="test-title">logging quiet-mode-argv-opts
-                  
-              </td>
-              <td class="test-duration">125</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">116</td>
-              <td class="test-title">logging quiet-mode-env
+              <td class="test-title">logging test-mode-option
                   
               </td>
               <td class="test-duration">124</td>
           </tr>
           <tr class="show logging success">
+              <td class="test-id">114</td>
+              <td class="test-title">logging test-mode-argv
+                  
+              </td>
+              <td class="test-duration">131</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">115</td>
+              <td class="test-title">logging test-mode-argv-opts
+                  
+              </td>
+              <td class="test-duration">181</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">116</td>
+              <td class="test-title">logging test-mode-env
+                  
+              </td>
+              <td class="test-duration">134</td>
+          </tr>
+          <tr class="show logging success">
               <td class="test-id">117</td>
+              <td class="test-title">logging quiet-mode-basic
+                  
+              </td>
+              <td class="test-duration">128</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">118</td>
+              <td class="test-title">logging quiet-mode-option
+                  
+              </td>
+              <td class="test-duration">184</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">119</td>
+              <td class="test-title">logging quiet-mode-argv
+                  
+              </td>
+              <td class="test-duration">140</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">120</td>
+              <td class="test-title">logging quiet-mode-argv-opts
+                  
+              </td>
+              <td class="test-duration">140</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">121</td>
+              <td class="test-title">logging quiet-mode-env
+                  
+              </td>
+              <td class="test-duration">183</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">122</td>
               <td class="test-title">logging test-quiet-mode-basic
                   
               </td>
               <td class="test-duration">122</td>
           </tr>
           <tr class="show logging success">
-              <td class="test-id">118</td>
+              <td class="test-id">123</td>
               <td class="test-title">logging quiet-test-mode-basic
                   
               </td>
-              <td class="test-duration">125</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">119</td>
-              <td class="test-title">logging test-ready-quiet-mode-basic
-                  
-              </td>
-              <td class="test-duration">240</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">120</td>
-              <td class="test-title">logging quiet-ready-test-mode-basic
-                  
-              </td>
-              <td class="test-duration">237</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">121</td>
-              <td class="test-title">logging quiet-argv-override
-                  
-              </td>
-              <td class="test-duration">129</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">122</td>
-              <td class="test-title">logging test-argv-override
-                  
-              </td>
-              <td class="test-duration">123</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">123</td>
-              <td class="test-title">logging quiet-env-override
-                  
-              </td>
-              <td class="test-duration">123</td>
+              <td class="test-duration">131</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">124</td>
-              <td class="test-title">logging test-env-override
+              <td class="test-title">logging test-ready-quiet-mode-basic
                   
               </td>
-              <td class="test-duration">123</td>
+              <td class="test-duration">241</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">125</td>
+              <td class="test-title">logging quiet-ready-test-mode-basic
+                  
+              </td>
+              <td class="test-duration">251</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">126</td>
+              <td class="test-title">logging quiet-argv-override
+                  
+              </td>
+              <td class="test-duration">143</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">127</td>
+              <td class="test-title">logging test-argv-override
+                  
+              </td>
+              <td class="test-duration">131</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">128</td>
+              <td class="test-title">logging quiet-env-override
+                  
+              </td>
+              <td class="test-duration">135</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">129</td>
+              <td class="test-title">logging test-env-override
+                  
+              </td>
+              <td class="test-duration">134</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">130</td>
               <td class="test-title">logging intern.build_act_entry
                   
               </td>
               <td class="test-duration">1</td>
           </tr>
           <tr class="show message success">
-              <td class="test-id">126</td>
+              <td class="test-id">131</td>
               <td class="test-title">message happy-vanilla
                   
               </td>
-              <td class="test-duration">24</td>
-          </tr>
-          <tr class="show message success">
-              <td class="test-id">127</td>
-              <td class="test-title">message happy-msg
-                  
-              </td>
-              <td class="test-duration">25</td>
-          </tr>
-          <tr class="show message success">
-              <td class="test-id">128</td>
-              <td class="test-title">message loop
-                  
-              </td>
-              <td class="test-duration">23</td>
-          </tr>
-          <tr class="show message success">
-              <td class="test-id">129</td>
-              <td class="test-title">message branch
-                  
-              </td>
-              <td class="test-duration">31</td>
-          </tr>
-          <tr class="show message success">
-              <td class="test-id">130</td>
-              <td class="test-title">message empty-response
-                  
-              </td>
-              <td class="test-duration">124</td>
-          </tr>
-          <tr class="show message success">
-              <td class="test-id">131</td>
-              <td class="test-title">message reply
-                  
-              </td>
-              <td class="test-duration">124</td>
+              <td class="test-duration">34</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">132</td>
-              <td class="test-title">message prior
+              <td class="test-title">message happy-msg
                   
               </td>
-              <td class="test-duration">126</td>
+              <td class="test-duration">32</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">133</td>
-              <td class="test-title">message entity
+              <td class="test-title">message loop
                   
               </td>
-              <td class="test-duration">35</td>
+              <td class="test-duration">30</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">134</td>
-              <td class="test-title">message single-simple-transport
+              <td class="test-title">message branch
+                  
+              </td>
+              <td class="test-duration">45</td>
+          </tr>
+          <tr class="show message success">
+              <td class="test-id">135</td>
+              <td class="test-title">message empty-response
+                  
+              </td>
+              <td class="test-duration">127</td>
+          </tr>
+          <tr class="show message success">
+              <td class="test-id">136</td>
+              <td class="test-title">message reply
                   
               </td>
               <td class="test-duration">175</td>
           </tr>
           <tr class="show message success">
-              <td class="test-id">135</td>
+              <td class="test-id">137</td>
+              <td class="test-title">message prior
+                  
+              </td>
+              <td class="test-duration">168</td>
+          </tr>
+          <tr class="show message success">
+              <td class="test-id">138</td>
+              <td class="test-title">message entity
+                  
+              </td>
+              <td class="test-duration">49</td>
+          </tr>
+          <tr class="show message success">
+              <td class="test-id">139</td>
+              <td class="test-title">message single-simple-transport
+                  
+              </td>
+              <td class="test-duration">157</td>
+          </tr>
+          <tr class="show message success">
+              <td class="test-id">140</td>
               <td class="test-title">message simple-transport
                   
               </td>
-              <td class="test-duration">600</td>
+              <td class="test-duration">684</td>
           </tr>
           <tr class="show message success">
-              <td class="test-id">136</td>
+              <td class="test-id">141</td>
               <td class="test-title">message partial-patterns
                   
               </td>
-              <td class="test-duration">124</td>
+              <td class="test-duration">165</td>
           </tr>
           <tr class="show meta success">
-              <td class="test-id">137</td>
+              <td class="test-id">142</td>
               <td class="test-title">meta custom-parents
                   
               </td>
-              <td class="test-duration">30</td>
+              <td class="test-duration">87</td>
           </tr>
           <tr class="show meta success">
-              <td class="test-id">138</td>
+              <td class="test-id">143</td>
               <td class="test-title">meta custom-priors
                   
               </td>
-              <td class="test-duration">34</td>
+              <td class="test-duration">42</td>
           </tr>
           <tr class="show meta success">
-              <td class="test-id">139</td>
+              <td class="test-id">144</td>
               <td class="test-title">meta custom-fixed
                   
               </td>
-              <td class="test-duration">24</td>
+              <td class="test-duration">23</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">140</td>
+              <td class="test-id">145</td>
               <td class="test-title">options strict.find
                   
               </td>
-              <td class="test-duration">7</td>
+              <td class="test-duration">9</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">141</td>
+              <td class="test-id">146</td>
               <td class="test-title">options internal.routers
                   
               </td>
               <td class="test-duration">13</td>
           </tr>
           <tr class="show order success">
-              <td class="test-id">142</td>
+              <td class="test-id">147</td>
               <td class="test-title">order happy
                   
               </td>
-              <td class="test-duration">261</td>
+              <td class="test-duration">267</td>
           </tr>
           <tr class="show outward success">
-              <td class="test-id">143</td>
+              <td class="test-id">148</td>
               <td class="test-title">outward make_error
                   
               </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">6</td>
           </tr>
           <tr class="show outward success">
-              <td class="test-id">144</td>
+              <td class="test-id">149</td>
               <td class="test-title">outward act_stats
                   
               </td>
-              <td class="test-duration">1</td>
+              <td class="test-duration">3</td>
           </tr>
           <tr class="show outward success">
-              <td class="test-id">145</td>
+              <td class="test-id">150</td>
               <td class="test-title">outward arg-check
                   
               </td>
-              <td class="test-duration">1</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">146</td>
-              <td class="test-title">plugin use.intern
-                  
-              </td>
-              <td class="test-duration">10</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">147</td>
-              <td class="test-title">plugin plugin-edges
-                  
-              </td>
-              <td class="test-duration">9</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">148</td>
-              <td class="test-title">plugin plugin-internal-ordu
-                  
-              </td>
-              <td class="test-duration">8</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">149</td>
-              <td class="test-title">plugin standard-test-plugin
-                  
-              </td>
-              <td class="test-duration">153</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">150</td>
-              <td class="test-title">plugin standard-test-plugin-full-ignore
-                  
-              </td>
-              <td class="test-duration">239</td>
+              <td class="test-duration">6</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">151</td>
-              <td class="test-title">plugin plugin-ignore-via-options
+              <td class="test-title">plugin use.intern
                   
               </td>
-              <td class="test-duration">122</td>
+              <td class="test-duration">73</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">152</td>
-              <td class="test-title">plugin plugin-ignore-null
+              <td class="test-title">plugin plugin-edges
                   
               </td>
-              <td class="test-duration">123</td>
+              <td class="test-duration">26</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">153</td>
-              <td class="test-title">plugin plugin-delegate-init
+              <td class="test-title">plugin plugin-internal-ordu
                   
               </td>
-              <td class="test-duration">129</td>
+              <td class="test-duration">22</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">154</td>
-              <td class="test-title">plugin load-defaults
+              <td class="test-title">plugin standard-test-plugin
                   
               </td>
-              <td class="test-duration">127</td>
+              <td class="test-duration">214</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">155</td>
-              <td class="test-title">plugin load-relative-to-root
+              <td class="test-title">plugin standard-test-plugin-full-ignore
+                  
+              </td>
+              <td class="test-duration">306</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">156</td>
+              <td class="test-title">plugin plugin-ignore-via-options
                   
               </td>
               <td class="test-duration">133</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">156</td>
-              <td class="test-title">plugin good-default-options
-                  
-              </td>
-              <td class="test-duration">130</td>
-          </tr>
-          <tr class="show plugin success">
               <td class="test-id">157</td>
-              <td class="test-title">plugin bad-default-options
+              <td class="test-title">plugin plugin-ignore-null
                   
               </td>
-              <td class="test-duration">21</td>
+              <td class="test-duration">143</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">158</td>
+              <td class="test-title">plugin plugin-delegate-init
+                  
+              </td>
+              <td class="test-duration">136</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">159</td>
+              <td class="test-title">plugin load-defaults
+                  
+              </td>
+              <td class="test-duration">184</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">160</td>
+              <td class="test-title">plugin load-relative-to-root
+                  
+              </td>
+              <td class="test-duration">144</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">161</td>
+              <td class="test-title">plugin good-default-options
+                  
+              </td>
+              <td class="test-duration">180</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">162</td>
+              <td class="test-title">plugin bad-default-options
+                  
+              </td>
+              <td class="test-duration">77</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">163</td>
               <td class="test-title">plugin legacy-options
                   
               </td>
               <td class="test-duration">16</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">159</td>
+              <td class="test-id">164</td>
               <td class="test-title">plugin should return &quot;no errors created.&quot; when passing test false
                   
               </td>
-              <td class="test-duration">403</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">160</td>
-              <td class="test-title">plugin should return &quot;error caught!&quot; when passing test true
-                  
-              </td>
-              <td class="test-duration">376</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">161</td>
-              <td class="test-title">plugin works with exportmap
-                  
-              </td>
-              <td class="test-duration">123</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">162</td>
-              <td class="test-title">plugin bad
-                  
-              </td>
-              <td class="test-duration">132</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">163</td>
-              <td class="test-title">plugin plugin-error-def
-                  
-              </td>
-              <td class="test-duration">22</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">164</td>
-              <td class="test-title">plugin plugin-error-deprecated
-                  
-              </td>
-              <td class="test-duration">23</td>
+              <td class="test-duration">442</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">165</td>
-              <td class="test-title">plugin plugin-error-add
+              <td class="test-title">plugin should return &quot;error caught!&quot; when passing test true
                   
               </td>
-              <td class="test-duration">20</td>
+              <td class="test-duration">442</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">166</td>
-              <td class="test-title">plugin plugin-error-act
+              <td class="test-title">plugin works with exportmap
+                  
+              </td>
+              <td class="test-duration">131</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">167</td>
+              <td class="test-title">plugin bad
+                  
+              </td>
+              <td class="test-duration">141</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">168</td>
+              <td class="test-title">plugin plugin-error-def
+                  
+              </td>
+              <td class="test-duration">52</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">169</td>
+              <td class="test-title">plugin plugin-error-deprecated
                   
               </td>
               <td class="test-duration">18</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">167</td>
-              <td class="test-title">plugin depends
-                  
-              </td>
-              <td class="test-duration">143</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">168</td>
-              <td class="test-title">plugin plugin-fix
-                  
-              </td>
-              <td class="test-duration">153</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">169</td>
-              <td class="test-title">plugin export
-                  
-              </td>
-              <td class="test-duration">12</td>
-          </tr>
-          <tr class="show plugin success">
               <td class="test-id">170</td>
-              <td class="test-title">plugin handles plugin with action that timesout
-                  
-              </td>
-              <td class="test-duration">245</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">171</td>
-              <td class="test-title">plugin handles plugin action that throws an error
-                  
-              </td>
-              <td class="test-duration">134</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">172</td>
-              <td class="test-title">plugin calling act from init actor is deprecated
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">173</td>
-              <td class="test-title">plugin plugin actions receive errors in callback function
-                  
-              </td>
-              <td class="test-duration">143</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">174</td>
-              <td class="test-title">plugin dynamic-load-sequence
-                  
-              </td>
-              <td class="test-duration">354</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">175</td>
-              <td class="test-title">plugin serial-load-sequence
-                  
-              </td>
-              <td class="test-duration">126</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">176</td>
-              <td class="test-title">plugin plugin options can be modified by plugins during load sequence
-                  
-              </td>
-              <td class="test-duration">123</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">177</td>
-              <td class="test-title">plugin plugin options can be modified by plugins during init sequence
-                  
-              </td>
-              <td class="test-duration">127</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">178</td>
-              <td class="test-title">plugin plugin init can add actions for future init actions to call
-                  
-              </td>
-              <td class="test-duration">125</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">179</td>
-              <td class="test-title">plugin plugin-init-error
-                  
-              </td>
-              <td class="test-duration">34</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">180</td>
-              <td class="test-title">plugin plugin-extend-action-modifier
-                  
-              </td>
-              <td class="test-duration">172</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">181</td>
-              <td class="test-title">plugin plugin-extend-logger
-                  
-              </td>
-              <td class="test-duration">129</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">182</td>
-              <td class="test-title">plugin plugins-from-options
-                  
-              </td>
-              <td class="test-duration">127</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">183</td>
-              <td class="test-title">plugin plugins-from-bad-options
+              <td class="test-title">plugin plugin-error-add
                   
               </td>
               <td class="test-duration">15</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">184</td>
-              <td class="test-title">plugin plugins-options-precedence
-                  
-              </td>
-              <td class="test-duration">128</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">185</td>
-              <td class="test-title">plugin error-plugin-define
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">186</td>
-              <td class="test-title">plugin error-plugin-init
+              <td class="test-id">171</td>
+              <td class="test-title">plugin plugin-error-act
                   
               </td>
               <td class="test-duration">21</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">187</td>
-              <td class="test-title">plugin error-plugin-action
+              <td class="test-id">172</td>
+              <td class="test-title">plugin depends
                   
               </td>
-              <td class="test-duration">32</td>
+              <td class="test-duration">150</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">173</td>
+              <td class="test-title">plugin plugin-fix
+                  
+              </td>
+              <td class="test-duration">192</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">174</td>
+              <td class="test-title">plugin export
+                  
+              </td>
+              <td class="test-duration">18</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">175</td>
+              <td class="test-title">plugin handles plugin with action that timesout
+                  
+              </td>
+              <td class="test-duration">246</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">176</td>
+              <td class="test-title">plugin handles plugin action that throws an error
+                  
+              </td>
+              <td class="test-duration">176</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">177</td>
+              <td class="test-title">plugin calling act from init actor is deprecated
+                  
+              </td>
+              <td class="test-duration">117</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">178</td>
+              <td class="test-title">plugin plugin actions receive errors in callback function
+                  
+              </td>
+              <td class="test-duration">178</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">179</td>
+              <td class="test-title">plugin dynamic-load-sequence
+                  
+              </td>
+              <td class="test-duration">379</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">180</td>
+              <td class="test-title">plugin serial-load-sequence
+                  
+              </td>
+              <td class="test-duration">139</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">181</td>
+              <td class="test-title">plugin plugin options can be modified by plugins during load sequence
+                  
+              </td>
+              <td class="test-duration">128</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">182</td>
+              <td class="test-title">plugin plugin options can be modified by plugins during init sequence
+                  
+              </td>
+              <td class="test-duration">140</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">183</td>
+              <td class="test-title">plugin plugin init can add actions for future init actions to call
+                  
+              </td>
+              <td class="test-duration">149</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">184</td>
+              <td class="test-title">plugin plugin-init-error
+                  
+              </td>
+              <td class="test-duration">39</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">185</td>
+              <td class="test-title">plugin plugin-extend-action-modifier
+                  
+              </td>
+              <td class="test-duration">148</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">186</td>
+              <td class="test-title">plugin plugin-extend-logger
+                  
+              </td>
+              <td class="test-duration">125</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">187</td>
+              <td class="test-title">plugin plugins-from-options
+                  
+              </td>
+              <td class="test-duration">136</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">188</td>
-              <td class="test-title">plugin no-name
+              <td class="test-title">plugin plugins-from-bad-options
                   
               </td>
-              <td class="test-duration">130</td>
+              <td class="test-duration">25</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">189</td>
-              <td class="test-title">plugin seneca-prefix-wins
+              <td class="test-title">plugin plugins-options-precedence
                   
               </td>
-              <td class="test-duration">126</td>
+              <td class="test-duration">139</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">190</td>
-              <td class="test-title">plugin plugin-defaults-top-level-joi
+              <td class="test-title">plugin error-plugin-define
                   
               </td>
-              <td class="test-duration">126</td>
+              <td class="test-duration">43</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">191</td>
+              <td class="test-title">plugin error-plugin-init
+                  
+              </td>
+              <td class="test-duration">41</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">192</td>
+              <td class="test-title">plugin error-plugin-action
+                  
+              </td>
+              <td class="test-duration">42</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">193</td>
+              <td class="test-title">plugin no-name
+                  
+              </td>
+              <td class="test-duration">134</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">194</td>
+              <td class="test-title">plugin seneca-prefix-wins
+                  
+              </td>
+              <td class="test-duration">134</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">195</td>
+              <td class="test-title">plugin plugin-defaults-top-level-joi
+                  
+              </td>
+              <td class="test-duration">186</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">196</td>
               <td class="test-title">plugin plugin-order-task-args
                   
               </td>
-              <td class="test-duration">14</td>
+              <td class="test-duration">15</td>
           </tr>
           <tr class="show print success">
-              <td class="test-id">192</td>
+              <td class="test-id">197</td>
               <td class="test-title">print init
                   
               </td>
-              <td class="test-duration">9</td>
+              <td class="test-duration">13</td>
           </tr>
           <tr class="show print success">
-              <td class="test-id">193</td>
+              <td class="test-id">198</td>
               <td class="test-title">print options
                   
               </td>
-              <td class="test-duration">14</td>
+              <td class="test-duration">15</td>
           </tr>
           <tr class="show print success">
-              <td class="test-id">194</td>
+              <td class="test-id">199</td>
               <td class="test-title">print print
                   
               </td>
-              <td class="test-duration">10</td>
+              <td class="test-duration">11</td>
           </tr>
           <tr class="show print success">
-              <td class="test-id">195</td>
+              <td class="test-id">200</td>
               <td class="test-title">print custom-print
+                  
+              </td>
+              <td class="test-duration">18</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">201</td>
+              <td class="test-title">prior happy
                   
               </td>
               <td class="test-duration">24</td>
           </tr>
           <tr class="show prior success">
-              <td class="test-id">196</td>
-              <td class="test-title">prior happy
-                  
-              </td>
-              <td class="test-duration">105</td>
-          </tr>
-          <tr class="show prior success">
-              <td class="test-id">197</td>
+              <td class="test-id">202</td>
               <td class="test-title">prior top-level
                   
               </td>
-              <td class="test-duration">12</td>
-          </tr>
-          <tr class="show prior success">
-              <td class="test-id">198</td>
-              <td class="test-title">prior add-general-to-specific
-                  
-              </td>
-              <td class="test-duration">51</td>
-          </tr>
-          <tr class="show prior success">
-              <td class="test-id">199</td>
-              <td class="test-title">prior add-strict-general-to-specific
-                  
-              </td>
-              <td class="test-duration">27</td>
-          </tr>
-          <tr class="show prior success">
-              <td class="test-id">200</td>
-              <td class="test-title">prior add-specific-to-general
-                  
-              </td>
-              <td class="test-duration">41</td>
-          </tr>
-          <tr class="show prior success">
-              <td class="test-id">201</td>
-              <td class="test-title">prior add-strict-specific-to-general
-                  
-              </td>
-              <td class="test-duration">29</td>
-          </tr>
-          <tr class="show prior success">
-              <td class="test-id">202</td>
-              <td class="test-title">prior add-general-to-specific-alpha
-                  
-              </td>
-              <td class="test-duration">30</td>
+              <td class="test-duration">9</td>
           </tr>
           <tr class="show prior success">
               <td class="test-id">203</td>
+              <td class="test-title">prior add-general-to-specific
+                  
+              </td>
+              <td class="test-duration">28</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">204</td>
+              <td class="test-title">prior add-strict-general-to-specific
+                  
+              </td>
+              <td class="test-duration">21</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">205</td>
+              <td class="test-title">prior add-specific-to-general
+                  
+              </td>
+              <td class="test-duration">16</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">206</td>
+              <td class="test-title">prior add-strict-specific-to-general
+                  
+              </td>
+              <td class="test-duration">15</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">207</td>
+              <td class="test-title">prior add-general-to-specific-alpha
+                  
+              </td>
+              <td class="test-duration">21</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">208</td>
               <td class="test-title">prior add-general-to-specific-reverse-alpha
                   
               </td>
               <td class="test-duration">23</td>
           </tr>
           <tr class="show prior success">
-              <td class="test-id">204</td>
+              <td class="test-id">209</td>
               <td class="test-title">prior add-strict-default
                   
               </td>
-              <td class="test-duration">30</td>
+              <td class="test-duration">21</td>
           </tr>
           <tr class="show prior success">
-              <td class="test-id">205</td>
+              <td class="test-id">210</td>
               <td class="test-title">prior add-strict-true
                   
               </td>
-              <td class="test-duration">28</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show private success">
-              <td class="test-id">206</td>
+              <td class="test-id">211</td>
               <td class="test-title">private exit_close
                   
               </td>
-              <td class="test-duration">415</td>
-          </tr>
-          <tr class="show ready success">
-              <td class="test-id">207</td>
-              <td class="test-title">ready ready_die
-                  
-              </td>
-              <td class="test-duration">121</td>
-          </tr>
-          <tr class="show ready success">
-              <td class="test-id">208</td>
-              <td class="test-title">ready ready_die_no_errhandler
-                  
-              </td>
-              <td class="test-duration">119</td>
-          </tr>
-          <tr class="show ready success">
-              <td class="test-id">209</td>
-              <td class="test-title">ready ready_null_name
-                  
-              </td>
-              <td class="test-duration">125</td>
-          </tr>
-          <tr class="show ready success">
-              <td class="test-id">210</td>
-              <td class="test-title">ready ready-complex
-                  
-              </td>
-              <td class="test-duration">270</td>
-          </tr>
-          <tr class="show ready success">
-              <td class="test-id">211</td>
-              <td class="test-title">ready ready-always-called
-                  
-              </td>
-              <td class="test-duration">233</td>
+              <td class="test-duration">399</td>
           </tr>
           <tr class="show ready success">
               <td class="test-id">212</td>
-              <td class="test-title">ready ready-error-test
+              <td class="test-title">ready ready_die
                   
               </td>
-              <td class="test-duration">124</td>
+              <td class="test-duration">122</td>
           </tr>
           <tr class="show ready success">
               <td class="test-id">213</td>
-              <td class="test-title">ready ready-event
+              <td class="test-title">ready ready_die_no_errhandler
                   
               </td>
-              <td class="test-duration">85</td>
+              <td class="test-duration">152</td>
           </tr>
           <tr class="show ready success">
               <td class="test-id">214</td>
+              <td class="test-title">ready ready_null_name
+                  
+              </td>
+              <td class="test-duration">153</td>
+          </tr>
+          <tr class="show ready success">
+              <td class="test-id">215</td>
+              <td class="test-title">ready ready-complex
+                  
+              </td>
+              <td class="test-duration">369</td>
+          </tr>
+          <tr class="show ready success">
+              <td class="test-id">216</td>
+              <td class="test-title">ready ready-always-called
+                  
+              </td>
+              <td class="test-duration">235</td>
+          </tr>
+          <tr class="show ready success">
+              <td class="test-id">217</td>
+              <td class="test-title">ready ready-error-test
+                  
+              </td>
+              <td class="test-duration">159</td>
+          </tr>
+          <tr class="show ready success">
+              <td class="test-id">218</td>
+              <td class="test-title">ready ready-event
+                  
+              </td>
+              <td class="test-duration">77</td>
+          </tr>
+          <tr class="show ready success">
+              <td class="test-id">219</td>
               <td class="test-title">ready ready-both
                   
               </td>
-              <td class="test-duration">179</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">215</td>
-              <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log&#x3D;level:warn
-                  
-              </td>
-              <td class="test-duration">12</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">216</td>
-              <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log&#x3D;level:warn+
-                  
-              </td>
-              <td class="test-duration">8</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">217</td>
-              <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log.level.warn
-                  
-              </td>
-              <td class="test-duration">14</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">218</td>
-              <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log.level.warn+
-                  
-              </td>
-              <td class="test-duration">42</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">219</td>
-              <td class="test-title">seneca --seneca.log arguments tests:  duplicate param --seneca.log
-                  
-              </td>
-              <td class="test-duration">31</td>
+              <td class="test-duration">142</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
               <td class="test-id">220</td>
-              <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log&#x3D;level:
+              <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log&#x3D;level:warn
                   
               </td>
-              <td class="test-duration">25</td>
+              <td class="test-duration">36</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
               <td class="test-id">221</td>
-              <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log.level.abc
+              <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log&#x3D;level:warn+
                   
               </td>
-              <td class="test-duration">25</td>
+              <td class="test-duration">15</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
               <td class="test-id">222</td>
+              <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log.level.warn
+                  
+              </td>
+              <td class="test-duration">36</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
+              <td class="test-id">223</td>
+              <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log.level.warn+
+                  
+              </td>
+              <td class="test-duration">29</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
+              <td class="test-id">224</td>
+              <td class="test-title">seneca --seneca.log arguments tests:  duplicate param --seneca.log
+                  
+              </td>
+              <td class="test-duration">26</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
+              <td class="test-id">225</td>
+              <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log&#x3D;level:
+                  
+              </td>
+              <td class="test-duration">16</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
+              <td class="test-id">226</td>
+              <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log.level.abc
+                  
+              </td>
+              <td class="test-duration">17</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
+              <td class="test-id">227</td>
               <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log.abc
                   
               </td>
               <td class="test-duration">12</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">223</td>
+              <td class="test-id">228</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.quiet
                   
               </td>
-              <td class="test-duration">25</td>
+              <td class="test-duration">15</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">224</td>
+              <td class="test-id">229</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.silent
                   
               </td>
-              <td class="test-duration">13</td>
+              <td class="test-duration">15</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">225</td>
+              <td class="test-id">230</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.all
+                  
+              </td>
+              <td class="test-duration">19</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">231</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.any
+                  
+              </td>
+              <td class="test-duration">17</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">232</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.print
+                  
+              </td>
+              <td class="test-duration">22</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">233</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.test
+                  
+              </td>
+              <td class="test-duration">22</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">234</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.standard
+                  
+              </td>
+              <td class="test-duration">24</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">235</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.quiet
+                  
+              </td>
+              <td class="test-duration">22</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">236</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.silent
+                  
+              </td>
+              <td class="test-duration">29</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">237</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.all
+                  
+              </td>
+              <td class="test-duration">26</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">238</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.any
+                  
+              </td>
+              <td class="test-duration">20</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">239</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.print
+                  
+              </td>
+              <td class="test-duration">22</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">240</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.test
                   
               </td>
               <td class="test-duration">28</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">226</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.any
-                  
-              </td>
-              <td class="test-duration">15</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">227</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.print
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">228</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.test
-                  
-              </td>
-              <td class="test-duration">17</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">229</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.standard
+              <td class="test-id">241</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.standard
                   
               </td>
               <td class="test-duration">21</td>
           </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">230</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.quiet
-                  
-              </td>
-              <td class="test-duration">14</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">231</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.silent
-                  
-              </td>
-              <td class="test-duration">32</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">232</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.all
-                  
-              </td>
-              <td class="test-duration">15</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">233</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.any
-                  
-              </td>
-              <td class="test-duration">12</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">234</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.print
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">235</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.test
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">236</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.standard
-                  
-              </td>
-              <td class="test-duration">15</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">237</td>
-              <td class="test-title">seneca happy
-                  
-              </td>
-              <td class="test-duration">32</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">238</td>
-              <td class="test-title">seneca require-abbrev
-                  
-              </td>
-              <td class="test-duration">242</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">239</td>
-              <td class="test-title">seneca version
-                  
-              </td>
-              <td class="test-duration">9</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">240</td>
-              <td class="test-title">seneca tag
-                  
-              </td>
-              <td class="test-duration">9</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">241</td>
-              <td class="test-title">seneca json-inspect
-                  
-              </td>
-              <td class="test-duration">16</td>
-          </tr>
           <tr class="show seneca success">
               <td class="test-id">242</td>
-              <td class="test-title">seneca quick
-                  
-              </td>
-              <td class="test-duration">39</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">243</td>
-              <td class="test-title">seneca happy-error
-                  
-              </td>
-              <td class="test-duration">13</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">244</td>
-              <td class="test-title">seneca errhandler
-                  
-              </td>
-              <td class="test-duration">115</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">245</td>
-              <td class="test-title">seneca action-basic
-                  
-              </td>
-              <td class="test-duration">17</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">246</td>
-              <td class="test-title">seneca action-callback-instance
-                  
-              </td>
-              <td class="test-duration">16</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">247</td>
-              <td class="test-title">seneca action-act-invalid-args
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">248</td>
-              <td class="test-title">seneca action-default
-                  
-              </td>
-              <td class="test-duration">17</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">249</td>
-              <td class="test-title">seneca action-override
-                  
-              </td>
-              <td class="test-duration">131</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">250</td>
-              <td class="test-title">seneca action-callback-args
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">251</td>
-              <td class="test-title">seneca action-extend
-                  
-              </td>
-              <td class="test-duration">129</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">252</td>
-              <td class="test-title">seneca prior-nocache
-                  
-              </td>
-              <td class="test-duration">351</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">253</td>
-              <td class="test-title">seneca gating
-                  
-              </td>
-              <td class="test-duration">126</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">254</td>
-              <td class="test-title">seneca act_if
-                  
-              </td>
-              <td class="test-duration">35</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">255</td>
-              <td class="test-title">seneca loading-plugins
-                  
-              </td>
-              <td class="test-duration">150</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">256</td>
-              <td class="test-title">seneca fire-and-forget
-                  
-              </td>
-              <td class="test-duration">11</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">257</td>
-              <td class="test-title">seneca strargs
+              <td class="test-title">seneca happy
                   
               </td>
               <td class="test-duration">42</td>
           </tr>
           <tr class="show seneca success">
+              <td class="test-id">243</td>
+              <td class="test-title">seneca require-abbrev
+                  
+              </td>
+              <td class="test-duration">254</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">244</td>
+              <td class="test-title">seneca version
+                  
+              </td>
+              <td class="test-duration">21</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">245</td>
+              <td class="test-title">seneca tag
+                  
+              </td>
+              <td class="test-duration">29</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">246</td>
+              <td class="test-title">seneca json-inspect
+                  
+              </td>
+              <td class="test-duration">42</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">247</td>
+              <td class="test-title">seneca quick
+                  
+              </td>
+              <td class="test-duration">61</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">248</td>
+              <td class="test-title">seneca happy-error
+                  
+              </td>
+              <td class="test-duration">24</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">249</td>
+              <td class="test-title">seneca errhandler
+                  
+              </td>
+              <td class="test-duration">121</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">250</td>
+              <td class="test-title">seneca action-basic
+                  
+              </td>
+              <td class="test-duration">62</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">251</td>
+              <td class="test-title">seneca action-callback-instance
+                  
+              </td>
+              <td class="test-duration">28</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">252</td>
+              <td class="test-title">seneca action-act-invalid-args
+                  
+              </td>
+              <td class="test-duration">29</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">253</td>
+              <td class="test-title">seneca action-default
+                  
+              </td>
+              <td class="test-duration">35</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">254</td>
+              <td class="test-title">seneca action-override
+                  
+              </td>
+              <td class="test-duration">133</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">255</td>
+              <td class="test-title">seneca action-callback-args
+                  
+              </td>
+              <td class="test-duration">23</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">256</td>
+              <td class="test-title">seneca action-extend
+                  
+              </td>
+              <td class="test-duration">170</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">257</td>
+              <td class="test-title">seneca prior-nocache
+                  
+              </td>
+              <td class="test-duration">379</td>
+          </tr>
+          <tr class="show seneca success">
               <td class="test-id">258</td>
+              <td class="test-title">seneca gating
+                  
+              </td>
+              <td class="test-duration">195</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">259</td>
+              <td class="test-title">seneca act_if
+                  
+              </td>
+              <td class="test-duration">118</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">260</td>
+              <td class="test-title">seneca loading-plugins
+                  
+              </td>
+              <td class="test-duration">163</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">261</td>
+              <td class="test-title">seneca fire-and-forget
+                  
+              </td>
+              <td class="test-duration">19</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">262</td>
+              <td class="test-title">seneca strargs
+                  
+              </td>
+              <td class="test-duration">90</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">263</td>
               <td class="test-title">seneca string-add
                   
               </td>
               <td class="test-duration">22</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">259</td>
+              <td class="test-id">264</td>
               <td class="test-title">seneca fix-basic
                   
               </td>
-              <td class="test-duration">11</td>
+              <td class="test-duration">10</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">260</td>
+              <td class="test-id">265</td>
               <td class="test-title">seneca act-history
                   
               </td>
               <td class="test-duration">59</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">261</td>
+              <td class="test-id">266</td>
               <td class="test-title">seneca wrap
                   
               </td>
-              <td class="test-duration">45</td>
+              <td class="test-duration">53</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">262</td>
+              <td class="test-id">267</td>
               <td class="test-title">seneca meta
                   
               </td>
               <td class="test-duration">25</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">263</td>
+              <td class="test-id">268</td>
               <td class="test-title">seneca strict-result
                   
               </td>
-              <td class="test-duration">9</td>
+              <td class="test-duration">11</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">264</td>
+              <td class="test-id">269</td>
               <td class="test-title">seneca add-noop
                   
               </td>
               <td class="test-duration">16</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">265</td>
+              <td class="test-id">270</td>
               <td class="test-title">seneca supports jsonic params to has
-                  
-              </td>
-              <td class="test-duration">10</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">266</td>
-              <td class="test-title">seneca supports a function to trace actions
-                  
-              </td>
-              <td class="test-duration">30</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">267</td>
-              <td class="test-title">seneca supports true to be passed as trace action option
                   
               </td>
               <td class="test-duration">13</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">268</td>
-              <td class="test-title">seneca strict-find-false
-                  
-              </td>
-              <td class="test-duration">20</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">269</td>
-              <td class="test-title">seneca strict-find-true
-                  
-              </td>
-              <td class="test-duration">16</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">270</td>
-              <td class="test-title">seneca strict-find-default
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show seneca success">
               <td class="test-id">271</td>
-              <td class="test-title">seneca catchall-pattern
+              <td class="test-title">seneca supports a function to trace actions
                   
               </td>
-              <td class="test-duration">123</td>
+              <td class="test-duration">29</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">272</td>
-              <td class="test-title">seneca memory
+              <td class="test-title">seneca supports true to be passed as trace action option
                   
               </td>
-              <td class="test-duration">414</td>
+              <td class="test-duration">25</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">273</td>
-              <td class="test-title">seneca use-shortcut
+              <td class="test-title">seneca strict-find-false
                   
               </td>
-              <td class="test-duration">22</td>
+              <td class="test-duration">24</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">274</td>
-              <td class="test-title">seneca status-log
-                  
-              </td>
-              <td class="test-duration">12</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">275</td>
-              <td class="test-title">seneca reply-seneca
-                  
-              </td>
-              <td class="test-duration">129</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">276</td>
-              <td class="test-title">seneca pattern-types
-                  
-              </td>
-              <td class="test-duration">138</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">277</td>
-              <td class="test-title">seneca order
-                  
-              </td>
-              <td class="test-duration">11</td>
-          </tr>
-          <tr class="show seneca #decorate success">
-              <td class="test-id">278</td>
-              <td class="test-title">seneca #decorate can add a property to seneca
-                  
-              </td>
-              <td class="test-duration">8</td>
-          </tr>
-          <tr class="show seneca #decorate success">
-              <td class="test-id">279</td>
-              <td class="test-title">seneca #decorate cannot override core property
-                  
-              </td>
-              <td class="test-duration">16</td>
-          </tr>
-          <tr class="show seneca #decorate success">
-              <td class="test-id">280</td>
-              <td class="test-title">seneca #decorate cannot overwrite a decorated property
-                  
-              </td>
-              <td class="test-duration">30</td>
-          </tr>
-          <tr class="show seneca #decorate success">
-              <td class="test-id">281</td>
-              <td class="test-title">seneca #decorate cannot prefix a property with an underscore
-                  
-              </td>
-              <td class="test-duration">16</td>
-          </tr>
-          <tr class="show seneca #intercept success">
-              <td class="test-id">282</td>
-              <td class="test-title">seneca #intercept intercept
-                  
-              </td>
-              <td class="test-duration">30</td>
-          </tr>
-          <tr class="show sequence success">
-              <td class="test-id">283</td>
-              <td class="test-title">sequence single-add-act
-                  
-              </td>
-              <td class="test-duration">26</td>
-          </tr>
-          <tr class="show sequence success">
-              <td class="test-id">284</td>
-              <td class="test-title">sequence double-add-act
-                  
-              </td>
-              <td class="test-duration">16</td>
-          </tr>
-          <tr class="show sequence success">
-              <td class="test-id">285</td>
-              <td class="test-title">sequence single-add-act-ready
-                  
-              </td>
-              <td class="test-duration">123</td>
-          </tr>
-          <tr class="show sequence success">
-              <td class="test-id">286</td>
-              <td class="test-title">sequence single-add-act-gate-action
+              <td class="test-title">seneca strict-find-true
                   
               </td>
               <td class="test-duration">18</td>
           </tr>
-          <tr class="show sequence success">
-              <td class="test-id">287</td>
-              <td class="test-title">sequence single-add-act-gate-instance
+          <tr class="show seneca success">
+              <td class="test-id">275</td>
+              <td class="test-title">seneca strict-find-default
                   
               </td>
-              <td class="test-duration">21</td>
+              <td class="test-duration">24</td>
           </tr>
-          <tr class="show smoke success">
-              <td class="test-id">288</td>
-              <td class="test-title">smoke seneca-smoke
-                  
-              </td>
-              <td class="test-duration">34</td>
-          </tr>
-          <tr class="show options success">
-              <td class="test-id">289</td>
-              <td class="test-title">options options-happy
-                  
-              </td>
-              <td class="test-duration">125</td>
-          </tr>
-          <tr class="show options success">
-              <td class="test-id">290</td>
-              <td class="test-title">options options-getset
-                  
-              </td>
-              <td class="test-duration">124</td>
-          </tr>
-          <tr class="show options success">
-              <td class="test-id">291</td>
-              <td class="test-title">options options-legacy
-                  
-              </td>
-              <td class="test-duration">125</td>
-          </tr>
-          <tr class="show options success">
-              <td class="test-id">292</td>
-              <td class="test-title">options options-file-js
-                  
-              </td>
-              <td class="test-duration">122</td>
-          </tr>
-          <tr class="show options success">
-              <td class="test-id">293</td>
-              <td class="test-title">options legacy-options-file-js
-                  
-              </td>
-              <td class="test-duration">123</td>
-          </tr>
-          <tr class="show options success">
-              <td class="test-id">294</td>
-              <td class="test-title">options options-file-json
-                  
-              </td>
-              <td class="test-duration">126</td>
-          </tr>
-          <tr class="show options success">
-              <td class="test-id">295</td>
-              <td class="test-title">options options-file-json-nomore
-                  
-              </td>
-              <td class="test-duration">121</td>
-          </tr>
-          <tr class="show options success">
-              <td class="test-id">296</td>
-              <td class="test-title">options options-env
-                  
-              </td>
-              <td class="test-duration">121</td>
-          </tr>
-          <tr class="show options success">
-              <td class="test-id">297</td>
-              <td class="test-title">options options-cmdline
-                  
-              </td>
-              <td class="test-duration">122</td>
-          </tr>
-          <tr class="show sub success">
-              <td class="test-id">298</td>
-              <td class="test-title">sub happy-sub
-                  
-              </td>
-              <td class="test-duration">26</td>
-          </tr>
-          <tr class="show sub success">
-              <td class="test-id">299</td>
-              <td class="test-title">sub inwards-outwards-sub
-                  
-              </td>
-              <td class="test-duration">45</td>
-          </tr>
-          <tr class="show sub success">
-              <td class="test-id">300</td>
-              <td class="test-title">sub specific-sub
-                  
-              </td>
-              <td class="test-duration">45</td>
-          </tr>
-          <tr class="show sub success">
-              <td class="test-id">301</td>
-              <td class="test-title">sub error-sub
-                  
-              </td>
-              <td class="test-duration">21</td>
-          </tr>
-          <tr class="show sub success">
-              <td class="test-id">302</td>
-              <td class="test-title">sub mixed-sub
-                  
-              </td>
-              <td class="test-duration">23</td>
-          </tr>
-          <tr class="show sub success">
-              <td class="test-id">303</td>
-              <td class="test-title">sub sub-prior
+          <tr class="show seneca success">
+              <td class="test-id">276</td>
+              <td class="test-title">seneca catchall-pattern
                   
               </td>
               <td class="test-duration">129</td>
           </tr>
-          <tr class="show sub success">
-              <td class="test-id">304</td>
-              <td class="test-title">sub sub-close
+          <tr class="show seneca success">
+              <td class="test-id">277</td>
+              <td class="test-title">seneca memory
                   
               </td>
-              <td class="test-duration">126</td>
+              <td class="test-duration">515</td>
           </tr>
-          <tr class="show sub success">
-              <td class="test-id">305</td>
-              <td class="test-title">sub sub-fix
+          <tr class="show seneca success">
+              <td class="test-id">278</td>
+              <td class="test-title">seneca use-shortcut
+                  
+              </td>
+              <td class="test-duration">44</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">279</td>
+              <td class="test-title">seneca status-log
+                  
+              </td>
+              <td class="test-duration">27</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">280</td>
+              <td class="test-title">seneca reply-seneca
+                  
+              </td>
+              <td class="test-duration">133</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">281</td>
+              <td class="test-title">seneca pattern-types
+                  
+              </td>
+              <td class="test-duration">153</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">282</td>
+              <td class="test-title">seneca order
+                  
+              </td>
+              <td class="test-duration">40</td>
+          </tr>
+          <tr class="show seneca #decorate success">
+              <td class="test-id">283</td>
+              <td class="test-title">seneca #decorate can add a property to seneca
+                  
+              </td>
+              <td class="test-duration">26</td>
+          </tr>
+          <tr class="show seneca #decorate success">
+              <td class="test-id">284</td>
+              <td class="test-title">seneca #decorate cannot override core property
+                  
+              </td>
+              <td class="test-duration">51</td>
+          </tr>
+          <tr class="show seneca #decorate success">
+              <td class="test-id">285</td>
+              <td class="test-title">seneca #decorate cannot overwrite a decorated property
+                  
+              </td>
+              <td class="test-duration">27</td>
+          </tr>
+          <tr class="show seneca #decorate success">
+              <td class="test-id">286</td>
+              <td class="test-title">seneca #decorate cannot prefix a property with an underscore
                   
               </td>
               <td class="test-duration">17</td>
           </tr>
-          <tr class="show timeout success">
-              <td class="test-id">306</td>
-              <td class="test-title">timeout happy
+          <tr class="show seneca #intercept success">
+              <td class="test-id">287</td>
+              <td class="test-title">seneca #intercept intercept
                   
               </td>
-              <td class="test-duration">122</td>
+              <td class="test-duration">38</td>
           </tr>
-          <tr class="show timeout success">
-              <td class="test-id">307</td>
-              <td class="test-title">timeout error-handler
+          <tr class="show sequence success">
+              <td class="test-id">288</td>
+              <td class="test-title">sequence single-add-act
                   
               </td>
-              <td class="test-duration">126</td>
+              <td class="test-duration">23</td>
           </tr>
-          <tr class="show timeout success">
-              <td class="test-id">308</td>
-              <td class="test-title">timeout should accept a timeout value from options
+          <tr class="show sequence success">
+              <td class="test-id">289</td>
+              <td class="test-title">sequence double-add-act
                   
               </td>
-              <td class="test-duration">235</td>
+              <td class="test-duration">37</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">309</td>
-              <td class="test-title">transport happy-nextgen
+          <tr class="show sequence success">
+              <td class="test-id">290</td>
+              <td class="test-title">sequence single-add-act-ready
                   
               </td>
-              <td class="test-duration">391</td>
+              <td class="test-duration">127</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">310</td>
-              <td class="test-title">transport config-legacy-nextgen
+          <tr class="show sequence success">
+              <td class="test-id">291</td>
+              <td class="test-title">sequence single-add-act-gate-action
                   
               </td>
-              <td class="test-duration">483</td>
+              <td class="test-duration">87</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">311</td>
-              <td class="test-title">transport error-nextgen
+          <tr class="show sequence success">
+              <td class="test-id">292</td>
+              <td class="test-title">sequence single-add-act-gate-instance
                   
               </td>
-              <td class="test-duration">367</td>
+              <td class="test-duration">67</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">312</td>
-              <td class="test-title">transport interop-nextgen
+          <tr class="show smoke success">
+              <td class="test-id">293</td>
+              <td class="test-title">smoke seneca-smoke
                   
               </td>
-              <td class="test-duration">271</td>
+              <td class="test-duration">19</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">313</td>
-              <td class="test-title">transport config-nextgen
+          <tr class="show options success">
+              <td class="test-id">294</td>
+              <td class="test-title">options options-happy
                   
               </td>
-              <td class="test-duration">511</td>
+              <td class="test-duration">133</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">314</td>
-              <td class="test-title">transport nextgen-transport-local-override
+          <tr class="show options success">
+              <td class="test-id">295</td>
+              <td class="test-title">options options-getset
                   
               </td>
-              <td class="test-duration">379</td>
+              <td class="test-duration">207</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">315</td>
-              <td class="test-title">transport nextgen-meta
+          <tr class="show options success">
+              <td class="test-id">296</td>
+              <td class="test-title">options options-legacy
                   
               </td>
-              <td class="test-duration">383</td>
+              <td class="test-duration">168</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">316</td>
-              <td class="test-title">transport nextgen-ordering
+          <tr class="show options success">
+              <td class="test-id">297</td>
+              <td class="test-title">options options-file-js
                   
               </td>
-              <td class="test-duration">493</td>
+              <td class="test-duration">168</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">317</td>
-              <td class="test-title">transport transport-exact-single
+          <tr class="show options success">
+              <td class="test-id">298</td>
+              <td class="test-title">options legacy-options-file-js
                   
               </td>
-              <td class="test-duration">174</td>
+              <td class="test-duration">160</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">318</td>
-              <td class="test-title">transport transport-local-override
+          <tr class="show options success">
+              <td class="test-id">299</td>
+              <td class="test-title">options options-file-json
                   
               </td>
-              <td class="test-duration">157</td>
+              <td class="test-duration">139</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">319</td>
-              <td class="test-title">transport transport-star
+          <tr class="show options success">
+              <td class="test-id">300</td>
+              <td class="test-title">options options-file-json-nomore
                   
               </td>
-              <td class="test-duration">276</td>
+              <td class="test-duration">146</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">320</td>
-              <td class="test-title">transport transport-star-pin-object
+          <tr class="show options success">
+              <td class="test-id">301</td>
+              <td class="test-title">options options-env
                   
               </td>
-              <td class="test-duration">282</td>
+              <td class="test-duration">180</td>
           </tr>
-          <tr class="show transport success">
-              <td class="test-id">321</td>
-              <td class="test-title">transport transport-single-notdef
-                  
-              </td>
-              <td class="test-duration">159</td>
-          </tr>
-          <tr class="show transport success">
-              <td class="test-id">322</td>
-              <td class="test-title">transport transport-pins-notdef
-                  
-              </td>
-              <td class="test-duration">183</td>
-          </tr>
-          <tr class="show transport success">
-              <td class="test-id">323</td>
-              <td class="test-title">transport transport-single-wrap-and-star
-                  
-              </td>
-              <td class="test-duration">309</td>
-          </tr>
-          <tr class="show transport success">
-              <td class="test-id">324</td>
-              <td class="test-title">transport transport-local-single-and-star
-                  
-              </td>
-              <td class="test-duration">277</td>
-          </tr>
-          <tr class="show transport success">
-              <td class="test-id">325</td>
-              <td class="test-title">transport transport-local-over-wrap
-                  
-              </td>
-              <td class="test-duration">249</td>
-          </tr>
-          <tr class="show transport success">
-              <td class="test-id">326</td>
-              <td class="test-title">transport transport-local-prior-wrap
+          <tr class="show options success">
+              <td class="test-id">302</td>
+              <td class="test-title">options options-cmdline
                   
               </td>
               <td class="test-duration">165</td>
           </tr>
+          <tr class="show sub success">
+              <td class="test-id">303</td>
+              <td class="test-title">sub happy-sub
+                  
+              </td>
+              <td class="test-duration">111</td>
+          </tr>
+          <tr class="show sub success">
+              <td class="test-id">304</td>
+              <td class="test-title">sub inwards-outwards-sub
+                  
+              </td>
+              <td class="test-duration">36</td>
+          </tr>
+          <tr class="show sub success">
+              <td class="test-id">305</td>
+              <td class="test-title">sub specific-sub
+                  
+              </td>
+              <td class="test-duration">31</td>
+          </tr>
+          <tr class="show sub success">
+              <td class="test-id">306</td>
+              <td class="test-title">sub error-sub
+                  
+              </td>
+              <td class="test-duration">24</td>
+          </tr>
+          <tr class="show sub success">
+              <td class="test-id">307</td>
+              <td class="test-title">sub mixed-sub
+                  
+              </td>
+              <td class="test-duration">25</td>
+          </tr>
+          <tr class="show sub success">
+              <td class="test-id">308</td>
+              <td class="test-title">sub sub-prior
+                  
+              </td>
+              <td class="test-duration">125</td>
+          </tr>
+          <tr class="show sub success">
+              <td class="test-id">309</td>
+              <td class="test-title">sub sub-close
+                  
+              </td>
+              <td class="test-duration">157</td>
+          </tr>
+          <tr class="show sub success">
+              <td class="test-id">310</td>
+              <td class="test-title">sub sub-fix
+                  
+              </td>
+              <td class="test-duration">37</td>
+          </tr>
+          <tr class="show timeout success">
+              <td class="test-id">311</td>
+              <td class="test-title">timeout happy
+                  
+              </td>
+              <td class="test-duration">129</td>
+          </tr>
+          <tr class="show timeout success">
+              <td class="test-id">312</td>
+              <td class="test-title">timeout error-handler
+                  
+              </td>
+              <td class="test-duration">144</td>
+          </tr>
+          <tr class="show timeout success">
+              <td class="test-id">313</td>
+              <td class="test-title">timeout should accept a timeout value from options
+                  
+              </td>
+              <td class="test-duration">261</td>
+          </tr>
           <tr class="show transport success">
-              <td class="test-id">327</td>
-              <td class="test-title">transport transport-init-ordering
+              <td class="test-id">314</td>
+              <td class="test-title">transport happy-nextgen
+                  
+              </td>
+              <td class="test-duration">421</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">315</td>
+              <td class="test-title">transport config-legacy-nextgen
+                  
+              </td>
+              <td class="test-duration">553</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">316</td>
+              <td class="test-title">transport error-nextgen
+                  
+              </td>
+              <td class="test-duration">416</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">317</td>
+              <td class="test-title">transport interop-nextgen
+                  
+              </td>
+              <td class="test-duration">392</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">318</td>
+              <td class="test-title">transport config-nextgen
+                  
+              </td>
+              <td class="test-duration">619</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">319</td>
+              <td class="test-title">transport nextgen-transport-local-override
+                  
+              </td>
+              <td class="test-duration">442</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">320</td>
+              <td class="test-title">transport nextgen-meta
+                  
+              </td>
+              <td class="test-duration">423</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">321</td>
+              <td class="test-title">transport nextgen-ordering
+                  
+              </td>
+              <td class="test-duration">563</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">322</td>
+              <td class="test-title">transport transport-exact-single
                   
               </td>
               <td class="test-duration">242</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">328</td>
-              <td class="test-title">transport transport-no-plugin-init
+              <td class="test-id">323</td>
+              <td class="test-title">transport transport-local-override
                   
               </td>
-              <td class="test-duration">281</td>
+              <td class="test-duration">160</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">324</td>
+              <td class="test-title">transport transport-star
+                  
+              </td>
+              <td class="test-duration">323</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">325</td>
+              <td class="test-title">transport transport-star-pin-object
+                  
+              </td>
+              <td class="test-duration">374</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">326</td>
+              <td class="test-title">transport transport-single-notdef
+                  
+              </td>
+              <td class="test-duration">200</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">327</td>
+              <td class="test-title">transport transport-pins-notdef
+                  
+              </td>
+              <td class="test-duration">198</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">328</td>
+              <td class="test-title">transport transport-single-wrap-and-star
+                  
+              </td>
+              <td class="test-duration">337</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">329</td>
-              <td class="test-title">transport transport-balance-exact
+              <td class="test-title">transport transport-local-single-and-star
                   
               </td>
-              <td class="test-duration">919</td>
+              <td class="test-duration">323</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">330</td>
-              <td class="test-title">transport multi-layer-error
+              <td class="test-title">transport transport-local-over-wrap
                   
               </td>
-              <td class="test-duration">731</td>
+              <td class="test-duration">289</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">331</td>
+              <td class="test-title">transport transport-local-prior-wrap
+                  
+              </td>
+              <td class="test-duration">208</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">332</td>
+              <td class="test-title">transport transport-init-ordering
+                  
+              </td>
+              <td class="test-duration">239</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">333</td>
+              <td class="test-title">transport transport-no-plugin-init
+                  
+              </td>
+              <td class="test-duration">307</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">334</td>
+              <td class="test-title">transport transport-balance-exact
+                  
+              </td>
+              <td class="test-duration">1022</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">335</td>
+              <td class="test-title">transport multi-layer-error
+                  
+              </td>
+              <td class="test-duration">778</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">336</td>
               <td class="test-title">transport server can be restarted without issues to clients
                   
               </td>
-              <td class="test-duration">631</td>
-          </tr>
-          <tr class="show transport transport-listen success">
-              <td class="test-id">332</td>
-              <td class="test-title">transport transport-listen supports-null-options
-                  
-              </td>
-              <td class="test-duration">126</td>
-          </tr>
-          <tr class="show transport transport-listen success">
-              <td class="test-id">333</td>
-              <td class="test-title">transport transport-listen supports type as tcp option
-                  
-              </td>
-              <td class="test-duration">124</td>
-          </tr>
-          <tr class="show transport transport-listen success">
-              <td class="test-id">334</td>
-              <td class="test-title">transport transport-listen supports type as http option
-                  
-              </td>
-              <td class="test-duration">128</td>
-          </tr>
-          <tr class="show transport transport-listen success">
-              <td class="test-id">335</td>
-              <td class="test-title">transport transport-listen supports the port number as an argument
-                  
-              </td>
-              <td class="test-duration">128</td>
-          </tr>
-          <tr class="show transport transport-listen success">
-              <td class="test-id">336</td>
-              <td class="test-title">transport transport-listen supports the port number and host as an argument
-                  
-              </td>
-              <td class="test-duration">125</td>
+              <td class="test-duration">648</td>
           </tr>
           <tr class="show transport transport-listen success">
               <td class="test-id">337</td>
-              <td class="test-title">transport transport-listen supports the port number, host, and path as an argument
+              <td class="test-title">transport transport-listen supports-null-options
                   
               </td>
-              <td class="test-duration">124</td>
+              <td class="test-duration">184</td>
           </tr>
           <tr class="show transport transport-listen success">
               <td class="test-id">338</td>
+              <td class="test-title">transport transport-listen supports type as tcp option
+                  
+              </td>
+              <td class="test-duration">132</td>
+          </tr>
+          <tr class="show transport transport-listen success">
+              <td class="test-id">339</td>
+              <td class="test-title">transport transport-listen supports type as http option
+                  
+              </td>
+              <td class="test-duration">136</td>
+          </tr>
+          <tr class="show transport transport-listen success">
+              <td class="test-id">340</td>
+              <td class="test-title">transport transport-listen supports the port number as an argument
+                  
+              </td>
+              <td class="test-duration">141</td>
+          </tr>
+          <tr class="show transport transport-listen success">
+              <td class="test-id">341</td>
+              <td class="test-title">transport transport-listen supports the port number and host as an argument
+                  
+              </td>
+              <td class="test-duration">174</td>
+          </tr>
+          <tr class="show transport transport-listen success">
+              <td class="test-id">342</td>
+              <td class="test-title">transport transport-listen supports the port number, host, and path as an argument
+                  
+              </td>
+              <td class="test-duration">165</td>
+          </tr>
+          <tr class="show transport transport-listen success">
+              <td class="test-id">343</td>
               <td class="test-title">transport transport-listen action-error
                   
               </td>
-              <td class="test-duration">122</td>
+              <td class="test-duration">159</td>
           </tr>
           <tr class="show transport client() success">
-              <td class="test-id">339</td>
+              <td class="test-id">344</td>
               <td class="test-title">transport client() supports null options
                   
               </td>
-              <td class="test-duration">128</td>
+              <td class="test-duration">132</td>
           </tr>
           <tr class="show util success">
-              <td class="test-id">340</td>
+              <td class="test-id">345</td>
               <td class="test-title">util seneca.util.deepextend.happy
-                  
-              </td>
-              <td class="test-duration">1</td>
-          </tr>
-          <tr class="show util success">
-              <td class="test-id">341</td>
-              <td class="test-title">util seneca.util.deepextend.types with new
                   
               </td>
               <td class="test-duration">2</td>
           </tr>
           <tr class="show util success">
-              <td class="test-id">342</td>
+              <td class="test-id">346</td>
+              <td class="test-title">util seneca.util.deepextend.types with new
+                  
+              </td>
+              <td class="test-duration">3</td>
+          </tr>
+          <tr class="show util success">
+              <td class="test-id">347</td>
               <td class="test-title">util seneca.util.deepextend.types
                   
               </td>
-              <td class="test-duration">1</td>
+              <td class="test-duration">2</td>
           </tr>
           <tr class="show util success">
-              <td class="test-id">343</td>
+              <td class="test-id">348</td>
               <td class="test-title">util seneca.util.deepextend.mixed
                   
               </td>
               <td class="test-duration">2</td>
           </tr>
           <tr class="show util success">
-              <td class="test-id">344</td>
+              <td class="test-id">349</td>
               <td class="test-title">util seneca.util.deepextend.entity
                   
               </td>
               <td class="test-duration">0</td>
           </tr>
           <tr class="show xward success">
-              <td class="test-id">345</td>
+              <td class="test-id">350</td>
               <td class="test-title">xward happy-inward
                   
               </td>
-              <td class="test-duration">16</td>
+              <td class="test-duration">37</td>
           </tr>
           <tr class="show xward success">
-              <td class="test-id">346</td>
+              <td class="test-id">351</td>
               <td class="test-title">xward happy-outward
                   
               </td>
-              <td class="test-duration">15</td>
+              <td class="test-duration">28</td>
           </tr>
           </tbody>
       </table>
@@ -3137,10 +3186,10 @@
     </div>    <div id="coverage">
         <h1>Code Coverage Report</h1>
         <div class="stats high">
-            <div class="percentage">91.61%</div>
-            <div class="sloc">4792</div>
-            <div class="hits">4390</div>
-            <div class="misses">402</div>
+            <div class="percentage">91.63%</div>
+            <div class="sloc">4817</div>
+            <div class="hits">4414</div>
+            <div class="misses">403</div>
         </div>
         <div id="filters">
           <input type="checkbox" checked="" onchange="filter(this)" value="generated" id="show-generated">
@@ -7717,7 +7766,7 @@
                         </tr>            <tr id="seneca.js__759" class="hit">
                           <td class="line" data-tooltip>759</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10358</td>
+                          <td class="hits" data-tooltip>10362</td>
                           <td class="source">      return void 0</td>
                           
                         </tr>            <tr id="seneca.js__760" class="hit">
@@ -8279,7 +8328,7 @@
                         </tr>            <tr id="lib/act.js__86" class="hit">
                           <td class="line" data-tooltip>86</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
+                          <td class="hits" data-tooltip>9</td>
                           <td class="source">      var timeout_err &#x3D; Common.error(&#x27;action_timeout&#x27;, {</td>
                           
                         </tr>            <tr id="lib/act.js__87" class="hit">
@@ -8345,7 +8394,7 @@
                         </tr>            <tr id="lib/act.js__97" class="hit">
                           <td class="line" data-tooltip>97</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
+                          <td class="hits" data-tooltip>9</td>
                           <td class="source">      intern.handle_reply(meta, actctxt, actmsg, timeout_err)</td>
                           
                         </tr>            <tr id="lib/act.js__98" class="hit">
@@ -9083,13 +9132,13 @@
                         </tr>            <tr id="lib/act.js__220" class="hit">
                           <td class="line" data-tooltip>220</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    var delegate &#x3D; actctxt.seneca</td>
                           
                         </tr>            <tr id="lib/act.js__221" class="hit">
                           <td class="line" data-tooltip>221</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    var reply &#x3D; actctxt.reply</td>
                           
                         </tr>            <tr id="lib/act.js__222" class="hit">
@@ -9101,7 +9150,7 @@
                         </tr>            <tr id="lib/act.js__223" class="hit">
                           <td class="line" data-tooltip>223</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    var data &#x3D; {</td>
                           
                         </tr>            <tr id="lib/act.js__224" class="hit">
@@ -9161,25 +9210,25 @@
                         </tr>            <tr id="lib/act.js__233" class="hit">
                           <td class="line" data-tooltip>233</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    actctxt.duration &#x3D; meta.end - meta.start</td>
                           
                         </tr>            <tr id="lib/act.js__234" class="hit">
                           <td class="line" data-tooltip>234</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    actctxt.actlog &#x3D; intern.actlog</td>
                           
                         </tr>            <tr id="lib/act.js__235" class="hit">
                           <td class="line" data-tooltip>235</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    actctxt.errlog &#x3D; intern.errlog</td>
                           
                         </tr>            <tr id="lib/act.js__236" class="hit">
                           <td class="line" data-tooltip>236</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    actctxt.error &#x3D; Common.error</td>
                           
                         </tr>            <tr id="lib/act.js__237" class="hit">
@@ -9191,7 +9240,7 @@
                         </tr>            <tr id="lib/act.js__238" class="hit">
                           <td class="line" data-tooltip>238</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    meta.error &#x3D; Util.isError(data.res)</td>
                           
                         </tr>            <tr id="lib/act.js__239" class="hit">
@@ -9209,7 +9258,7 @@
                         </tr>            <tr id="lib/act.js__241" class="hit">
                           <td class="line" data-tooltip>241</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    if (!meta.error &amp;&amp; data.res &#x3D;&#x3D;&#x3D; data.err) {</td>
                           
                         </tr>            <tr id="lib/act.js__242" class="hit">
@@ -9239,7 +9288,7 @@
                         </tr>            <tr id="lib/act.js__246" class="hit">
                           <td class="line" data-tooltip>246</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    if (</td>
                           
                         </tr>            <tr id="lib/act.js__247" class="hit">
@@ -9305,7 +9354,7 @@
                         </tr>            <tr id="lib/act.js__257" class="hit">
                           <td class="line" data-tooltip>257</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    intern.process_outward(actctxt, data, delegate)</td>
                           
                         </tr>            <tr id="lib/act.js__258" class="hit">
@@ -9317,19 +9366,19 @@
                         </tr>            <tr id="lib/act.js__259" class="hit">
                           <td class="line" data-tooltip>259</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    if (data.has_callback) {</td>
                           
                         </tr>            <tr id="lib/act.js__260" class="hit">
                           <td class="line" data-tooltip>260</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2815</td>
+                          <td class="hits" data-tooltip>2819</td>
                           <td class="source">      try {</td>
                           
                         </tr>            <tr id="lib/act.js__261" class="hit">
                           <td class="line" data-tooltip>261</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2815</td>
+                          <td class="hits" data-tooltip>2819</td>
                           <td class="source">        reply.call(delegate, data.err, data.res, data.meta)</td>
                           
                         </tr>            <tr id="lib/act.js__262" class="hit">
@@ -9407,7 +9456,7 @@
                         </tr>            <tr id="lib/act.js__274" class="hit">
                           <td class="line" data-tooltip>274</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2825</td>
+                          <td class="hits" data-tooltip>2829</td>
                           <td class="source">    if (outward) {</td>
                           
                         </tr>            <tr id="lib/act.js__275" class="hit">
@@ -12358,10 +12407,10 @@
             <div class="file ">
                 <h2 id="lib/api.js">lib/api.js </h2>
                 <div class="stats high">
-                    <div class="percentage">92.46%</div>
-                    <div class="sloc">650</div>
-                    <div class="hits">601</div>
-                    <div class="misses">49</div>
+                    <div class="percentage">92.42%</div>
+                    <div class="sloc">673</div>
+                    <div class="hits">622</div>
+                    <div class="misses">51</div>
                 </div>
                 <table>
                     <thead>
@@ -12719,7 +12768,7 @@
                         </tr>            <tr id="lib/api.js__58" class="hit">
                           <td class="line" data-tooltip>58</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>22095</td>
+                          <td class="hits" data-tooltip>22107</td>
                           <td class="source">  var private$ &#x3D; self.private$</td>
                           
                         </tr>            <tr id="lib/api.js__59" class="hit">
@@ -12731,13 +12780,13 @@
                         </tr>            <tr id="lib/api.js__60" class="hit">
                           <td class="line" data-tooltip>60</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>22095</td>
+                          <td class="hits" data-tooltip>22107</td>
                           <td class="source">  if (null &#x3D;&#x3D; options) {</td>
                           
                         </tr>            <tr id="lib/api.js__61" class="hit">
                           <td class="line" data-tooltip>61</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>20824</td>
+                          <td class="hits" data-tooltip>20836</td>
                           <td class="source">    return private$.optioner.get()</td>
                           
                         </tr>            <tr id="lib/api.js__62" class="hit">
@@ -13253,7 +13302,7 @@
                         </tr>            <tr id="lib/api.js__147" class="hit">
                           <td class="line" data-tooltip>147</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>16</td>
+                          <td class="hits" data-tooltip>17</td>
                           <td class="source">    if (null &#x3D;&#x3D; first) {</td>
                           
                         </tr>            <tr id="lib/api.js__148" class="hit">
@@ -13277,7 +13326,7 @@
                         </tr>            <tr id="lib/api.js__151" class="hit">
                           <td class="line" data-tooltip>151</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>14</td>
+                          <td class="hits" data-tooltip>15</td>
                           <td class="source">    var plugin_fullname &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__152" class="chunks">
@@ -13295,7 +13344,7 @@
                         </tr>            <tr id="lib/api.js__154" class="hit">
                           <td class="line" data-tooltip>154</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>14</td>
+                          <td class="hits" data-tooltip>15</td>
                           <td class="source">    var plugin &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__155" class="hit">
@@ -13325,13 +13374,13 @@
                         </tr>            <tr id="lib/api.js__159" class="hit">
                           <td class="line" data-tooltip>159</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>14</td>
+                          <td class="hits" data-tooltip>15</td>
                           <td class="source">    var error &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__160" class="hit">
                           <td class="line" data-tooltip>160</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>14</td>
+                          <td class="hits" data-tooltip>15</td>
                           <td class="source">    if (plugin &amp;&amp; plugin.eraro &amp;&amp; plugin.eraro.has(first)) {</td>
                           
                         </tr>            <tr id="lib/api.js__161" class="hit">
@@ -13349,7 +13398,7 @@
                         </tr>            <tr id="lib/api.js__163" class="hit">
                           <td class="line" data-tooltip>163</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
+                          <td class="hits" data-tooltip>12</td>
                           <td class="source">      error &#x3D; Common.eraro.apply(this, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__164" class="hit">
@@ -13367,7 +13416,7 @@
                         </tr>            <tr id="lib/api.js__166" class="hit">
                           <td class="line" data-tooltip>166</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>14</td>
+                          <td class="hits" data-tooltip>15</td>
                           <td class="source">    return error</td>
                           
                         </tr>            <tr id="lib/api.js__167" class="hit">
@@ -13398,43 +13447,43 @@
                           <td class="line" data-tooltip>171</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.fail &#x3D; function (code, args) {</td>
+                          <td class="source">exports.fail &#x3D; function (...args) {</td>
                           
                         </tr>            <tr id="lib/api.js__172" class="hit">
                           <td class="line" data-tooltip>172</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var error &#x3D; this.error(code, args)</td>
+                          <td class="source">  if (args.length &#x3D;&#x3D;&#x3D; 2) {</td>
                           
                         </tr>            <tr id="lib/api.js__173" class="hit">
                           <td class="line" data-tooltip>173</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">    return mustFail(this, ...args)</td>
                           
-                        </tr>            <tr id="lib/api.js__174" class="chunks">
+                        </tr>            <tr id="lib/api.js__174" class="hit">
                           <td class="line" data-tooltip>174</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  if (</div><div class="miss true" data-tooltip>args</div><div> &amp;&amp; </div><div class="miss false" data-tooltip>false &#x3D;&#x3D;&#x3D; args.throw$</div><div>) {</div></td>
+                          <td class="source">  }</td>
                           
-                        </tr>            <tr id="lib/api.js__175" class="miss">
+                        </tr>            <tr id="lib/api.js__175" class="hit">
                           <td class="line" data-tooltip>175</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>    return error</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__176" class="hit">
                           <td class="line" data-tooltip>176</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">  if (args.length &#x3D;&#x3D;&#x3D; 3) {</td>
                           
                         </tr>            <tr id="lib/api.js__177" class="hit">
                           <td class="line" data-tooltip>177</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">    throw error</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    return failIf(this, ...args)</td>
                           
                         </tr>            <tr id="lib/api.js__178" class="hit">
                           <td class="line" data-tooltip>178</td>
@@ -13446,85 +13495,85 @@
                           <td class="line" data-tooltip>179</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__180" class="hit">
                           <td class="line" data-tooltip>180</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">  throw this.util.error(&#x27;fail_wrong_number_of_args&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__181" class="hit">
                           <td class="line" data-tooltip>181</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.inward &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    { num_args: args.length })</td>
                           
                         </tr>            <tr id="lib/api.js__182" class="hit">
                           <td class="line" data-tooltip>182</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // TODO: norma should support f/x where x &#x3D; # args</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__183" class="hit">
                           <td class="line" data-tooltip>183</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var args &#x3D; Norma(&#x27;inward:f&#x27;, arguments)</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__184" class="hit">
                           <td class="line" data-tooltip>184</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  this.private$.inward.add(args.inward)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  function mustFail(self, code, args) {</td>
                           
                         </tr>            <tr id="lib/api.js__185" class="hit">
                           <td class="line" data-tooltip>185</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">    const error &#x3D; self.error(code, args)</td>
                           
                         </tr>            <tr id="lib/api.js__186" class="hit">
                           <td class="line" data-tooltip>186</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__187" class="hit">
+                        </tr>            <tr id="lib/api.js__187" class="chunks">
                           <td class="line" data-tooltip>187</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>    if (</div><div class="miss true" data-tooltip>args</div><div> &amp;&amp; </div><div class="miss false" data-tooltip>false &#x3D;&#x3D;&#x3D; args.throw$</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__188" class="hit">
+                        </tr>            <tr id="lib/api.js__188" class="miss">
                           <td class="line" data-tooltip>188</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.outward &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source" data-tooltip>      return error</td>
                           
                         </tr>            <tr id="lib/api.js__189" class="hit">
                           <td class="line" data-tooltip>189</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var args &#x3D; Norma(&#x27;outward:f&#x27;, arguments)</td>
+                          <td class="source">    } else {</td>
                           
                         </tr>            <tr id="lib/api.js__190" class="hit">
                           <td class="line" data-tooltip>190</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  this.private$.outward.add(args.outward)</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">      throw error</td>
                           
                         </tr>            <tr id="lib/api.js__191" class="hit">
                           <td class="line" data-tooltip>191</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__192" class="hit">
                           <td class="line" data-tooltip>192</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__193" class="hit">
                           <td class="line" data-tooltip>193</td>
@@ -13535,218 +13584,218 @@
                         </tr>            <tr id="lib/api.js__194" class="hit">
                           <td class="line" data-tooltip>194</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.prior &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  function failIf(self, cond, code, args) {</td>
                           
                         </tr>            <tr id="lib/api.js__195" class="hit">
                           <td class="line" data-tooltip>195</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  if (null &#x3D;&#x3D; this.private$.act) {</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    Assert(typeof cond &#x3D;&#x3D;&#x3D; &#x27;boolean&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__196" class="hit">
                           <td class="line" data-tooltip>196</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // TODO: should be a top level api method: seneca.fail</td>
+                          <td class="source">      &#x27;Expected the &#x60;cond&#x60; param to be a boolean.&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__197" class="hit">
                           <td class="line" data-tooltip>197</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    throw this.util.error(&#x27;no_prior_action&#x27;, { args: arguments })</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__198" class="hit">
                           <td class="line" data-tooltip>198</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    if (!cond) {</td>
                           
                         </tr>            <tr id="lib/api.js__199" class="hit">
                           <td class="line" data-tooltip>199</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      return</td>
                           
                         </tr>            <tr id="lib/api.js__200" class="hit">
                           <td class="line" data-tooltip>200</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // Get definition of prior action</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__201" class="hit">
                           <td class="line" data-tooltip>201</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  var priordef &#x3D; this.private$.act.def.priordef</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__202" class="hit">
                           <td class="line" data-tooltip>202</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    const error &#x3D; self.error(code, args)</td>
                           
                         </tr>            <tr id="lib/api.js__203" class="hit">
                           <td class="line" data-tooltip>203</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  var spec &#x3D; Common.build_message(this, arguments, &#x27;reply:f?&#x27;, this.fixedargs)</td>
-                          
-                        </tr>            <tr id="lib/api.js__204" class="hit">
-                          <td class="line" data-tooltip>204</td>
-                          <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__205" class="hit">
+                        </tr>            <tr id="lib/api.js__204" class="chunks">
+                          <td class="line" data-tooltip>204</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>    if (</div><div class="miss true" data-tooltip>args</div><div> &amp;&amp; </div><div class="miss false" data-tooltip>false &#x3D;&#x3D;&#x3D; args.throw$</div><div>) {</div></td>
+                          
+                        </tr>            <tr id="lib/api.js__205" class="miss">
                           <td class="line" data-tooltip>205</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // TODO: clean sufficiently so that seneca.util.clean not needed</td>
+                          <td class="source" data-tooltip>      return error</td>
                           
                         </tr>            <tr id="lib/api.js__206" class="hit">
                           <td class="line" data-tooltip>206</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  var msg &#x3D; spec.msg</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    } else {</td>
                           
                         </tr>            <tr id="lib/api.js__207" class="hit">
                           <td class="line" data-tooltip>207</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  var reply &#x3D; spec.reply</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      throw error</td>
                           
                         </tr>            <tr id="lib/api.js__208" class="hit">
                           <td class="line" data-tooltip>208</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__209" class="hit">
                           <td class="line" data-tooltip>209</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  if (priordef) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__210" class="hit">
                           <td class="line" data-tooltip>210</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>103</td>
-                          <td class="source">    msg.prior$ &#x3D; priordef.id</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__211" class="hit">
                           <td class="line" data-tooltip>211</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>103</td>
-                          <td class="source">    this.act(msg, reply)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__212" class="hit">
                           <td class="line" data-tooltip>212</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.inward &#x3D; function () {</td>
                           
-                        </tr>            <tr id="lib/api.js__213" class="chunks">
+                        </tr>            <tr id="lib/api.js__213" class="hit">
                           <td class="line" data-tooltip>213</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var meta &#x3D; </div><div class="miss false" data-tooltip>msg.meta$</div><div> || {}</div></td>
+                          <td class="source">  // TODO: norma should support f/x where x &#x3D; # args</td>
                           
-                        </tr>            <tr id="lib/api.js__214" class="chunks">
+                        </tr>            <tr id="lib/api.js__214" class="hit">
                           <td class="line" data-tooltip>214</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var out &#x3D; msg.default$ || </div><div class="miss false" data-tooltip>meta.dflt</div><div> || null</div></td>
+                          <td class="source">  var args &#x3D; Norma(&#x27;inward:f&#x27;, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__215" class="hit">
                           <td class="line" data-tooltip>215</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>25</td>
-                          <td class="source">    out &#x3D; null &#x3D;&#x3D; out ? out : Object.assign({}, out)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  this.private$.inward.add(args.inward)</td>
                           
                         </tr>            <tr id="lib/api.js__216" class="hit">
                           <td class="line" data-tooltip>216</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>25</td>
-                          <td class="source">    return reply.call(this, null, out, meta)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__217" class="hit">
                           <td class="line" data-tooltip>217</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__218" class="hit">
                           <td class="line" data-tooltip>218</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__219" class="hit">
                           <td class="line" data-tooltip>219</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.outward &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__220" class="hit">
                           <td class="line" data-tooltip>220</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// TODO: rename fixedargs</td>
+                          <td class="source">  var args &#x3D; Norma(&#x27;outward:f&#x27;, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__221" class="hit">
                           <td class="line" data-tooltip>221</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.delegate &#x3D; function (fixedargs, fixedmeta) {</td>
+                          <td class="source">  this.private$.outward.add(args.outward)</td>
                           
                         </tr>            <tr id="lib/api.js__222" class="hit">
                           <td class="line" data-tooltip>222</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var self &#x3D; this</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__223" class="hit">
                           <td class="line" data-tooltip>223</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var root &#x3D; this.root</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__224" class="hit">
                           <td class="line" data-tooltip>224</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var opts &#x3D; this.options()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__225" class="hit">
                           <td class="line" data-tooltip>225</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.prior &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__226" class="hit">
                           <td class="line" data-tooltip>226</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  fixedargs &#x3D; fixedargs || {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  if (null &#x3D;&#x3D; this.private$.act) {</td>
                           
                         </tr>            <tr id="lib/api.js__227" class="hit">
                           <td class="line" data-tooltip>227</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  fixedmeta &#x3D; fixedmeta || {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    // TODO: should be a top level api method: seneca.fail</td>
                           
                         </tr>            <tr id="lib/api.js__228" class="hit">
                           <td class="line" data-tooltip>228</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    throw this.util.error(&#x27;no_prior_action&#x27;, { args: arguments })</td>
                           
                         </tr>            <tr id="lib/api.js__229" class="hit">
                           <td class="line" data-tooltip>229</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var delegate &#x3D; Object.create(self)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__230" class="hit">
                           <td class="line" data-tooltip>230</td>
@@ -13757,26 +13806,26 @@
                         </tr>            <tr id="lib/api.js__231" class="hit">
                           <td class="line" data-tooltip>231</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  delegate.private$ &#x3D; Object.create(self.private$)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // Get definition of prior action</td>
                           
                         </tr>            <tr id="lib/api.js__232" class="hit">
                           <td class="line" data-tooltip>232</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  var priordef &#x3D; this.private$.act.def.priordef</td>
                           
                         </tr>            <tr id="lib/api.js__233" class="hit">
                           <td class="line" data-tooltip>233</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  delegate.did &#x3D;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__234" class="hit">
                           <td class="line" data-tooltip>234</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    (delegate.did ? delegate.did + &#x27;/&#x27; : &#x27;&#x27;) + self.private$.didnid()</td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  var spec &#x3D; Common.build_message(this, arguments, &#x27;reply:f?&#x27;, this.fixedargs)</td>
                           
                         </tr>            <tr id="lib/api.js__235" class="hit">
                           <td class="line" data-tooltip>235</td>
@@ -13788,19 +13837,19 @@
                           <td class="line" data-tooltip>236</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  function delegate_log() {</td>
+                          <td class="source">  // TODO: clean sufficiently so that seneca.util.clean not needed</td>
                           
                         </tr>            <tr id="lib/api.js__237" class="hit">
                           <td class="line" data-tooltip>237</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11962</td>
-                          <td class="source">    return root.log.apply(delegate, arguments)</td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  var msg &#x3D; spec.msg</td>
                           
                         </tr>            <tr id="lib/api.js__238" class="hit">
                           <td class="line" data-tooltip>238</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  var reply &#x3D; spec.reply</td>
                           
                         </tr>            <tr id="lib/api.js__239" class="hit">
                           <td class="line" data-tooltip>239</td>
@@ -13811,290 +13860,290 @@
                         </tr>            <tr id="lib/api.js__240" class="hit">
                           <td class="line" data-tooltip>240</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  Object.assign(delegate_log, root.log)</td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  if (priordef) {</td>
                           
                         </tr>            <tr id="lib/api.js__241" class="hit">
                           <td class="line" data-tooltip>241</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  delegate_log.self &#x3D; () &#x3D;&gt; delegate</td>
+                          <td class="hits" data-tooltip>103</td>
+                          <td class="source">    msg.prior$ &#x3D; priordef.id</td>
                           
                         </tr>            <tr id="lib/api.js__242" class="hit">
                           <td class="line" data-tooltip>242</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>103</td>
+                          <td class="source">    this.act(msg, reply)</td>
                           
                         </tr>            <tr id="lib/api.js__243" class="hit">
                           <td class="line" data-tooltip>243</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var strdesc</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  } else {</td>
                           
-                        </tr>            <tr id="lib/api.js__244" class="hit">
+                        </tr>            <tr id="lib/api.js__244" class="chunks">
                           <td class="line" data-tooltip>244</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>    var meta &#x3D; </div><div class="miss false" data-tooltip>msg.meta$</div><div> || {}</div></td>
                           
-                        </tr>            <tr id="lib/api.js__245" class="hit">
+                        </tr>            <tr id="lib/api.js__245" class="chunks">
                           <td class="line" data-tooltip>245</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  function delegate_toString() {</td>
+                          <td class="source"><div>    var out &#x3D; msg.default$ || </div><div class="miss false" data-tooltip>meta.dflt</div><div> || null</div></td>
                           
                         </tr>            <tr id="lib/api.js__246" class="hit">
                           <td class="line" data-tooltip>246</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>94</td>
-                          <td class="source">    if (strdesc) return strdesc</td>
+                          <td class="hits" data-tooltip>25</td>
+                          <td class="source">    out &#x3D; null &#x3D;&#x3D; out ? out : Object.assign({}, out)</td>
                           
                         </tr>            <tr id="lib/api.js__247" class="hit">
                           <td class="line" data-tooltip>247</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">    var vfa &#x3D; {}</td>
+                          <td class="hits" data-tooltip>25</td>
+                          <td class="source">    return reply.call(this, null, out, meta)</td>
                           
                         </tr>            <tr id="lib/api.js__248" class="hit">
                           <td class="line" data-tooltip>248</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">    Object.keys(fixedargs).forEach((k) &#x3D;&gt; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__249" class="hit">
                           <td class="line" data-tooltip>249</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      var v &#x3D; fixedargs[k]</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__250" class="hit">
                           <td class="line" data-tooltip>250</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>193</td>
-                          <td class="source">      if (~k.indexOf(&#x27;$&#x27;)) return</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__251" class="hit">
                           <td class="line" data-tooltip>251</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      vfa[k] &#x3D; v</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">// TODO: rename fixedargs</td>
                           
                         </tr>            <tr id="lib/api.js__252" class="hit">
                           <td class="line" data-tooltip>252</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.delegate &#x3D; function (fixedargs, fixedmeta) {</td>
                           
                         </tr>            <tr id="lib/api.js__253" class="hit">
                           <td class="line" data-tooltip>253</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__254" class="hit">
                           <td class="line" data-tooltip>254</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">    strdesc &#x3D;</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var root &#x3D; this.root</td>
                           
                         </tr>            <tr id="lib/api.js__255" class="hit">
                           <td class="line" data-tooltip>255</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      self.toString() +</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var opts &#x3D; this.options()</td>
                           
                         </tr>            <tr id="lib/api.js__256" class="hit">
                           <td class="line" data-tooltip>256</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      (Object.keys(vfa).length ? &#x27;/&#x27; + Jsonic.stringify(vfa) : &#x27;&#x27;)</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__257" class="hit">
                           <td class="line" data-tooltip>257</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  fixedargs &#x3D; fixedargs || {}</td>
                           
                         </tr>            <tr id="lib/api.js__258" class="hit">
                           <td class="line" data-tooltip>258</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">    return strdesc</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  fixedmeta &#x3D; fixedmeta || {}</td>
                           
                         </tr>            <tr id="lib/api.js__259" class="hit">
                           <td class="line" data-tooltip>259</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__260" class="hit">
                           <td class="line" data-tooltip>260</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var delegate &#x3D; Object.create(self)</td>
                           
-                        </tr>            <tr id="lib/api.js__261" class="chunks">
+                        </tr>            <tr id="lib/api.js__261" class="hit">
                           <td class="line" data-tooltip>261</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  var delegate_fixedargs &#x3D; </div><div class="miss true" data-tooltip>opts.strict.fixedargs</div></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__262" class="hit">
                           <td class="line" data-tooltip>262</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    ? Object.assign({}, fixedargs, self.fixedargs)</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  delegate.private$ &#x3D; Object.create(self.private$)</td>
                           
-                        </tr>            <tr id="lib/api.js__263" class="chunks">
+                        </tr>            <tr id="lib/api.js__263" class="hit">
                           <td class="line" data-tooltip>263</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    : </div><div class="miss never" data-tooltip>Object.assign({}, self.fixedargs, fixedargs)</div></td>
-                          
-                        </tr>            <tr id="lib/api.js__264" class="hit">
-                          <td class="line" data-tooltip>264</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__265" class="chunks">
+                        </tr>            <tr id="lib/api.js__264" class="hit">
+                          <td class="line" data-tooltip>264</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  delegate.did &#x3D;</td>
+                          
+                        </tr>            <tr id="lib/api.js__265" class="hit">
                           <td class="line" data-tooltip>265</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  var delegate_fixedmeta &#x3D; </div><div class="miss false" data-tooltip>opts.strict.fixedmeta</div></td>
+                          <td class="source">    (delegate.did ? delegate.did + &#x27;/&#x27; : &#x27;&#x27;) + self.private$.didnid()</td>
                           
-                        </tr>            <tr id="lib/api.js__266" class="chunks">
+                        </tr>            <tr id="lib/api.js__266" class="hit">
                           <td class="line" data-tooltip>266</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    ? </div><div class="miss never" data-tooltip>Object.assign({}, fixedmeta, self.fixedmeta)</div></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__267" class="hit">
                           <td class="line" data-tooltip>267</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    : Object.assign({}, self.fixedmeta, fixedmeta)</td>
+                          <td class="source">  function delegate_log() {</td>
                           
                         </tr>            <tr id="lib/api.js__268" class="hit">
                           <td class="line" data-tooltip>268</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>11974</td>
+                          <td class="source">    return root.log.apply(delegate, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__269" class="hit">
                           <td class="line" data-tooltip>269</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  function delegate_delegate(further_fixedargs, further_fixedmeta) {</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__270" class="hit">
                           <td class="line" data-tooltip>270</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2131</td>
-                          <td class="source">    var args &#x3D; Object.assign({}, delegate.fixedargs, further_fixedargs || {})</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__271" class="hit">
                           <td class="line" data-tooltip>271</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2131</td>
-                          <td class="source">    var meta &#x3D; Object.assign({}, delegate.fixedmeta, further_fixedmeta || {})</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  Object.assign(delegate_log, root.log)</td>
                           
                         </tr>            <tr id="lib/api.js__272" class="hit">
                           <td class="line" data-tooltip>272</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2131</td>
-                          <td class="source">    return self.delegate.call(this, args, meta)</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  delegate_log.self &#x3D; () &#x3D;&gt; delegate</td>
                           
                         </tr>            <tr id="lib/api.js__273" class="hit">
                           <td class="line" data-tooltip>273</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__274" class="hit">
                           <td class="line" data-tooltip>274</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var strdesc</td>
                           
                         </tr>            <tr id="lib/api.js__275" class="hit">
                           <td class="line" data-tooltip>275</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // Somewhere to put contextual data for this delegate.</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__276" class="hit">
                           <td class="line" data-tooltip>276</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // For example, data for individual web requests.</td>
+                          <td class="source">  function delegate_toString() {</td>
                           
                         </tr>            <tr id="lib/api.js__277" class="hit">
                           <td class="line" data-tooltip>277</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var delegate_context &#x3D; Object.assign({}, self.context)</td>
+                          <td class="hits" data-tooltip>98</td>
+                          <td class="source">    if (strdesc) return strdesc</td>
                           
                         </tr>            <tr id="lib/api.js__278" class="hit">
                           <td class="line" data-tooltip>278</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>82</td>
+                          <td class="source">    var vfa &#x3D; {}</td>
                           
                         </tr>            <tr id="lib/api.js__279" class="hit">
                           <td class="line" data-tooltip>279</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // Prevents incorrect prototype properties in mocha test contexts</td>
+                          <td class="hits" data-tooltip>82</td>
+                          <td class="source">    Object.keys(fixedargs).forEach((k) &#x3D;&gt; {</td>
                           
                         </tr>            <tr id="lib/api.js__280" class="hit">
                           <td class="line" data-tooltip>280</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  Object.defineProperties(delegate, {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      var v &#x3D; fixedargs[k]</td>
                           
                         </tr>            <tr id="lib/api.js__281" class="hit">
                           <td class="line" data-tooltip>281</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    log: { value: delegate_log, writable: true },</td>
+                          <td class="hits" data-tooltip>209</td>
+                          <td class="source">      if (~k.indexOf(&#x27;$&#x27;)) return</td>
                           
                         </tr>            <tr id="lib/api.js__282" class="hit">
                           <td class="line" data-tooltip>282</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    toString: { value: delegate_toString, writable: true },</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      vfa[k] &#x3D; v</td>
                           
                         </tr>            <tr id="lib/api.js__283" class="hit">
                           <td class="line" data-tooltip>283</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    fixedargs: { value: delegate_fixedargs, writable: true },</td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__284" class="hit">
                           <td class="line" data-tooltip>284</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    fixedmeta: { value: delegate_fixedmeta, writable: true },</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__285" class="hit">
                           <td class="line" data-tooltip>285</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    delegate: { value: delegate_delegate, writable: true },</td>
+                          <td class="hits" data-tooltip>82</td>
+                          <td class="source">    strdesc &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__286" class="hit">
                           <td class="line" data-tooltip>286</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    context: { value: delegate_context, writable: true },</td>
+                          <td class="source">      self.toString() +</td>
                           
                         </tr>            <tr id="lib/api.js__287" class="hit">
                           <td class="line" data-tooltip>287</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  })</td>
+                          <td class="source">      (Object.keys(vfa).length ? &#x27;/&#x27; + Jsonic.stringify(vfa) : &#x27;&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__288" class="hit">
                           <td class="line" data-tooltip>288</td>
@@ -14105,14 +14154,14 @@
                         </tr>            <tr id="lib/api.js__289" class="hit">
                           <td class="line" data-tooltip>289</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  return delegate</td>
+                          <td class="hits" data-tooltip>82</td>
+                          <td class="source">    return strdesc</td>
                           
                         </tr>            <tr id="lib/api.js__290" class="hit">
                           <td class="line" data-tooltip>290</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__291" class="hit">
                           <td class="line" data-tooltip>291</td>
@@ -14120,47 +14169,47 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__292" class="hit">
+                        </tr>            <tr id="lib/api.js__292" class="chunks">
                           <td class="line" data-tooltip>292</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.depends &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>  var delegate_fixedargs &#x3D; </div><div class="miss true" data-tooltip>opts.strict.fixedargs</div></td>
                           
                         </tr>            <tr id="lib/api.js__293" class="hit">
                           <td class="line" data-tooltip>293</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var self &#x3D; this</td>
+                          <td class="source">    ? Object.assign({}, fixedargs, self.fixedargs)</td>
                           
-                        </tr>            <tr id="lib/api.js__294" class="hit">
+                        </tr>            <tr id="lib/api.js__294" class="chunks">
                           <td class="line" data-tooltip>294</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  var private$ &#x3D; this.private$</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>    : </div><div class="miss never" data-tooltip>Object.assign({}, self.fixedargs, fixedargs)</div></td>
                           
                         </tr>            <tr id="lib/api.js__295" class="hit">
                           <td class="line" data-tooltip>295</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  var error &#x3D; this.util.error</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__296" class="hit">
+                        </tr>            <tr id="lib/api.js__296" class="chunks">
                           <td class="line" data-tooltip>296</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  var args &#x3D; Norma(&#x27;{pluginname:s deps:a? moredeps:s*}&#x27;, arguments)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>  var delegate_fixedmeta &#x3D; </div><div class="miss false" data-tooltip>opts.strict.fixedmeta</div></td>
                           
-                        </tr>            <tr id="lib/api.js__297" class="hit">
+                        </tr>            <tr id="lib/api.js__297" class="chunks">
                           <td class="line" data-tooltip>297</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>    ? </div><div class="miss never" data-tooltip>Object.assign({}, fixedmeta, self.fixedmeta)</div></td>
                           
                         </tr>            <tr id="lib/api.js__298" class="hit">
                           <td class="line" data-tooltip>298</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  var deps &#x3D; args.deps || args.moredeps || []</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    : Object.assign({}, self.fixedmeta, fixedmeta)</td>
                           
                         </tr>            <tr id="lib/api.js__299" class="hit">
                           <td class="line" data-tooltip>299</td>
@@ -14171,170 +14220,170 @@
                         </tr>            <tr id="lib/api.js__300" class="hit">
                           <td class="line" data-tooltip>300</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  for (var i &#x3D; 0; i &lt; deps.length; i++) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  function delegate_delegate(further_fixedargs, further_fixedmeta) {</td>
                           
                         </tr>            <tr id="lib/api.js__301" class="hit">
                           <td class="line" data-tooltip>301</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
-                          <td class="source">    var depname &#x3D; deps[i]</td>
+                          <td class="hits" data-tooltip>2131</td>
+                          <td class="source">    var args &#x3D; Object.assign({}, delegate.fixedargs, further_fixedargs || {})</td>
                           
                         </tr>            <tr id="lib/api.js__302" class="hit">
                           <td class="line" data-tooltip>302</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>2131</td>
+                          <td class="source">    var meta &#x3D; Object.assign({}, delegate.fixedmeta, further_fixedmeta || {})</td>
                           
                         </tr>            <tr id="lib/api.js__303" class="hit">
                           <td class="line" data-tooltip>303</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
-                          <td class="source">    if (</td>
+                          <td class="hits" data-tooltip>2131</td>
+                          <td class="source">    return self.delegate.call(this, args, meta)</td>
                           
                         </tr>            <tr id="lib/api.js__304" class="hit">
                           <td class="line" data-tooltip>304</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      !private$.plugin_order.byname.includes(depname) &amp;&amp;</td>
+                          <td class="source">  }</td>
                           
-                        </tr>            <tr id="lib/api.js__305" class="chunks">
+                        </tr>            <tr id="lib/api.js__305" class="hit">
                           <td class="line" data-tooltip>305</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      </div><div class="miss true" data-tooltip>!private$.plugin_order.byname.includes(&#x27;seneca-&#x27; + depname)</div></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__306" class="hit">
                           <td class="line" data-tooltip>306</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    ) {</td>
+                          <td class="source">  // Somewhere to put contextual data for this delegate.</td>
                           
                         </tr>            <tr id="lib/api.js__307" class="hit">
                           <td class="line" data-tooltip>307</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">      self.die(</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // For example, data for individual web requests.</td>
                           
                         </tr>            <tr id="lib/api.js__308" class="hit">
                           <td class="line" data-tooltip>308</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        error(&#x27;plugin_required&#x27;, {</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var delegate_context &#x3D; Object.assign({}, self.context)</td>
                           
                         </tr>            <tr id="lib/api.js__309" class="hit">
                           <td class="line" data-tooltip>309</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          name: args.pluginname,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__310" class="hit">
                           <td class="line" data-tooltip>310</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          dependency: depname,</td>
+                          <td class="source">  // Prevents incorrect prototype properties in mocha test contexts</td>
                           
                         </tr>            <tr id="lib/api.js__311" class="hit">
                           <td class="line" data-tooltip>311</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        })</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  Object.defineProperties(delegate, {</td>
                           
                         </tr>            <tr id="lib/api.js__312" class="hit">
                           <td class="line" data-tooltip>312</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      )</td>
+                          <td class="source">    log: { value: delegate_log, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__313" class="hit">
                           <td class="line" data-tooltip>313</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">      break</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    toString: { value: delegate_toString, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__314" class="hit">
                           <td class="line" data-tooltip>314</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">    fixedargs: { value: delegate_fixedargs, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__315" class="hit">
                           <td class="line" data-tooltip>315</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    fixedmeta: { value: delegate_fixedmeta, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__316" class="hit">
                           <td class="line" data-tooltip>316</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    delegate: { value: delegate_delegate, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__317" class="hit">
                           <td class="line" data-tooltip>317</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    context: { value: delegate_context, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__318" class="hit">
                           <td class="line" data-tooltip>318</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.export &#x3D; function (key) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  })</td>
                           
                         </tr>            <tr id="lib/api.js__319" class="hit">
                           <td class="line" data-tooltip>319</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var self &#x3D; this</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__320" class="hit">
                           <td class="line" data-tooltip>320</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>76</td>
-                          <td class="source">  var private$ &#x3D; this.private$</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  return delegate</td>
                           
                         </tr>            <tr id="lib/api.js__321" class="hit">
                           <td class="line" data-tooltip>321</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>76</td>
-                          <td class="source">  var error &#x3D; this.util.error</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__322" class="hit">
                           <td class="line" data-tooltip>322</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>76</td>
-                          <td class="source">  var opts &#x3D; this.options()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__323" class="hit">
                           <td class="line" data-tooltip>323</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.depends &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__324" class="hit">
                           <td class="line" data-tooltip>324</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // Legacy aliases</td>
+                          <td class="source">  var self &#x3D; this</td>
                           
-                        </tr>            <tr id="lib/api.js__325" class="chunks">
+                        </tr>            <tr id="lib/api.js__325" class="hit">
                           <td class="line" data-tooltip>325</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  if (</div><div class="miss false" data-tooltip>key &#x3D;&#x3D;&#x3D; &#x27;util&#x27;</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  var private$ &#x3D; this.private$</td>
                           
-                        </tr>            <tr id="lib/api.js__326" class="miss">
+                        </tr>            <tr id="lib/api.js__326" class="hit">
                           <td class="line" data-tooltip>326</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>    key &#x3D; &#x27;basic&#x27;</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  var error &#x3D; this.util.error</td>
                           
                         </tr>            <tr id="lib/api.js__327" class="hit">
                           <td class="line" data-tooltip>327</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  var args &#x3D; Norma(&#x27;{pluginname:s deps:a? moredeps:s*}&#x27;, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__328" class="hit">
                           <td class="line" data-tooltip>328</td>
@@ -14345,8 +14394,8 @@
                         </tr>            <tr id="lib/api.js__329" class="hit">
                           <td class="line" data-tooltip>329</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>76</td>
-                          <td class="source">  var exportval &#x3D; private$.exports[key]</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  var deps &#x3D; args.deps || args.moredeps || []</td>
                           
                         </tr>            <tr id="lib/api.js__330" class="hit">
                           <td class="line" data-tooltip>330</td>
@@ -14354,95 +14403,95 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__331" class="chunks">
+                        </tr>            <tr id="lib/api.js__331" class="hit">
                           <td class="line" data-tooltip>331</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  if (!exportval &amp;&amp; </div><div class="miss true" data-tooltip>opts.strict.exports</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  for (var i &#x3D; 0; i &lt; deps.length; i++) {</td>
                           
                         </tr>            <tr id="lib/api.js__332" class="hit">
                           <td class="line" data-tooltip>332</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    return self.die(error(&#x27;export_not_found&#x27;, { key: key }))</td>
+                          <td class="hits" data-tooltip>9</td>
+                          <td class="source">    var depname &#x3D; deps[i]</td>
                           
                         </tr>            <tr id="lib/api.js__333" class="hit">
                           <td class="line" data-tooltip>333</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__334" class="hit">
                           <td class="line" data-tooltip>334</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>9</td>
+                          <td class="source">    if (</td>
                           
                         </tr>            <tr id="lib/api.js__335" class="hit">
                           <td class="line" data-tooltip>335</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>75</td>
-                          <td class="source">  return exportval</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      !private$.plugin_order.byname.includes(depname) &amp;&amp;</td>
                           
-                        </tr>            <tr id="lib/api.js__336" class="hit">
+                        </tr>            <tr id="lib/api.js__336" class="chunks">
                           <td class="line" data-tooltip>336</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"><div>      </div><div class="miss true" data-tooltip>!private$.plugin_order.byname.includes(&#x27;seneca-&#x27; + depname)</div></td>
                           
                         </tr>            <tr id="lib/api.js__337" class="hit">
                           <td class="line" data-tooltip>337</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    ) {</td>
                           
                         </tr>            <tr id="lib/api.js__338" class="hit">
                           <td class="line" data-tooltip>338</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.quiet &#x3D; function (flags) {</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">      self.die(</td>
                           
                         </tr>            <tr id="lib/api.js__339" class="hit">
                           <td class="line" data-tooltip>339</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  flags &#x3D; flags || {}</td>
+                          <td class="source">        error(&#x27;plugin_required&#x27;, {</td>
                           
                         </tr>            <tr id="lib/api.js__340" class="hit">
                           <td class="line" data-tooltip>340</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">          name: args.pluginname,</td>
                           
                         </tr>            <tr id="lib/api.js__341" class="hit">
                           <td class="line" data-tooltip>341</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>39</td>
-                          <td class="source">  var quiet_opts &#x3D; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">          dependency: depname,</td>
                           
                         </tr>            <tr id="lib/api.js__342" class="hit">
                           <td class="line" data-tooltip>342</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    test: false,</td>
+                          <td class="source">        })</td>
                           
                         </tr>            <tr id="lib/api.js__343" class="hit">
                           <td class="line" data-tooltip>343</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    quiet: true,</td>
+                          <td class="source">      )</td>
                           
                         </tr>            <tr id="lib/api.js__344" class="hit">
                           <td class="line" data-tooltip>344</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    log: &#x27;none&#x27;,</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">      break</td>
                           
                         </tr>            <tr id="lib/api.js__345" class="hit">
                           <td class="line" data-tooltip>345</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    reload$: true,</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__346" class="hit">
                           <td class="line" data-tooltip>346</td>
@@ -14454,67 +14503,67 @@
                           <td class="line" data-tooltip>347</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__348" class="hit">
                           <td class="line" data-tooltip>348</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>39</td>
-                          <td class="source">  var opts &#x3D; this.options(quiet_opts)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__349" class="hit">
                           <td class="line" data-tooltip>349</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.export &#x3D; function (key) {</td>
                           
                         </tr>            <tr id="lib/api.js__350" class="hit">
                           <td class="line" data-tooltip>350</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // An override from env or args is possible.</td>
+                          <td class="source">  var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__351" class="hit">
                           <td class="line" data-tooltip>351</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // Only flip to test mode if called from test() method</td>
+                          <td class="hits" data-tooltip>76</td>
+                          <td class="source">  var private$ &#x3D; this.private$</td>
                           
-                        </tr>            <tr id="lib/api.js__352" class="chunks">
+                        </tr>            <tr id="lib/api.js__352" class="hit">
                           <td class="line" data-tooltip>352</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  if (opts.test &amp;&amp; </div><div class="miss true" data-tooltip>&#x27;test&#x27; !&#x3D;&#x3D; flags.from</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>76</td>
+                          <td class="source">  var error &#x3D; this.util.error</td>
                           
                         </tr>            <tr id="lib/api.js__353" class="hit">
                           <td class="line" data-tooltip>353</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    return this.test()</td>
+                          <td class="hits" data-tooltip>76</td>
+                          <td class="source">  var opts &#x3D; this.options()</td>
                           
                         </tr>            <tr id="lib/api.js__354" class="hit">
                           <td class="line" data-tooltip>354</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__355" class="hit">
                           <td class="line" data-tooltip>355</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>37</td>
-                          <td class="source">    this.private$.logging.build_log(this)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // Legacy aliases</td>
                           
-                        </tr>            <tr id="lib/api.js__356" class="hit">
+                        </tr>            <tr id="lib/api.js__356" class="chunks">
                           <td class="line" data-tooltip>356</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>  if (</div><div class="miss false" data-tooltip>key &#x3D;&#x3D;&#x3D; &#x27;util&#x27;</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__357" class="hit">
+                        </tr>            <tr id="lib/api.js__357" class="miss">
                           <td class="line" data-tooltip>357</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>37</td>
-                          <td class="source">    return this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source" data-tooltip>    key &#x3D; &#x27;basic&#x27;</td>
                           
                         </tr>            <tr id="lib/api.js__358" class="hit">
                           <td class="line" data-tooltip>358</td>
@@ -14526,169 +14575,169 @@
                           <td class="line" data-tooltip>359</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__360" class="hit">
                           <td class="line" data-tooltip>360</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>76</td>
+                          <td class="source">  var exportval &#x3D; private$.exports[key]</td>
                           
                         </tr>            <tr id="lib/api.js__361" class="hit">
                           <td class="line" data-tooltip>361</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.test &#x3D; function (errhandler, logspec) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__362" class="hit">
+                        </tr>            <tr id="lib/api.js__362" class="chunks">
                           <td class="line" data-tooltip>362</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var opts &#x3D; this.options()</td>
+                          <td class="source"><div>  if (!exportval &amp;&amp; </div><div class="miss true" data-tooltip>opts.strict.exports</div><div>) {</div></td>
                           
                         </tr>            <tr id="lib/api.js__363" class="hit">
                           <td class="line" data-tooltip>363</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    return self.die(error(&#x27;export_not_found&#x27;, { key: key }))</td>
                           
                         </tr>            <tr id="lib/api.js__364" class="hit">
                           <td class="line" data-tooltip>364</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  if (&#x27;-&#x27; !&#x3D; opts.tag) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__365" class="hit">
                           <td class="line" data-tooltip>365</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
-                          <td class="source">    this.root.id &#x3D;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__366" class="hit">
                           <td class="line" data-tooltip>366</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      null &#x3D;&#x3D; opts.id$</td>
+                          <td class="hits" data-tooltip>75</td>
+                          <td class="source">  return exportval</td>
                           
                         </tr>            <tr id="lib/api.js__367" class="hit">
                           <td class="line" data-tooltip>367</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        ? this.private$.actnid().substring(0, 4) + &#x27;/&#x27; + opts.tag</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__368" class="hit">
                           <td class="line" data-tooltip>368</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        : &#x27;&#x27; + opts.id$</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__369" class="hit">
                           <td class="line" data-tooltip>369</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.quiet &#x3D; function (flags) {</td>
                           
                         </tr>            <tr id="lib/api.js__370" class="hit">
                           <td class="line" data-tooltip>370</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  flags &#x3D; flags || {}</td>
                           
                         </tr>            <tr id="lib/api.js__371" class="hit">
                           <td class="line" data-tooltip>371</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  if (&#x27;function&#x27; !&#x3D;&#x3D; typeof errhandler &amp;&amp; null !&#x3D;&#x3D; errhandler) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__372" class="hit">
                           <td class="line" data-tooltip>372</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>55</td>
-                          <td class="source">    logspec &#x3D; errhandler</td>
+                          <td class="hits" data-tooltip>39</td>
+                          <td class="source">  var quiet_opts &#x3D; {</td>
                           
                         </tr>            <tr id="lib/api.js__373" class="hit">
                           <td class="line" data-tooltip>373</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>55</td>
-                          <td class="source">    errhandler &#x3D; null</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    test: false,</td>
                           
                         </tr>            <tr id="lib/api.js__374" class="hit">
                           <td class="line" data-tooltip>374</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    quiet: true,</td>
                           
                         </tr>            <tr id="lib/api.js__375" class="hit">
                           <td class="line" data-tooltip>375</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    log: &#x27;none&#x27;,</td>
                           
-                        </tr>            <tr id="lib/api.js__376" class="chunks">
+                        </tr>            <tr id="lib/api.js__376" class="hit">
                           <td class="line" data-tooltip>376</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  logspec &#x3D; </div><div class="miss false" data-tooltip>true &#x3D;&#x3D;&#x3D; logspec</div><div> || &#x27;true&#x27; &#x3D;&#x3D;&#x3D; logspec ? &#x27;test&#x27; : logspec</div></td>
+                          <td class="source">    reload$: true,</td>
                           
                         </tr>            <tr id="lib/api.js__377" class="hit">
                           <td class="line" data-tooltip>377</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__378" class="hit">
                           <td class="line" data-tooltip>378</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  var test_opts &#x3D; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__379" class="hit">
                           <td class="line" data-tooltip>379</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    errhandler: null &#x3D;&#x3D; errhandler ? null : errhandler,</td>
+                          <td class="hits" data-tooltip>39</td>
+                          <td class="source">  var opts &#x3D; this.options(quiet_opts)</td>
                           
                         </tr>            <tr id="lib/api.js__380" class="hit">
                           <td class="line" data-tooltip>380</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    test: true,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__381" class="hit">
                           <td class="line" data-tooltip>381</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    quiet: false,</td>
+                          <td class="source">  // An override from env or args is possible.</td>
                           
                         </tr>            <tr id="lib/api.js__382" class="hit">
                           <td class="line" data-tooltip>382</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    reload$: true,</td>
+                          <td class="source">  // Only flip to test mode if called from test() method</td>
                           
-                        </tr>            <tr id="lib/api.js__383" class="hit">
+                        </tr>            <tr id="lib/api.js__383" class="chunks">
                           <td class="line" data-tooltip>383</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    log: logspec || &#x27;test&#x27;,</td>
+                          <td class="source"><div>  if (opts.test &amp;&amp; </div><div class="miss true" data-tooltip>&#x27;test&#x27; !&#x3D;&#x3D; flags.from</div><div>) {</div></td>
                           
                         </tr>            <tr id="lib/api.js__384" class="hit">
                           <td class="line" data-tooltip>384</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    return this.test()</td>
                           
                         </tr>            <tr id="lib/api.js__385" class="hit">
                           <td class="line" data-tooltip>385</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  } else {</td>
                           
                         </tr>            <tr id="lib/api.js__386" class="hit">
                           <td class="line" data-tooltip>386</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  var set_opts &#x3D; this.options(test_opts)</td>
+                          <td class="hits" data-tooltip>37</td>
+                          <td class="source">    this.private$.logging.build_log(this)</td>
                           
                         </tr>            <tr id="lib/api.js__387" class="hit">
                           <td class="line" data-tooltip>387</td>
@@ -14699,182 +14748,182 @@
                         </tr>            <tr id="lib/api.js__388" class="hit">
                           <td class="line" data-tooltip>388</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // An override from env or args is possible.</td>
+                          <td class="hits" data-tooltip>37</td>
+                          <td class="source">    return this</td>
                           
                         </tr>            <tr id="lib/api.js__389" class="hit">
                           <td class="line" data-tooltip>389</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  if (set_opts.quiet) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__390" class="hit">
                           <td class="line" data-tooltip>390</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    return this.quiet({ from: &#x27;test&#x27; })</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__391" class="hit">
                           <td class="line" data-tooltip>391</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__392" class="hit">
                           <td class="line" data-tooltip>392</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>201</td>
-                          <td class="source">    this.private$.logging.build_log(this)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.test &#x3D; function (errhandler, logspec) {</td>
                           
                         </tr>            <tr id="lib/api.js__393" class="hit">
                           <td class="line" data-tooltip>393</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  var opts &#x3D; this.options()</td>
                           
                         </tr>            <tr id="lib/api.js__394" class="hit">
                           <td class="line" data-tooltip>394</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // Manually set logger to test_logger (avoids infecting options structure),</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__395" class="hit">
                           <td class="line" data-tooltip>395</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    // unless there was an external logger defined by the options</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  if (&#x27;-&#x27; !&#x3D; opts.tag) {</td>
                           
                         </tr>            <tr id="lib/api.js__396" class="hit">
                           <td class="line" data-tooltip>396</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>201</td>
-                          <td class="source">    if (!this.private$.logger.from_options$) {</td>
+                          <td class="hits" data-tooltip>21</td>
+                          <td class="source">    this.root.id &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__397" class="hit">
                           <td class="line" data-tooltip>397</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>188</td>
-                          <td class="source">      this.root.private$.logger &#x3D; this.private$.logging.test_logger</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      null &#x3D;&#x3D; opts.id$</td>
                           
                         </tr>            <tr id="lib/api.js__398" class="hit">
                           <td class="line" data-tooltip>398</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">        ? this.private$.actnid().substring(0, 4) + &#x27;/&#x27; + opts.tag</td>
                           
                         </tr>            <tr id="lib/api.js__399" class="hit">
                           <td class="line" data-tooltip>399</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">        : &#x27;&#x27; + opts.id$</td>
                           
                         </tr>            <tr id="lib/api.js__400" class="hit">
                           <td class="line" data-tooltip>400</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>201</td>
-                          <td class="source">    return this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__401" class="hit">
                           <td class="line" data-tooltip>401</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__402" class="hit">
                           <td class="line" data-tooltip>402</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  if (&#x27;function&#x27; !&#x3D;&#x3D; typeof errhandler &amp;&amp; null !&#x3D;&#x3D; errhandler) {</td>
                           
                         </tr>            <tr id="lib/api.js__403" class="hit">
                           <td class="line" data-tooltip>403</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>55</td>
+                          <td class="source">    logspec &#x3D; errhandler</td>
                           
                         </tr>            <tr id="lib/api.js__404" class="hit">
                           <td class="line" data-tooltip>404</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.ping &#x3D; function () {</td>
+                          <td class="hits" data-tooltip>55</td>
+                          <td class="source">    errhandler &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__405" class="hit">
                           <td class="line" data-tooltip>405</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var now &#x3D; Date.now()</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__406" class="hit">
                           <td class="line" data-tooltip>406</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">  return {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__407" class="hit">
+                        </tr>            <tr id="lib/api.js__407" class="chunks">
                           <td class="line" data-tooltip>407</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    now: now,</td>
+                          <td class="source"><div>  logspec &#x3D; </div><div class="miss false" data-tooltip>true &#x3D;&#x3D;&#x3D; logspec</div><div> || &#x27;true&#x27; &#x3D;&#x3D;&#x3D; logspec ? &#x27;test&#x27; : logspec</div></td>
                           
                         </tr>            <tr id="lib/api.js__408" class="hit">
                           <td class="line" data-tooltip>408</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    uptime: now - this.private$.stats.start,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__409" class="hit">
                           <td class="line" data-tooltip>409</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    id: this.id,</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  var test_opts &#x3D; {</td>
                           
                         </tr>            <tr id="lib/api.js__410" class="hit">
                           <td class="line" data-tooltip>410</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    cpu: process.cpuUsage(),</td>
+                          <td class="source">    errhandler: null &#x3D;&#x3D; errhandler ? null : errhandler,</td>
                           
                         </tr>            <tr id="lib/api.js__411" class="hit">
                           <td class="line" data-tooltip>411</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    mem: process.memoryUsage(),</td>
+                          <td class="source">    test: true,</td>
                           
                         </tr>            <tr id="lib/api.js__412" class="hit">
                           <td class="line" data-tooltip>412</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    act: this.private$.stats.act,</td>
+                          <td class="source">    quiet: false,</td>
                           
                         </tr>            <tr id="lib/api.js__413" class="hit">
                           <td class="line" data-tooltip>413</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    tr: this.private$.transport.register.map(function (x) {</td>
+                          <td class="source">    reload$: true,</td>
                           
                         </tr>            <tr id="lib/api.js__414" class="hit">
                           <td class="line" data-tooltip>414</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      return Object.assign({ when: x.when, err: x.err }, x.config)</td>
+                          <td class="source">    log: logspec || &#x27;test&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__415" class="hit">
                           <td class="line" data-tooltip>415</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }),</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__416" class="hit">
                           <td class="line" data-tooltip>416</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__417" class="hit">
                           <td class="line" data-tooltip>417</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  var set_opts &#x3D; this.options(test_opts)</td>
                           
                         </tr>            <tr id="lib/api.js__418" class="hit">
                           <td class="line" data-tooltip>418</td>
@@ -14885,32 +14934,32 @@
                         </tr>            <tr id="lib/api.js__419" class="hit">
                           <td class="line" data-tooltip>419</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.translate &#x3D; function (from_in, to_in, pick_in) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // An override from env or args is possible.</td>
                           
                         </tr>            <tr id="lib/api.js__420" class="hit">
                           <td class="line" data-tooltip>420</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var from &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof from_in ? Jsonic(from_in) : from_in</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  if (set_opts.quiet) {</td>
                           
                         </tr>            <tr id="lib/api.js__421" class="hit">
                           <td class="line" data-tooltip>421</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  var to &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof to_in ? Jsonic(to_in) : to_in</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    return this.quiet({ from: &#x27;test&#x27; })</td>
                           
                         </tr>            <tr id="lib/api.js__422" class="hit">
                           <td class="line" data-tooltip>422</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  } else {</td>
                           
                         </tr>            <tr id="lib/api.js__423" class="hit">
                           <td class="line" data-tooltip>423</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  var pick &#x3D; {}</td>
+                          <td class="hits" data-tooltip>201</td>
+                          <td class="source">    this.private$.logging.build_log(this)</td>
                           
                         </tr>            <tr id="lib/api.js__424" class="hit">
                           <td class="line" data-tooltip>424</td>
@@ -14921,374 +14970,374 @@
                         </tr>            <tr id="lib/api.js__425" class="hit">
                           <td class="line" data-tooltip>425</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  if (&#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pick_in) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    // Manually set logger to test_logger (avoids infecting options structure),</td>
                           
                         </tr>            <tr id="lib/api.js__426" class="hit">
                           <td class="line" data-tooltip>426</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>4</td>
-                          <td class="source">    pick_in &#x3D; pick_in.split(/\s*,\s*/)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    // unless there was an external logger defined by the options</td>
                           
                         </tr>            <tr id="lib/api.js__427" class="hit">
                           <td class="line" data-tooltip>427</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>201</td>
+                          <td class="source">    if (!this.private$.logger.from_options$) {</td>
                           
                         </tr>            <tr id="lib/api.js__428" class="hit">
                           <td class="line" data-tooltip>428</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>188</td>
+                          <td class="source">      this.root.private$.logger &#x3D; this.private$.logging.test_logger</td>
                           
                         </tr>            <tr id="lib/api.js__429" class="hit">
                           <td class="line" data-tooltip>429</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  if (Array.isArray(pick_in)) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__430" class="hit">
                           <td class="line" data-tooltip>430</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">    pick_in.forEach(function (prop) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__431" class="hit">
                           <td class="line" data-tooltip>431</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      if (prop.startsWith(&#x27;-&#x27;)) {</td>
+                          <td class="hits" data-tooltip>201</td>
+                          <td class="source">    return this</td>
                           
                         </tr>            <tr id="lib/api.js__432" class="hit">
                           <td class="line" data-tooltip>432</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">        pick[prop.substring(1)] &#x3D; false</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__433" class="hit">
                           <td class="line" data-tooltip>433</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      } else {</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__434" class="hit">
                           <td class="line" data-tooltip>434</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">        pick[prop] &#x3D; true</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__435" class="hit">
                           <td class="line" data-tooltip>435</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.ping &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__436" class="hit">
                           <td class="line" data-tooltip>436</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source">  var now &#x3D; Date.now()</td>
                           
                         </tr>            <tr id="lib/api.js__437" class="hit">
                           <td class="line" data-tooltip>437</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">  } else if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof pick_in) {</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">  return {</td>
                           
                         </tr>            <tr id="lib/api.js__438" class="hit">
                           <td class="line" data-tooltip>438</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    pick &#x3D; Object.assign({}, pick_in)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    now: now,</td>
                           
                         </tr>            <tr id="lib/api.js__439" class="hit">
                           <td class="line" data-tooltip>439</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="source">    uptime: now - this.private$.stats.start,</td>
                           
                         </tr>            <tr id="lib/api.js__440" class="hit">
                           <td class="line" data-tooltip>440</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    pick &#x3D; null</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    id: this.id,</td>
                           
                         </tr>            <tr id="lib/api.js__441" class="hit">
                           <td class="line" data-tooltip>441</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    cpu: process.cpuUsage(),</td>
                           
                         </tr>            <tr id="lib/api.js__442" class="hit">
                           <td class="line" data-tooltip>442</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    mem: process.memoryUsage(),</td>
                           
                         </tr>            <tr id="lib/api.js__443" class="hit">
                           <td class="line" data-tooltip>443</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  this.add(from, function (msg, reply) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    act: this.private$.stats.act,</td>
                           
                         </tr>            <tr id="lib/api.js__444" class="hit">
                           <td class="line" data-tooltip>444</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    var pick_msg</td>
+                          <td class="source">    tr: this.private$.transport.register.map(function (x) {</td>
                           
                         </tr>            <tr id="lib/api.js__445" class="hit">
                           <td class="line" data-tooltip>445</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      return Object.assign({ when: x.when, err: x.err }, x.config)</td>
                           
                         </tr>            <tr id="lib/api.js__446" class="hit">
                           <td class="line" data-tooltip>446</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">    if (pick) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }),</td>
                           
                         </tr>            <tr id="lib/api.js__447" class="hit">
                           <td class="line" data-tooltip>447</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">      pick_msg &#x3D; {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__448" class="hit">
                           <td class="line" data-tooltip>448</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">      Object.keys(pick).forEach(function (prop) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__449" class="hit">
                           <td class="line" data-tooltip>449</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        if (pick[prop]) {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__450" class="hit">
                           <td class="line" data-tooltip>450</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
-                          <td class="source">          pick_msg[prop] &#x3D; msg[prop]</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.translate &#x3D; function (from_in, to_in, pick_in) {</td>
                           
                         </tr>            <tr id="lib/api.js__451" class="hit">
                           <td class="line" data-tooltip>451</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="source">  var from &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof from_in ? Jsonic(from_in) : from_in</td>
                           
                         </tr>            <tr id="lib/api.js__452" class="hit">
                           <td class="line" data-tooltip>452</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      })</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  var to &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof to_in ? Jsonic(to_in) : to_in</td>
                           
                         </tr>            <tr id="lib/api.js__453" class="hit">
                           <td class="line" data-tooltip>453</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    } else {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__454" class="hit">
                           <td class="line" data-tooltip>454</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">      pick_msg &#x3D; this.util.clean(msg)</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  var pick &#x3D; {}</td>
                           
                         </tr>            <tr id="lib/api.js__455" class="hit">
                           <td class="line" data-tooltip>455</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__456" class="hit">
                           <td class="line" data-tooltip>456</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  if (&#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pick_in) {</td>
                           
                         </tr>            <tr id="lib/api.js__457" class="hit">
                           <td class="line" data-tooltip>457</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">    var transmsg &#x3D; Object.assign(pick_msg, to)</td>
+                          <td class="hits" data-tooltip>4</td>
+                          <td class="source">    pick_in &#x3D; pick_in.split(/\s*,\s*/)</td>
                           
                         </tr>            <tr id="lib/api.js__458" class="hit">
                           <td class="line" data-tooltip>458</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">    this.act(transmsg, reply)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__459" class="hit">
                           <td class="line" data-tooltip>459</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  })</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__460" class="hit">
                           <td class="line" data-tooltip>460</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  if (Array.isArray(pick_in)) {</td>
                           
                         </tr>            <tr id="lib/api.js__461" class="hit">
                           <td class="line" data-tooltip>461</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">    pick_in.forEach(function (prop) {</td>
                           
                         </tr>            <tr id="lib/api.js__462" class="hit">
                           <td class="line" data-tooltip>462</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">      if (prop.startsWith(&#x27;-&#x27;)) {</td>
                           
                         </tr>            <tr id="lib/api.js__463" class="hit">
                           <td class="line" data-tooltip>463</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">        pick[prop.substring(1)] &#x3D; false</td>
                           
                         </tr>            <tr id="lib/api.js__464" class="hit">
                           <td class="line" data-tooltip>464</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.gate &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      } else {</td>
                           
                         </tr>            <tr id="lib/api.js__465" class="hit">
                           <td class="line" data-tooltip>465</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  return this.delegate({ gate$: true })</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">        pick[prop] &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__466" class="hit">
                           <td class="line" data-tooltip>466</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__467" class="hit">
                           <td class="line" data-tooltip>467</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__468" class="hit">
                           <td class="line" data-tooltip>468</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.ungate &#x3D; function () {</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">  } else if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof pick_in) {</td>
                           
                         </tr>            <tr id="lib/api.js__469" class="hit">
                           <td class="line" data-tooltip>469</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  this.fixedargs.gate$ &#x3D; false</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    pick &#x3D; Object.assign({}, pick_in)</td>
                           
                         </tr>            <tr id="lib/api.js__470" class="hit">
                           <td class="line" data-tooltip>470</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  } else {</td>
                           
                         </tr>            <tr id="lib/api.js__471" class="hit">
                           <td class="line" data-tooltip>471</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    pick &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__472" class="hit">
                           <td class="line" data-tooltip>472</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__473" class="hit">
                           <td class="line" data-tooltip>473</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// TODO this needs a better name</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__474" class="hit">
                           <td class="line" data-tooltip>474</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.list_plugins &#x3D; function () {</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  this.add(from, function (msg, reply) {</td>
                           
                         </tr>            <tr id="lib/api.js__475" class="hit">
                           <td class="line" data-tooltip>475</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return Object.assign({}, this.private$.plugins)</td>
+                          <td class="source">    var pick_msg</td>
                           
                         </tr>            <tr id="lib/api.js__476" class="hit">
                           <td class="line" data-tooltip>476</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__477" class="hit">
                           <td class="line" data-tooltip>477</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">    if (pick) {</td>
                           
                         </tr>            <tr id="lib/api.js__478" class="hit">
                           <td class="line" data-tooltip>478</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.find_plugin &#x3D; function (plugindesc, tag) {</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">      pick_msg &#x3D; {}</td>
                           
                         </tr>            <tr id="lib/api.js__479" class="hit">
                           <td class="line" data-tooltip>479</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">      Object.keys(pick).forEach(function (prop) {</td>
                           
                         </tr>            <tr id="lib/api.js__480" class="hit">
                           <td class="line" data-tooltip>480</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>4</td>
-                          <td class="source">  return this.private$.plugins[plugin_key]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        if (pick[prop]) {</td>
                           
                         </tr>            <tr id="lib/api.js__481" class="hit">
                           <td class="line" data-tooltip>481</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>9</td>
+                          <td class="source">          pick_msg[prop] &#x3D; msg[prop]</td>
                           
                         </tr>            <tr id="lib/api.js__482" class="hit">
                           <td class="line" data-tooltip>482</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__483" class="hit">
                           <td class="line" data-tooltip>483</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.has_plugin &#x3D; function (plugindesc, tag) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      })</td>
                           
                         </tr>            <tr id="lib/api.js__484" class="hit">
                           <td class="line" data-tooltip>484</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
+                          <td class="source">    } else {</td>
                           
                         </tr>            <tr id="lib/api.js__485" class="hit">
                           <td class="line" data-tooltip>485</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>13</td>
-                          <td class="source">  return !!this.private$.plugins[plugin_key]</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">      pick_msg &#x3D; this.util.clean(msg)</td>
                           
                         </tr>            <tr id="lib/api.js__486" class="hit">
                           <td class="line" data-tooltip>486</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__487" class="hit">
                           <td class="line" data-tooltip>487</td>
@@ -15299,92 +15348,92 @@
                         </tr>            <tr id="lib/api.js__488" class="hit">
                           <td class="line" data-tooltip>488</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.ignore_plugin &#x3D; function (plugindesc, tag, ignore) {</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">    var transmsg &#x3D; Object.assign(pick_msg, to)</td>
                           
                         </tr>            <tr id="lib/api.js__489" class="hit">
                           <td class="line" data-tooltip>489</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  if (&#x27;boolean&#x27; &#x3D;&#x3D;&#x3D; typeof tag) {</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">    this.act(transmsg, reply)</td>
                           
                         </tr>            <tr id="lib/api.js__490" class="hit">
                           <td class="line" data-tooltip>490</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">    ignore &#x3D; tag</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  })</td>
                           
                         </tr>            <tr id="lib/api.js__491" class="hit">
                           <td class="line" data-tooltip>491</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">    tag &#x3D; null</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__492" class="hit">
                           <td class="line" data-tooltip>492</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__493" class="hit">
                           <td class="line" data-tooltip>493</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__494" class="hit">
                           <td class="line" data-tooltip>494</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">  var resolved_ignore &#x3D; (this.private$.ignore_plugins[plugin_key] &#x3D;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__495" class="hit">
                           <td class="line" data-tooltip>495</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    null &#x3D;&#x3D; ignore ? true : !!ignore)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.gate &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__496" class="hit">
                           <td class="line" data-tooltip>496</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  return this.delegate({ gate$: true })</td>
                           
                         </tr>            <tr id="lib/api.js__497" class="hit">
                           <td class="line" data-tooltip>497</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">  this.log.info({</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__498" class="hit">
                           <td class="line" data-tooltip>498</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    kind: &#x27;plugin&#x27;,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__499" class="hit">
                           <td class="line" data-tooltip>499</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    case: &#x27;ignore&#x27;,</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.ungate &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__500" class="hit">
                           <td class="line" data-tooltip>500</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    full: plugin_key,</td>
+                          <td class="source">  this.fixedargs.gate$ &#x3D; false</td>
                           
                         </tr>            <tr id="lib/api.js__501" class="hit">
                           <td class="line" data-tooltip>501</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    ignore: resolved_ignore,</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__502" class="hit">
                           <td class="line" data-tooltip>502</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  })</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__503" class="hit">
                           <td class="line" data-tooltip>503</td>
@@ -15395,182 +15444,182 @@
                         </tr>            <tr id="lib/api.js__504" class="hit">
                           <td class="line" data-tooltip>504</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">// TODO this needs a better name</td>
                           
                         </tr>            <tr id="lib/api.js__505" class="hit">
                           <td class="line" data-tooltip>505</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.list_plugins &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__506" class="hit">
                           <td class="line" data-tooltip>506</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  return Object.assign({}, this.private$.plugins)</td>
                           
                         </tr>            <tr id="lib/api.js__507" class="hit">
                           <td class="line" data-tooltip>507</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Find the action metadata for a given pattern, if it exists.</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__508" class="hit">
                           <td class="line" data-tooltip>508</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.find &#x3D; function (pattern, flags) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__509" class="hit">
                           <td class="line" data-tooltip>509</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var seneca &#x3D; this</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.find_plugin &#x3D; function (plugindesc, tag) {</td>
                           
                         </tr>            <tr id="lib/api.js__510" class="hit">
                           <td class="line" data-tooltip>510</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
                           
                         </tr>            <tr id="lib/api.js__511" class="hit">
                           <td class="line" data-tooltip>511</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  var pat &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pattern ? Jsonic(pattern) : pattern</td>
+                          <td class="hits" data-tooltip>4</td>
+                          <td class="source">  return this.private$.plugins[plugin_key]</td>
                           
                         </tr>            <tr id="lib/api.js__512" class="hit">
                           <td class="line" data-tooltip>512</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  pat &#x3D; seneca.util.clean(pat)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__513" class="hit">
                           <td class="line" data-tooltip>513</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  pat &#x3D; pat || {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__514" class="hit">
                           <td class="line" data-tooltip>514</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.has_plugin &#x3D; function (plugindesc, tag) {</td>
                           
                         </tr>            <tr id="lib/api.js__515" class="hit">
                           <td class="line" data-tooltip>515</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  var actdef &#x3D; seneca.private$.actrouter.find(pat, flags &amp;&amp; flags.exact)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
                           
                         </tr>            <tr id="lib/api.js__516" class="hit">
                           <td class="line" data-tooltip>516</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>13</td>
+                          <td class="source">  return !!this.private$.plugins[plugin_key]</td>
                           
                         </tr>            <tr id="lib/api.js__517" class="hit">
                           <td class="line" data-tooltip>517</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  if (!actdef) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__518" class="hit">
                           <td class="line" data-tooltip>518</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7692</td>
-                          <td class="source">    actdef &#x3D; seneca.private$.actrouter.find({})</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__519" class="hit">
                           <td class="line" data-tooltip>519</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.ignore_plugin &#x3D; function (plugindesc, tag, ignore) {</td>
                           
                         </tr>            <tr id="lib/api.js__520" class="hit">
                           <td class="line" data-tooltip>520</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  if (&#x27;boolean&#x27; &#x3D;&#x3D;&#x3D; typeof tag) {</td>
                           
                         </tr>            <tr id="lib/api.js__521" class="hit">
                           <td class="line" data-tooltip>521</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  return actdef</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">    ignore &#x3D; tag</td>
                           
                         </tr>            <tr id="lib/api.js__522" class="hit">
                           <td class="line" data-tooltip>522</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">    tag &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__523" class="hit">
                           <td class="line" data-tooltip>523</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__524" class="hit">
                           <td class="line" data-tooltip>524</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// True if an action matching the pattern exists.</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
                           
                         </tr>            <tr id="lib/api.js__525" class="hit">
                           <td class="line" data-tooltip>525</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.has &#x3D; function (pattern) {</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">  var resolved_ignore &#x3D; (this.private$.ignore_plugins[plugin_key] &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__526" class="hit">
                           <td class="line" data-tooltip>526</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return !!this.find(pattern, { exact: true })</td>
+                          <td class="source">    null &#x3D;&#x3D; ignore ? true : !!ignore)</td>
                           
                         </tr>            <tr id="lib/api.js__527" class="hit">
                           <td class="line" data-tooltip>527</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__528" class="hit">
                           <td class="line" data-tooltip>528</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">  this.log.info({</td>
                           
                         </tr>            <tr id="lib/api.js__529" class="hit">
                           <td class="line" data-tooltip>529</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// List all actions that match the pattern.</td>
+                          <td class="source">    kind: &#x27;plugin&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__530" class="hit">
                           <td class="line" data-tooltip>530</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.list &#x3D; function (pattern) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    case: &#x27;ignore&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__531" class="hit">
                           <td class="line" data-tooltip>531</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return this.private$.actrouter</td>
+                          <td class="source">    full: plugin_key,</td>
                           
                         </tr>            <tr id="lib/api.js__532" class="hit">
                           <td class="line" data-tooltip>532</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    .list(null &#x3D;&#x3D; pattern ? {} : Jsonic(pattern))</td>
+                          <td class="source">    ignore: resolved_ignore,</td>
                           
                         </tr>            <tr id="lib/api.js__533" class="hit">
                           <td class="line" data-tooltip>533</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    .map((x) &#x3D;&gt; x.match)</td>
+                          <td class="source">  })</td>
                           
                         </tr>            <tr id="lib/api.js__534" class="hit">
                           <td class="line" data-tooltip>534</td>
@@ -15581,272 +15630,272 @@
                         </tr>            <tr id="lib/api.js__535" class="hit">
                           <td class="line" data-tooltip>535</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  /*</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__536" class="hit">
                           <td class="line" data-tooltip>536</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return _.map(</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__537" class="hit">
                           <td class="line" data-tooltip>537</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    this.private$.actrouter.list(null &#x3D;&#x3D; pattern ? {} : Jsonic(pattern)),</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__538" class="hit">
                           <td class="line" data-tooltip>538</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;match&#x27;</td>
+                          <td class="source">// Find the action metadata for a given pattern, if it exists.</td>
                           
                         </tr>            <tr id="lib/api.js__539" class="hit">
                           <td class="line" data-tooltip>539</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  )</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.find &#x3D; function (pattern, flags) {</td>
                           
                         </tr>            <tr id="lib/api.js__540" class="hit">
                           <td class="line" data-tooltip>540</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  */</td>
+                          <td class="source">  var seneca &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__541" class="hit">
                           <td class="line" data-tooltip>541</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__542" class="hit">
                           <td class="line" data-tooltip>542</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  var pat &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pattern ? Jsonic(pattern) : pattern</td>
                           
                         </tr>            <tr id="lib/api.js__543" class="hit">
                           <td class="line" data-tooltip>543</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// Get the current status of the instance.</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  pat &#x3D; seneca.util.clean(pat)</td>
                           
                         </tr>            <tr id="lib/api.js__544" class="hit">
                           <td class="line" data-tooltip>544</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.status &#x3D; function (flags) {</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  pat &#x3D; pat || {}</td>
                           
                         </tr>            <tr id="lib/api.js__545" class="hit">
                           <td class="line" data-tooltip>545</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  flags &#x3D; flags || {}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__546" class="hit">
                           <td class="line" data-tooltip>546</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  var actdef &#x3D; seneca.private$.actrouter.find(pat, flags &amp;&amp; flags.exact)</td>
                           
                         </tr>            <tr id="lib/api.js__547" class="hit">
                           <td class="line" data-tooltip>547</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  var hist &#x3D; this.private$.history.stats()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__548" class="hit">
                           <td class="line" data-tooltip>548</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  hist.log &#x3D; this.private$.history.list()</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  if (!actdef) {</td>
                           
                         </tr>            <tr id="lib/api.js__549" class="hit">
                           <td class="line" data-tooltip>549</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>7692</td>
+                          <td class="source">    actdef &#x3D; seneca.private$.actrouter.find({})</td>
                           
                         </tr>            <tr id="lib/api.js__550" class="hit">
                           <td class="line" data-tooltip>550</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  var status &#x3D; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__551" class="hit">
                           <td class="line" data-tooltip>551</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    stats: this.stats(flags.stats),</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__552" class="hit">
                           <td class="line" data-tooltip>552</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    history: hist,</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  return actdef</td>
                           
                         </tr>            <tr id="lib/api.js__553" class="hit">
                           <td class="line" data-tooltip>553</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    transport: this.private$.transport,</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__554" class="hit">
                           <td class="line" data-tooltip>554</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__555" class="hit">
                           <td class="line" data-tooltip>555</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">// True if an action matching the pattern exists.</td>
                           
                         </tr>            <tr id="lib/api.js__556" class="hit">
                           <td class="line" data-tooltip>556</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  return status</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.has &#x3D; function (pattern) {</td>
                           
                         </tr>            <tr id="lib/api.js__557" class="hit">
                           <td class="line" data-tooltip>557</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  return !!this.find(pattern, { exact: true })</td>
                           
                         </tr>            <tr id="lib/api.js__558" class="hit">
                           <td class="line" data-tooltip>558</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__559" class="hit">
                           <td class="line" data-tooltip>559</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Reply to an action that is waiting for a result.</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__560" class="hit">
                           <td class="line" data-tooltip>560</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Used by transports to decouple sending messages from receiving responses.</td>
+                          <td class="source">// List all actions that match the pattern.</td>
                           
                         </tr>            <tr id="lib/api.js__561" class="hit">
                           <td class="line" data-tooltip>561</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.reply &#x3D; function (spec) {</td>
+                          <td class="source">exports.list &#x3D; function (pattern) {</td>
                           
                         </tr>            <tr id="lib/api.js__562" class="hit">
                           <td class="line" data-tooltip>562</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var instance &#x3D; this</td>
+                          <td class="source">  return this.private$.actrouter</td>
                           
                         </tr>            <tr id="lib/api.js__563" class="hit">
                           <td class="line" data-tooltip>563</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>34</td>
-                          <td class="source">  var actctxt &#x3D; null</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    .list(null &#x3D;&#x3D; pattern ? {} : Jsonic(pattern))</td>
                           
                         </tr>            <tr id="lib/api.js__564" class="hit">
                           <td class="line" data-tooltip>564</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    .map((x) &#x3D;&gt; x.match)</td>
                           
                         </tr>            <tr id="lib/api.js__565" class="hit">
                           <td class="line" data-tooltip>565</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>34</td>
-                          <td class="source">  if (spec &amp;&amp; spec.meta) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__566" class="hit">
                           <td class="line" data-tooltip>566</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>32</td>
-                          <td class="source">    actctxt &#x3D; instance.private$.history.get(spec.meta.id)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  /*</td>
                           
                         </tr>            <tr id="lib/api.js__567" class="hit">
                           <td class="line" data-tooltip>567</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>32</td>
-                          <td class="source">    if (actctxt) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  return _.map(</td>
                           
                         </tr>            <tr id="lib/api.js__568" class="hit">
                           <td class="line" data-tooltip>568</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>31</td>
-                          <td class="source">      actctxt.reply(spec.err, spec.out, spec.meta)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    this.private$.actrouter.list(null &#x3D;&#x3D; pattern ? {} : Jsonic(pattern)),</td>
                           
                         </tr>            <tr id="lib/api.js__569" class="hit">
                           <td class="line" data-tooltip>569</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">    &#x27;match&#x27;</td>
                           
                         </tr>            <tr id="lib/api.js__570" class="hit">
                           <td class="line" data-tooltip>570</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">  )</td>
                           
                         </tr>            <tr id="lib/api.js__571" class="hit">
                           <td class="line" data-tooltip>571</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  */</td>
                           
                         </tr>            <tr id="lib/api.js__572" class="hit">
                           <td class="line" data-tooltip>572</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>34</td>
-                          <td class="source">  return !!actctxt</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__573" class="hit">
                           <td class="line" data-tooltip>573</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__574" class="hit">
                           <td class="line" data-tooltip>574</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">// Get the current status of the instance.</td>
                           
                         </tr>            <tr id="lib/api.js__575" class="hit">
                           <td class="line" data-tooltip>575</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// Listen for inbound messages.</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.status &#x3D; function (flags) {</td>
                           
                         </tr>            <tr id="lib/api.js__576" class="hit">
                           <td class="line" data-tooltip>576</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.listen &#x3D; function (callpoint) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  flags &#x3D; flags || {}</td>
                           
                         </tr>            <tr id="lib/api.js__577" class="hit">
                           <td class="line" data-tooltip>577</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return function api_listen(...argsarr) {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__578" class="hit">
                           <td class="line" data-tooltip>578</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    var private$ &#x3D; this.private$</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  var hist &#x3D; this.private$.history.stats()</td>
                           
                         </tr>            <tr id="lib/api.js__579" class="hit">
                           <td class="line" data-tooltip>579</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    var self &#x3D; this</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  hist.log &#x3D; this.private$.history.list()</td>
                           
                         </tr>            <tr id="lib/api.js__580" class="hit">
                           <td class="line" data-tooltip>580</td>
@@ -15857,146 +15906,146 @@
                         </tr>            <tr id="lib/api.js__581" class="hit">
                           <td class="line" data-tooltip>581</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    var done &#x3D; argsarr[argsarr.length - 1]</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  var status &#x3D; {</td>
                           
                         </tr>            <tr id="lib/api.js__582" class="hit">
                           <td class="line" data-tooltip>582</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    if (typeof done &#x3D;&#x3D;&#x3D; &#x27;function&#x27;) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    stats: this.stats(flags.stats),</td>
                           
                         </tr>            <tr id="lib/api.js__583" class="hit">
                           <td class="line" data-tooltip>583</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      argsarr.pop()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    history: hist,</td>
                           
                         </tr>            <tr id="lib/api.js__584" class="hit">
                           <td class="line" data-tooltip>584</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    } else {</td>
+                          <td class="source">    transport: this.private$.transport,</td>
                           
                         </tr>            <tr id="lib/api.js__585" class="hit">
                           <td class="line" data-tooltip>585</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>46</td>
-                          <td class="source">      done &#x3D; () &#x3D;&gt; {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__586" class="hit">
                           <td class="line" data-tooltip>586</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__587" class="hit">
                           <td class="line" data-tooltip>587</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  return status</td>
                           
                         </tr>            <tr id="lib/api.js__588" class="hit">
                           <td class="line" data-tooltip>588</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    self.log.info({</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__589" class="hit">
                           <td class="line" data-tooltip>589</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      kind: &#x27;listen&#x27;,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__590" class="hit">
                           <td class="line" data-tooltip>590</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      case: &#x27;INIT&#x27;,</td>
+                          <td class="source">// Reply to an action that is waiting for a result.</td>
                           
                         </tr>            <tr id="lib/api.js__591" class="hit">
                           <td class="line" data-tooltip>591</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      data: argsarr,</td>
+                          <td class="source">// Used by transports to decouple sending messages from receiving responses.</td>
                           
                         </tr>            <tr id="lib/api.js__592" class="hit">
                           <td class="line" data-tooltip>592</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      callpoint: callpoint(true),</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.reply &#x3D; function (spec) {</td>
                           
                         </tr>            <tr id="lib/api.js__593" class="hit">
                           <td class="line" data-tooltip>593</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source">  var instance &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__594" class="hit">
                           <td class="line" data-tooltip>594</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>34</td>
+                          <td class="source">  var actctxt &#x3D; null</td>
                           
-                        </tr>            <tr id="lib/api.js__595" class="chunks">
+                        </tr>            <tr id="lib/api.js__595" class="hit">
                           <td class="line" data-tooltip>595</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var opts &#x3D; </div><div class="miss true" data-tooltip>self.options().transport</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__596" class="hit">
                           <td class="line" data-tooltip>596</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    var config &#x3D; intern.resolve_config(intern.parse_config(argsarr), opts)</td>
+                          <td class="hits" data-tooltip>34</td>
+                          <td class="source">  if (spec &amp;&amp; spec.meta) {</td>
                           
                         </tr>            <tr id="lib/api.js__597" class="hit">
                           <td class="line" data-tooltip>597</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>32</td>
+                          <td class="source">    actctxt &#x3D; instance.private$.history.get(spec.meta.id)</td>
                           
                         </tr>            <tr id="lib/api.js__598" class="hit">
                           <td class="line" data-tooltip>598</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    self.act(</td>
+                          <td class="hits" data-tooltip>32</td>
+                          <td class="source">    if (actctxt) {</td>
                           
                         </tr>            <tr id="lib/api.js__599" class="hit">
                           <td class="line" data-tooltip>599</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      &#x27;role:transport,cmd:listen&#x27;,</td>
+                          <td class="hits" data-tooltip>31</td>
+                          <td class="source">      actctxt.reply(spec.err, spec.out, spec.meta)</td>
                           
                         </tr>            <tr id="lib/api.js__600" class="hit">
                           <td class="line" data-tooltip>600</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      { config: config, gate$: true },</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__601" class="hit">
                           <td class="line" data-tooltip>601</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      function (err, result) {</td>
+                          <td class="source">  }</td>
                           
-                        </tr>            <tr id="lib/api.js__602" class="chunks">
+                        </tr>            <tr id="lib/api.js__602" class="hit">
                           <td class="line" data-tooltip>602</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>err</div><div>) {</div></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__603" class="miss">
+                        </tr>            <tr id="lib/api.js__603" class="hit">
                           <td class="line" data-tooltip>603</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>          return self.die(private$.error(err, &#x27;transport_listen&#x27;, config))</td>
+                          <td class="hits" data-tooltip>34</td>
+                          <td class="source">  return !!actctxt</td>
                           
                         </tr>            <tr id="lib/api.js__604" class="hit">
                           <td class="line" data-tooltip>604</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__605" class="hit">
                           <td class="line" data-tooltip>605</td>
@@ -16007,134 +16056,134 @@
                         </tr>            <tr id="lib/api.js__606" class="hit">
                           <td class="line" data-tooltip>606</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">        done(null, result)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">// Listen for inbound messages.</td>
                           
                         </tr>            <tr id="lib/api.js__607" class="hit">
                           <td class="line" data-tooltip>607</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">        done &#x3D; () &#x3D;&gt; {}</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.listen &#x3D; function (callpoint) {</td>
                           
                         </tr>            <tr id="lib/api.js__608" class="hit">
                           <td class="line" data-tooltip>608</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">  return function api_listen(...argsarr) {</td>
                           
                         </tr>            <tr id="lib/api.js__609" class="hit">
                           <td class="line" data-tooltip>609</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    )</td>
+                          <td class="source">    var private$ &#x3D; this.private$</td>
                           
                         </tr>            <tr id="lib/api.js__610" class="hit">
                           <td class="line" data-tooltip>610</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__611" class="hit">
                           <td class="line" data-tooltip>611</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    return self</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__612" class="hit">
                           <td class="line" data-tooltip>612</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    var done &#x3D; argsarr[argsarr.length - 1]</td>
                           
                         </tr>            <tr id="lib/api.js__613" class="hit">
                           <td class="line" data-tooltip>613</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    if (typeof done &#x3D;&#x3D;&#x3D; &#x27;function&#x27;) {</td>
                           
                         </tr>            <tr id="lib/api.js__614" class="hit">
                           <td class="line" data-tooltip>614</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      argsarr.pop()</td>
                           
                         </tr>            <tr id="lib/api.js__615" class="hit">
                           <td class="line" data-tooltip>615</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Send outbound messages.</td>
+                          <td class="source">    } else {</td>
                           
                         </tr>            <tr id="lib/api.js__616" class="hit">
                           <td class="line" data-tooltip>616</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.client &#x3D; function (callpoint) {</td>
+                          <td class="hits" data-tooltip>46</td>
+                          <td class="source">      done &#x3D; () &#x3D;&gt; {}</td>
                           
                         </tr>            <tr id="lib/api.js__617" class="hit">
                           <td class="line" data-tooltip>617</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return function api_client() {</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__618" class="hit">
                           <td class="line" data-tooltip>618</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    var private$ &#x3D; this.private$</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__619" class="hit">
                           <td class="line" data-tooltip>619</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var argsarr &#x3D; Array.prototype.slice.call(arguments)</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    self.log.info({</td>
                           
                         </tr>            <tr id="lib/api.js__620" class="hit">
                           <td class="line" data-tooltip>620</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var self &#x3D; this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      kind: &#x27;listen&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__621" class="hit">
                           <td class="line" data-tooltip>621</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      case: &#x27;INIT&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__622" class="hit">
                           <td class="line" data-tooltip>622</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    self.log.info({</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      data: argsarr,</td>
                           
                         </tr>            <tr id="lib/api.js__623" class="hit">
                           <td class="line" data-tooltip>623</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      kind: &#x27;client&#x27;,</td>
+                          <td class="source">      callpoint: callpoint(true),</td>
                           
                         </tr>            <tr id="lib/api.js__624" class="hit">
                           <td class="line" data-tooltip>624</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      case: &#x27;INIT&#x27;,</td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__625" class="hit">
                           <td class="line" data-tooltip>625</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      data: argsarr,</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__626" class="hit">
+                        </tr>            <tr id="lib/api.js__626" class="chunks">
                           <td class="line" data-tooltip>626</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      callpoint: callpoint(true),</td>
+                          <td class="source"><div>    var opts &#x3D; </div><div class="miss true" data-tooltip>self.options().transport</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
                           
                         </tr>            <tr id="lib/api.js__627" class="hit">
                           <td class="line" data-tooltip>627</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    var config &#x3D; intern.resolve_config(intern.parse_config(argsarr), opts)</td>
                           
                         </tr>            <tr id="lib/api.js__628" class="hit">
                           <td class="line" data-tooltip>628</td>
@@ -16142,47 +16191,47 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__629" class="chunks">
+                        </tr>            <tr id="lib/api.js__629" class="hit">
                           <td class="line" data-tooltip>629</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var legacy &#x3D; </div><div class="miss true" data-tooltip>self.options().legacy</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    self.act(</td>
                           
-                        </tr>            <tr id="lib/api.js__630" class="chunks">
+                        </tr>            <tr id="lib/api.js__630" class="hit">
                           <td class="line" data-tooltip>630</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var opts &#x3D; </div><div class="miss true" data-tooltip>self.options().transport</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
+                          <td class="source">      &#x27;role:transport,cmd:listen&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__631" class="hit">
                           <td class="line" data-tooltip>631</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      { config: config, gate$: true },</td>
                           
                         </tr>            <tr id="lib/api.js__632" class="hit">
                           <td class="line" data-tooltip>632</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var raw_config &#x3D; intern.parse_config(argsarr)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      function (err, result) {</td>
                           
-                        </tr>            <tr id="lib/api.js__633" class="hit">
+                        </tr>            <tr id="lib/api.js__633" class="chunks">
                           <td class="line" data-tooltip>633</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>err</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__634" class="hit">
+                        </tr>            <tr id="lib/api.js__634" class="miss">
                           <td class="line" data-tooltip>634</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // pg: pin group</td>
+                          <td class="source" data-tooltip>          return self.die(private$.error(err, &#x27;transport_listen&#x27;, config))</td>
                           
                         </tr>            <tr id="lib/api.js__635" class="hit">
                           <td class="line" data-tooltip>635</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    raw_config.pg &#x3D; Common.pincanon(raw_config.pin || raw_config.pins)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__636" class="hit">
                           <td class="line" data-tooltip>636</td>
@@ -16193,182 +16242,182 @@
                         </tr>            <tr id="lib/api.js__637" class="hit">
                           <td class="line" data-tooltip>637</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var config &#x3D; intern.resolve_config(raw_config, opts)</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">        done(null, result)</td>
                           
                         </tr>            <tr id="lib/api.js__638" class="hit">
                           <td class="line" data-tooltip>638</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">        done &#x3D; () &#x3D;&gt; {}</td>
                           
                         </tr>            <tr id="lib/api.js__639" class="hit">
                           <td class="line" data-tooltip>639</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    config.id &#x3D; config.id || Common.pattern(raw_config)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__640" class="hit">
                           <td class="line" data-tooltip>640</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    )</td>
                           
                         </tr>            <tr id="lib/api.js__641" class="hit">
                           <td class="line" data-tooltip>641</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var pins &#x3D;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__642" class="hit">
                           <td class="line" data-tooltip>642</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      config.pins ||</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    return self</td>
                           
-                        </tr>            <tr id="lib/api.js__643" class="chunks">
+                        </tr>            <tr id="lib/api.js__643" class="hit">
                           <td class="line" data-tooltip>643</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      (</div><div class="miss false" data-tooltip>Array.isArray(config.pin)</div><div> ? </div><div class="miss never" data-tooltip>config.pin</div><div> : [config.pin || &#x27;&#x27;])</div></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__644" class="hit">
                           <td class="line" data-tooltip>644</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__645" class="hit">
                           <td class="line" data-tooltip>645</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    pins &#x3D; pins.map((pin) &#x3D;&gt; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__646" class="hit">
                           <td class="line" data-tooltip>646</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      return &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pin ? Jsonic(pin) : pin</td>
+                          <td class="source">// Send outbound messages.</td>
                           
                         </tr>            <tr id="lib/api.js__647" class="hit">
                           <td class="line" data-tooltip>647</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.client &#x3D; function (callpoint) {</td>
                           
                         </tr>            <tr id="lib/api.js__648" class="hit">
                           <td class="line" data-tooltip>648</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  return function api_client() {</td>
                           
                         </tr>            <tr id="lib/api.js__649" class="hit">
                           <td class="line" data-tooltip>649</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    //var sd &#x3D; Plugins.make_delegate(self, {</td>
+                          <td class="source">    var private$ &#x3D; this.private$</td>
                           
                         </tr>            <tr id="lib/api.js__650" class="hit">
                           <td class="line" data-tooltip>650</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    // TODO: review - this feels like a hack</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var argsarr &#x3D; Array.prototype.slice.call(arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__651" class="hit">
                           <td class="line" data-tooltip>651</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    // perhaps we should instantiate a virtual plugin to represent the client?</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__652" class="hit">
                           <td class="line" data-tooltip>652</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // ... but is this necessary at all?</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__653" class="hit">
                           <td class="line" data-tooltip>653</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var task_res &#x3D; self.order.plugin.task.delegate.exec({</td>
+                          <td class="source">    self.log.info({</td>
                           
                         </tr>            <tr id="lib/api.js__654" class="hit">
                           <td class="line" data-tooltip>654</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      ctx: {</td>
+                          <td class="source">      kind: &#x27;client&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__655" class="hit">
                           <td class="line" data-tooltip>655</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        seneca: self,</td>
+                          <td class="source">      case: &#x27;INIT&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__656" class="hit">
                           <td class="line" data-tooltip>656</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      },</td>
+                          <td class="source">      data: argsarr,</td>
                           
                         </tr>            <tr id="lib/api.js__657" class="hit">
                           <td class="line" data-tooltip>657</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      data: {</td>
+                          <td class="source">      callpoint: callpoint(true),</td>
                           
                         </tr>            <tr id="lib/api.js__658" class="hit">
                           <td class="line" data-tooltip>658</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        plugin: {</td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__659" class="hit">
                           <td class="line" data-tooltip>659</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          // TODO: make this unique with a counter</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__660" class="hit">
+                        </tr>            <tr id="lib/api.js__660" class="chunks">
                           <td class="line" data-tooltip>660</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          name: &#x27;seneca_internal_client&#x27;,</td>
+                          <td class="source"><div>    var legacy &#x3D; </div><div class="miss true" data-tooltip>self.options().legacy</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
                           
-                        </tr>            <tr id="lib/api.js__661" class="hit">
+                        </tr>            <tr id="lib/api.js__661" class="chunks">
                           <td class="line" data-tooltip>661</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          tag: void 0,</td>
+                          <td class="source"><div>    var opts &#x3D; </div><div class="miss true" data-tooltip>self.options().transport</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
                           
                         </tr>            <tr id="lib/api.js__662" class="hit">
                           <td class="line" data-tooltip>662</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        },</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__663" class="hit">
                           <td class="line" data-tooltip>663</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      },</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var raw_config &#x3D; intern.parse_config(argsarr)</td>
                           
                         </tr>            <tr id="lib/api.js__664" class="hit">
                           <td class="line" data-tooltip>664</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__665" class="hit">
                           <td class="line" data-tooltip>665</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    // pg: pin group</td>
                           
                         </tr>            <tr id="lib/api.js__666" class="hit">
                           <td class="line" data-tooltip>666</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var sd &#x3D; task_res.out.delegate</td>
+                          <td class="source">    raw_config.pg &#x3D; Common.pincanon(raw_config.pin || raw_config.pins)</td>
                           
                         </tr>            <tr id="lib/api.js__667" class="hit">
                           <td class="line" data-tooltip>667</td>
@@ -16380,7 +16429,7 @@
                           <td class="line" data-tooltip>668</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var sendclient</td>
+                          <td class="source">    var config &#x3D; intern.resolve_config(raw_config, opts)</td>
                           
                         </tr>            <tr id="lib/api.js__669" class="hit">
                           <td class="line" data-tooltip>669</td>
@@ -16392,169 +16441,169 @@
                           <td class="line" data-tooltip>670</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var transport_client &#x3D; function transport_client(msg, reply, meta) {</td>
+                          <td class="source">    config.id &#x3D; config.id || Common.pattern(raw_config)</td>
                           
-                        </tr>            <tr id="lib/api.js__671" class="chunks">
+                        </tr>            <tr id="lib/api.js__671" class="hit">
                           <td class="line" data-tooltip>671</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>legacy.meta</div><div>) {</div></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__672" class="miss">
+                        </tr>            <tr id="lib/api.js__672" class="hit">
                           <td class="line" data-tooltip>672</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        meta &#x3D; meta || msg.meta$</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var pins &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__673" class="hit">
                           <td class="line" data-tooltip>673</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">      config.pins ||</td>
                           
-                        </tr>            <tr id="lib/api.js__674" class="hit">
+                        </tr>            <tr id="lib/api.js__674" class="chunks">
                           <td class="line" data-tooltip>674</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>      (</div><div class="miss false" data-tooltip>Array.isArray(config.pin)</div><div> ? </div><div class="miss never" data-tooltip>config.pin</div><div> : [config.pin || &#x27;&#x27;])</div></td>
                           
                         </tr>            <tr id="lib/api.js__675" class="hit">
                           <td class="line" data-tooltip>675</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      // Undefined plugin init actions pass through here when</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__676" class="hit">
                           <td class="line" data-tooltip>676</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      // there&#x27;s a catchall client, as they have local$:true</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    pins &#x3D; pins.map((pin) &#x3D;&gt; {</td>
                           
                         </tr>            <tr id="lib/api.js__677" class="hit">
                           <td class="line" data-tooltip>677</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>69</td>
-                          <td class="source">      if (meta.local) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      return &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pin ? Jsonic(pin) : pin</td>
                           
                         </tr>            <tr id="lib/api.js__678" class="hit">
                           <td class="line" data-tooltip>678</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">        this.prior(msg, reply)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
-                        </tr>            <tr id="lib/api.js__679" class="chunks">
+                        </tr>            <tr id="lib/api.js__679" class="hit">
                           <td class="line" data-tooltip>679</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      } else if (</div><div class="miss true" data-tooltip>sendclient</div><div> &amp;&amp; </div><div class="miss true" data-tooltip>sendclient.send</div><div>) {</div></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__680" class="chunks">
+                        </tr>            <tr id="lib/api.js__680" class="hit">
                           <td class="line" data-tooltip>680</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>legacy.meta</div><div>) {</div></td>
+                          <td class="source">    //var sd &#x3D; Plugins.make_delegate(self, {</td>
                           
-                        </tr>            <tr id="lib/api.js__681" class="miss">
+                        </tr>            <tr id="lib/api.js__681" class="hit">
                           <td class="line" data-tooltip>681</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>          msg.meta$ &#x3D; meta</td>
+                          <td class="source">    // TODO: review - this feels like a hack</td>
                           
                         </tr>            <tr id="lib/api.js__682" class="hit">
                           <td class="line" data-tooltip>682</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="source">    // perhaps we should instantiate a virtual plugin to represent the client?</td>
                           
                         </tr>            <tr id="lib/api.js__683" class="hit">
                           <td class="line" data-tooltip>683</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    // ... but is this necessary at all?</td>
                           
                         </tr>            <tr id="lib/api.js__684" class="hit">
                           <td class="line" data-tooltip>684</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>58</td>
-                          <td class="source">        sendclient.send.call(this, msg, reply, meta)</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var task_res &#x3D; self.order.plugin.task.delegate.exec({</td>
                           
                         </tr>            <tr id="lib/api.js__685" class="hit">
                           <td class="line" data-tooltip>685</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      } else {</td>
+                          <td class="source">      ctx: {</td>
                           
-                        </tr>            <tr id="lib/api.js__686" class="miss">
+                        </tr>            <tr id="lib/api.js__686" class="hit">
                           <td class="line" data-tooltip>686</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        this.log.error(&#x27;no-transport-client&#x27;, { config: config, msg: msg })</td>
+                          <td class="source">        seneca: self,</td>
                           
                         </tr>            <tr id="lib/api.js__687" class="hit">
                           <td class="line" data-tooltip>687</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">      },</td>
                           
                         </tr>            <tr id="lib/api.js__688" class="hit">
                           <td class="line" data-tooltip>688</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">      data: {</td>
                           
                         </tr>            <tr id="lib/api.js__689" class="hit">
                           <td class="line" data-tooltip>689</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">        plugin: {</td>
                           
                         </tr>            <tr id="lib/api.js__690" class="hit">
                           <td class="line" data-tooltip>690</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    transport_client.id &#x3D; config.id</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">          // TODO: make this unique with a counter</td>
                           
                         </tr>            <tr id="lib/api.js__691" class="hit">
                           <td class="line" data-tooltip>691</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">          name: &#x27;seneca_internal_client&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__692" class="hit">
                           <td class="line" data-tooltip>692</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    if (config.makehandle) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">          tag: void 0,</td>
                           
                         </tr>            <tr id="lib/api.js__693" class="hit">
                           <td class="line" data-tooltip>693</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      transport_client.handle &#x3D; config.makehandle(config)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        },</td>
                           
                         </tr>            <tr id="lib/api.js__694" class="hit">
                           <td class="line" data-tooltip>694</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">      },</td>
                           
                         </tr>            <tr id="lib/api.js__695" class="hit">
                           <td class="line" data-tooltip>695</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__696" class="hit">
                           <td class="line" data-tooltip>696</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    pins.forEach((pin) &#x3D;&gt; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__697" class="hit">
                           <td class="line" data-tooltip>697</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      pin &#x3D; Object.assign({}, pin)</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var sd &#x3D; task_res.out.delegate</td>
                           
                         </tr>            <tr id="lib/api.js__698" class="hit">
                           <td class="line" data-tooltip>698</td>
@@ -16565,92 +16614,92 @@
                         </tr>            <tr id="lib/api.js__699" class="hit">
                           <td class="line" data-tooltip>699</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      // Override local actions, including those more specific than</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var sendclient</td>
                           
                         </tr>            <tr id="lib/api.js__700" class="hit">
                           <td class="line" data-tooltip>700</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      // the client pattern</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__701" class="chunks">
+                        </tr>            <tr id="lib/api.js__701" class="hit">
                           <td class="line" data-tooltip>701</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>config.override</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var transport_client &#x3D; function transport_client(msg, reply, meta) {</td>
                           
-                        </tr>            <tr id="lib/api.js__702" class="miss">
+                        </tr>            <tr id="lib/api.js__702" class="chunks">
                           <td class="line" data-tooltip>702</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        sd.wrap(</td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>legacy.meta</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__703" class="hit">
+                        </tr>            <tr id="lib/api.js__703" class="miss">
                           <td class="line" data-tooltip>703</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          sd.util.clean(pin),</td>
+                          <td class="source" data-tooltip>        meta &#x3D; meta || msg.meta$</td>
                           
                         </tr>            <tr id="lib/api.js__704" class="hit">
                           <td class="line" data-tooltip>704</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          { client_pattern: sd.util.pattern(pin) },</td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__705" class="hit">
                           <td class="line" data-tooltip>705</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          transport_client</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__706" class="hit">
                           <td class="line" data-tooltip>706</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        )</td>
+                          <td class="source">      // Undefined plugin init actions pass through here when</td>
                           
                         </tr>            <tr id="lib/api.js__707" class="hit">
                           <td class="line" data-tooltip>707</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">      // there&#x27;s a catchall client, as they have local$:true</td>
                           
                         </tr>            <tr id="lib/api.js__708" class="hit">
                           <td class="line" data-tooltip>708</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>69</td>
+                          <td class="source">      if (meta.local) {</td>
                           
                         </tr>            <tr id="lib/api.js__709" class="hit">
                           <td class="line" data-tooltip>709</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>44</td>
-                          <td class="source">      pin.client$ &#x3D; true</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">        this.prior(msg, reply)</td>
                           
-                        </tr>            <tr id="lib/api.js__710" class="hit">
+                        </tr>            <tr id="lib/api.js__710" class="chunks">
                           <td class="line" data-tooltip>710</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>44</td>
-                          <td class="source">      pin.strict$ &#x3D; { add: true }</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>      } else if (</div><div class="miss true" data-tooltip>sendclient</div><div> &amp;&amp; </div><div class="miss true" data-tooltip>sendclient.send</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__711" class="hit">
+                        </tr>            <tr id="lib/api.js__711" class="chunks">
                           <td class="line" data-tooltip>711</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>legacy.meta</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__712" class="hit">
+                        </tr>            <tr id="lib/api.js__712" class="miss">
                           <td class="line" data-tooltip>712</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>44</td>
-                          <td class="source">      sd.add(pin, transport_client)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source" data-tooltip>          msg.meta$ &#x3D; meta</td>
                           
                         </tr>            <tr id="lib/api.js__713" class="hit">
                           <td class="line" data-tooltip>713</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__714" class="hit">
                           <td class="line" data-tooltip>714</td>
@@ -16661,86 +16710,86 @@
                         </tr>            <tr id="lib/api.js__715" class="hit">
                           <td class="line" data-tooltip>715</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    // Create client.</td>
+                          <td class="hits" data-tooltip>58</td>
+                          <td class="source">        sendclient.send.call(this, msg, reply, meta)</td>
                           
                         </tr>            <tr id="lib/api.js__716" class="hit">
                           <td class="line" data-tooltip>716</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    sd.act(</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      } else {</td>
                           
-                        </tr>            <tr id="lib/api.js__717" class="hit">
+                        </tr>            <tr id="lib/api.js__717" class="miss">
                           <td class="line" data-tooltip>717</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      &#x27;role:transport,cmd:client&#x27;,</td>
+                          <td class="source" data-tooltip>        this.log.error(&#x27;no-transport-client&#x27;, { config: config, msg: msg })</td>
                           
                         </tr>            <tr id="lib/api.js__718" class="hit">
                           <td class="line" data-tooltip>718</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      { config: config, gate$: true },</td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__719" class="hit">
                           <td class="line" data-tooltip>719</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      function (err, liveclient) {</td>
+                          <td class="source">    }</td>
                           
-                        </tr>            <tr id="lib/api.js__720" class="chunks">
+                        </tr>            <tr id="lib/api.js__720" class="hit">
                           <td class="line" data-tooltip>720</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>err</div><div>) {</div></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__721" class="miss">
+                        </tr>            <tr id="lib/api.js__721" class="hit">
                           <td class="line" data-tooltip>721</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>          return sd.die(private$.error(err, &#x27;transport_client&#x27;, config))</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    transport_client.id &#x3D; config.id</td>
                           
                         </tr>            <tr id="lib/api.js__722" class="hit">
                           <td class="line" data-tooltip>722</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__723" class="hit">
                           <td class="line" data-tooltip>723</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    if (config.makehandle) {</td>
                           
-                        </tr>            <tr id="lib/api.js__724" class="chunks">
+                        </tr>            <tr id="lib/api.js__724" class="hit">
                           <td class="line" data-tooltip>724</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>null &#x3D;&#x3D; liveclient</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      transport_client.handle &#x3D; config.makehandle(config)</td>
                           
-                        </tr>            <tr id="lib/api.js__725" class="miss">
+                        </tr>            <tr id="lib/api.js__725" class="hit">
                           <td class="line" data-tooltip>725</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>          return sd.die(</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__726" class="hit">
                           <td class="line" data-tooltip>726</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">            private$.error(&#x27;transport_client_null&#x27;, Common.clean(config))</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__727" class="hit">
                           <td class="line" data-tooltip>727</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">          )</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    pins.forEach((pin) &#x3D;&gt; {</td>
                           
                         </tr>            <tr id="lib/api.js__728" class="hit">
                           <td class="line" data-tooltip>728</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="source">      pin &#x3D; Object.assign({}, pin)</td>
                           
                         </tr>            <tr id="lib/api.js__729" class="hit">
                           <td class="line" data-tooltip>729</td>
@@ -16751,74 +16800,74 @@
                         </tr>            <tr id="lib/api.js__730" class="hit">
                           <td class="line" data-tooltip>730</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">        sendclient &#x3D; liveclient</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      // Override local actions, including those more specific than</td>
                           
                         </tr>            <tr id="lib/api.js__731" class="hit">
                           <td class="line" data-tooltip>731</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">      // the client pattern</td>
                           
-                        </tr>            <tr id="lib/api.js__732" class="hit">
+                        </tr>            <tr id="lib/api.js__732" class="chunks">
                           <td class="line" data-tooltip>732</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    )</td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>config.override</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__733" class="hit">
+                        </tr>            <tr id="lib/api.js__733" class="miss">
                           <td class="line" data-tooltip>733</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source" data-tooltip>        sd.wrap(</td>
                           
                         </tr>            <tr id="lib/api.js__734" class="hit">
                           <td class="line" data-tooltip>734</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    return self</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">          sd.util.clean(pin),</td>
                           
                         </tr>            <tr id="lib/api.js__735" class="hit">
                           <td class="line" data-tooltip>735</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">          { client_pattern: sd.util.pattern(pin) },</td>
                           
                         </tr>            <tr id="lib/api.js__736" class="hit">
                           <td class="line" data-tooltip>736</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">          transport_client</td>
                           
                         </tr>            <tr id="lib/api.js__737" class="hit">
                           <td class="line" data-tooltip>737</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">        )</td>
                           
                         </tr>            <tr id="lib/api.js__738" class="hit">
                           <td class="line" data-tooltip>738</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Inspired by https://github.com/hapijs/hapi/blob/master/lib/plugin.js decorate</td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__739" class="hit">
                           <td class="line" data-tooltip>739</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// TODO: convert to plugin configuration, with standard errors</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__740" class="hit">
                           <td class="line" data-tooltip>740</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.decorate &#x3D; function () {</td>
+                          <td class="hits" data-tooltip>44</td>
+                          <td class="source">      pin.client$ &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__741" class="hit">
                           <td class="line" data-tooltip>741</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var args &#x3D; Norma(&#x27;property:s value:.&#x27;, arguments)</td>
+                          <td class="hits" data-tooltip>44</td>
+                          <td class="source">      pin.strict$ &#x3D; { add: true }</td>
                           
                         </tr>            <tr id="lib/api.js__742" class="hit">
                           <td class="line" data-tooltip>742</td>
@@ -16829,308 +16878,308 @@
                         </tr>            <tr id="lib/api.js__743" class="hit">
                           <td class="line" data-tooltip>743</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>32</td>
-                          <td class="source">  var property &#x3D; args.property</td>
+                          <td class="hits" data-tooltip>44</td>
+                          <td class="source">      sd.add(pin, transport_client)</td>
                           
                         </tr>            <tr id="lib/api.js__744" class="hit">
                           <td class="line" data-tooltip>744</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>32</td>
-                          <td class="source">  Assert(property[0] !&#x3D;&#x3D; &#x27;_&#x27;, &#x27;property cannot start with _&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__745" class="hit">
                           <td class="line" data-tooltip>745</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>31</td>
-                          <td class="source">  Assert(</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__746" class="hit">
                           <td class="line" data-tooltip>746</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    this.private$.decorations[property] &#x3D;&#x3D;&#x3D; undefined,</td>
+                          <td class="source">    // Create client.</td>
                           
                         </tr>            <tr id="lib/api.js__747" class="hit">
                           <td class="line" data-tooltip>747</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;seneca is already decorated with the property: &#x27; + property</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    sd.act(</td>
                           
                         </tr>            <tr id="lib/api.js__748" class="hit">
                           <td class="line" data-tooltip>748</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  )</td>
+                          <td class="source">      &#x27;role:transport,cmd:client&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__749" class="hit">
                           <td class="line" data-tooltip>749</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>30</td>
-                          <td class="source">  Assert(</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      { config: config, gate$: true },</td>
                           
                         </tr>            <tr id="lib/api.js__750" class="hit">
                           <td class="line" data-tooltip>750</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    this.root[property] &#x3D;&#x3D;&#x3D; undefined,</td>
+                          <td class="source">      function (err, liveclient) {</td>
                           
-                        </tr>            <tr id="lib/api.js__751" class="hit">
+                        </tr>            <tr id="lib/api.js__751" class="chunks">
                           <td class="line" data-tooltip>751</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;cannot override a core seneca property: &#x27; + property</td>
+                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>err</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__752" class="hit">
+                        </tr>            <tr id="lib/api.js__752" class="miss">
                           <td class="line" data-tooltip>752</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  )</td>
+                          <td class="source" data-tooltip>          return sd.die(private$.error(err, &#x27;transport_client&#x27;, config))</td>
                           
                         </tr>            <tr id="lib/api.js__753" class="hit">
                           <td class="line" data-tooltip>753</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__754" class="hit">
                           <td class="line" data-tooltip>754</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>29</td>
-                          <td class="source">  this.root[property] &#x3D; this.private$.decorations[property] &#x3D; args.value</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__755" class="hit">
+                        </tr>            <tr id="lib/api.js__755" class="chunks">
                           <td class="line" data-tooltip>755</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>null &#x3D;&#x3D; liveclient</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__756" class="hit">
+                        </tr>            <tr id="lib/api.js__756" class="miss">
                           <td class="line" data-tooltip>756</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source" data-tooltip>          return sd.die(</td>
                           
                         </tr>            <tr id="lib/api.js__757" class="hit">
                           <td class="line" data-tooltip>757</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">intern.parse_config &#x3D; function (args) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">            private$.error(&#x27;transport_client_null&#x27;, Common.clean(config))</td>
                           
                         </tr>            <tr id="lib/api.js__758" class="hit">
                           <td class="line" data-tooltip>758</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var out &#x3D; {}</td>
+                          <td class="source">          )</td>
                           
                         </tr>            <tr id="lib/api.js__759" class="hit">
                           <td class="line" data-tooltip>759</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__760" class="hit">
                           <td class="line" data-tooltip>760</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  var config &#x3D; args.filter((x) &#x3D;&gt; null !&#x3D; x)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__761" class="hit">
                           <td class="line" data-tooltip>761</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">        sendclient &#x3D; liveclient</td>
                           
                         </tr>            <tr id="lib/api.js__762" class="hit">
                           <td class="line" data-tooltip>762</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  var arglen &#x3D; config.length</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__763" class="hit">
                           <td class="line" data-tooltip>763</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    )</td>
                           
                         </tr>            <tr id="lib/api.js__764" class="hit">
                           <td class="line" data-tooltip>764</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // TODO: use Joi for better error msgs</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__765" class="hit">
                           <td class="line" data-tooltip>765</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    return self</td>
                           
                         </tr>            <tr id="lib/api.js__766" class="hit">
                           <td class="line" data-tooltip>766</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  if (arglen &#x3D;&#x3D;&#x3D; 1) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
-                        </tr>            <tr id="lib/api.js__767" class="chunks">
+                        </tr>            <tr id="lib/api.js__767" class="hit">
                           <td class="line" data-tooltip>767</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof config[0] &amp;&amp; </div><div class="miss true" data-tooltip>null !&#x3D; config[0]</div><div>) {</div></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__768" class="hit">
                           <td class="line" data-tooltip>768</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>63</td>
-                          <td class="source">      out &#x3D; Object.assign({}, config[0])</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__769" class="hit">
                           <td class="line" data-tooltip>769</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    } else {</td>
+                          <td class="source">// Inspired by https://github.com/hapijs/hapi/blob/master/lib/plugin.js decorate</td>
                           
                         </tr>            <tr id="lib/api.js__770" class="hit">
                           <td class="line" data-tooltip>770</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
-                          <td class="source">      out.port &#x3D; parseInt(config[0], 10)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">// TODO: convert to plugin configuration, with standard errors</td>
                           
                         </tr>            <tr id="lib/api.js__771" class="hit">
                           <td class="line" data-tooltip>771</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.decorate &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__772" class="hit">
                           <td class="line" data-tooltip>772</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10</td>
-                          <td class="source">  } else if (arglen &#x3D;&#x3D;&#x3D; 2) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var args &#x3D; Norma(&#x27;property:s value:.&#x27;, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__773" class="hit">
                           <td class="line" data-tooltip>773</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    out.port &#x3D; parseInt(config[0], 10)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__774" class="hit">
                           <td class="line" data-tooltip>774</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    out.host &#x3D; config[1]</td>
+                          <td class="hits" data-tooltip>32</td>
+                          <td class="source">  var property &#x3D; args.property</td>
                           
                         </tr>            <tr id="lib/api.js__775" class="hit">
                           <td class="line" data-tooltip>775</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
-                          <td class="source">  } else if (arglen &#x3D;&#x3D;&#x3D; 3) {</td>
+                          <td class="hits" data-tooltip>32</td>
+                          <td class="source">  Assert(property[0] !&#x3D;&#x3D; &#x27;_&#x27;, &#x27;property cannot start with _&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__776" class="hit">
                           <td class="line" data-tooltip>776</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    out.port &#x3D; parseInt(config[0], 10)</td>
+                          <td class="hits" data-tooltip>31</td>
+                          <td class="source">  Assert(</td>
                           
                         </tr>            <tr id="lib/api.js__777" class="hit">
                           <td class="line" data-tooltip>777</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    out.host &#x3D; config[1]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    this.private$.decorations[property] &#x3D;&#x3D;&#x3D; undefined,</td>
                           
                         </tr>            <tr id="lib/api.js__778" class="hit">
                           <td class="line" data-tooltip>778</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    out.path &#x3D; config[2]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    &#x27;seneca is already decorated with the property: &#x27; + property</td>
                           
                         </tr>            <tr id="lib/api.js__779" class="hit">
                           <td class="line" data-tooltip>779</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">  )</td>
                           
                         </tr>            <tr id="lib/api.js__780" class="hit">
                           <td class="line" data-tooltip>780</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>30</td>
+                          <td class="source">  Assert(</td>
                           
                         </tr>            <tr id="lib/api.js__781" class="hit">
                           <td class="line" data-tooltip>781</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  return out</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    this.root[property] &#x3D;&#x3D;&#x3D; undefined,</td>
                           
                         </tr>            <tr id="lib/api.js__782" class="hit">
                           <td class="line" data-tooltip>782</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    &#x27;cannot override a core seneca property: &#x27; + property</td>
                           
                         </tr>            <tr id="lib/api.js__783" class="hit">
                           <td class="line" data-tooltip>783</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  )</td>
                           
                         </tr>            <tr id="lib/api.js__784" class="hit">
                           <td class="line" data-tooltip>784</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">intern.resolve_config &#x3D; function (config, options) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__785" class="hit">
                           <td class="line" data-tooltip>785</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var out &#x3D; Object.assign({}, config)</td>
+                          <td class="hits" data-tooltip>29</td>
+                          <td class="source">  this.root[property] &#x3D; this.private$.decorations[property] &#x3D; args.value</td>
                           
                         </tr>            <tr id="lib/api.js__786" class="hit">
                           <td class="line" data-tooltip>786</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__787" class="hit">
                           <td class="line" data-tooltip>787</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  Object.keys(options).forEach((key) &#x3D;&gt; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__788" class="hit">
                           <td class="line" data-tooltip>788</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    var value &#x3D; options[key]</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">intern.parse_config &#x3D; function (args) {</td>
                           
                         </tr>            <tr id="lib/api.js__789" class="hit">
                           <td class="line" data-tooltip>789</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>241</td>
-                          <td class="source">    if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof value) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var out &#x3D; {}</td>
                           
                         </tr>            <tr id="lib/api.js__790" class="hit">
                           <td class="line" data-tooltip>790</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>13</td>
-                          <td class="source">      return</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__791" class="hit">
                           <td class="line" data-tooltip>791</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  var config &#x3D; args.filter((x) &#x3D;&gt; null !&#x3D; x)</td>
                           
                         </tr>            <tr id="lib/api.js__792" class="hit">
                           <td class="line" data-tooltip>792</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>228</td>
-                          <td class="source">    out[key] &#x3D; out[key] &#x3D;&#x3D;&#x3D; void 0 ? value : out[key]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__793" class="hit">
                           <td class="line" data-tooltip>793</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  })</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  var arglen &#x3D; config.length</td>
                           
                         </tr>            <tr id="lib/api.js__794" class="hit">
                           <td class="line" data-tooltip>794</td>
@@ -17142,241 +17191,241 @@
                           <td class="line" data-tooltip>795</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // Default transport is web</td>
+                          <td class="source">  // TODO: use Joi for better error msgs</td>
                           
                         </tr>            <tr id="lib/api.js__796" class="hit">
                           <td class="line" data-tooltip>796</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  out.type &#x3D; out.type || &#x27;web&#x27;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__797" class="hit">
                           <td class="line" data-tooltip>797</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  if (arglen &#x3D;&#x3D;&#x3D; 1) {</td>
                           
-                        </tr>            <tr id="lib/api.js__798" class="hit">
+                        </tr>            <tr id="lib/api.js__798" class="chunks">
                           <td class="line" data-tooltip>798</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // DEPRECATED: Remove in 4.0</td>
+                          <td class="source"><div>    if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof config[0] &amp;&amp; </div><div class="miss true" data-tooltip>null !&#x3D; config[0]</div><div>) {</div></td>
                           
                         </tr>            <tr id="lib/api.js__799" class="hit">
                           <td class="line" data-tooltip>799</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  if (out.type &#x3D;&#x3D;&#x3D; &#x27;direct&#x27; || out.type &#x3D;&#x3D;&#x3D; &#x27;http&#x27;) {</td>
+                          <td class="hits" data-tooltip>63</td>
+                          <td class="source">      out &#x3D; Object.assign({}, config[0])</td>
                           
                         </tr>            <tr id="lib/api.js__800" class="hit">
                           <td class="line" data-tooltip>800</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    out.type &#x3D; &#x27;web&#x27;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    } else {</td>
                           
                         </tr>            <tr id="lib/api.js__801" class="hit">
                           <td class="line" data-tooltip>801</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>17</td>
+                          <td class="source">      out.port &#x3D; parseInt(config[0], 10)</td>
                           
                         </tr>            <tr id="lib/api.js__802" class="hit">
                           <td class="line" data-tooltip>802</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__803" class="hit">
                           <td class="line" data-tooltip>803</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  var base &#x3D; options[out.type] || {}</td>
+                          <td class="hits" data-tooltip>10</td>
+                          <td class="source">  } else if (arglen &#x3D;&#x3D;&#x3D; 2) {</td>
                           
                         </tr>            <tr id="lib/api.js__804" class="hit">
                           <td class="line" data-tooltip>804</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    out.port &#x3D; parseInt(config[0], 10)</td>
                           
                         </tr>            <tr id="lib/api.js__805" class="hit">
                           <td class="line" data-tooltip>805</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  out &#x3D; Object.assign({}, base, out)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    out.host &#x3D; config[1]</td>
                           
                         </tr>            <tr id="lib/api.js__806" class="hit">
                           <td class="line" data-tooltip>806</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>9</td>
+                          <td class="source">  } else if (arglen &#x3D;&#x3D;&#x3D; 3) {</td>
                           
                         </tr>            <tr id="lib/api.js__807" class="hit">
                           <td class="line" data-tooltip>807</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  if (out.type &#x3D;&#x3D;&#x3D; &#x27;web&#x27; || out.type &#x3D;&#x3D;&#x3D; &#x27;tcp&#x27;) {</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    out.port &#x3D; parseInt(config[0], 10)</td>
                           
-                        </tr>            <tr id="lib/api.js__808" class="chunks">
+                        </tr>            <tr id="lib/api.js__808" class="hit">
                           <td class="line" data-tooltip>808</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    out.port &#x3D; </div><div class="miss false" data-tooltip>out.port &#x3D;&#x3D; null</div><div> ? </div><div class="miss never" data-tooltip>base.port</div><div> : out.port</div></td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    out.host &#x3D; config[1]</td>
                           
                         </tr>            <tr id="lib/api.js__809" class="hit">
                           <td class="line" data-tooltip>809</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>53</td>
-                          <td class="source">    out.host &#x3D; out.host &#x3D;&#x3D; null ? base.host : out.host</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    out.path &#x3D; config[2]</td>
                           
                         </tr>            <tr id="lib/api.js__810" class="hit">
                           <td class="line" data-tooltip>810</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>53</td>
-                          <td class="source">    out.path &#x3D; out.path &#x3D;&#x3D; null ? base.path : out.path</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__811" class="hit">
                           <td class="line" data-tooltip>811</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__812" class="hit">
                           <td class="line" data-tooltip>812</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  return out</td>
                           
                         </tr>            <tr id="lib/api.js__813" class="hit">
                           <td class="line" data-tooltip>813</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  return out</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__814" class="hit">
                           <td class="line" data-tooltip>814</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__815" class="hit">
                           <td class="line" data-tooltip>815</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">intern.resolve_config &#x3D; function (config, options) {</td>
                           
                         </tr>            <tr id="lib/api.js__816" class="hit">
                           <td class="line" data-tooltip>816</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">intern.close &#x3D; function (callpoint, done) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var out &#x3D; Object.assign({}, config)</td>
                           
                         </tr>            <tr id="lib/api.js__817" class="hit">
                           <td class="line" data-tooltip>817</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var seneca &#x3D; this</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__818" class="hit">
                           <td class="line" data-tooltip>818</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">  var options &#x3D; seneca.options()</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  Object.keys(options).forEach((key) &#x3D;&gt; {</td>
                           
                         </tr>            <tr id="lib/api.js__819" class="hit">
                           <td class="line" data-tooltip>819</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    var value &#x3D; options[key]</td>
                           
                         </tr>            <tr id="lib/api.js__820" class="hit">
                           <td class="line" data-tooltip>820</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">  var done_called &#x3D; false</td>
+                          <td class="hits" data-tooltip>241</td>
+                          <td class="source">    if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof value) {</td>
                           
                         </tr>            <tr id="lib/api.js__821" class="hit">
                           <td class="line" data-tooltip>821</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">  var safe_done &#x3D; function safe_done(err) {</td>
+                          <td class="hits" data-tooltip>13</td>
+                          <td class="source">      return</td>
                           
                         </tr>            <tr id="lib/api.js__822" class="hit">
                           <td class="line" data-tooltip>822</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    if (!done_called &amp;&amp; &#x27;function&#x27; &#x3D;&#x3D;&#x3D; typeof done) {</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__823" class="hit">
                           <td class="line" data-tooltip>823</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      done_called &#x3D; true</td>
+                          <td class="hits" data-tooltip>228</td>
+                          <td class="source">    out[key] &#x3D; out[key] &#x3D;&#x3D;&#x3D; void 0 ? value : out[key]</td>
                           
                         </tr>            <tr id="lib/api.js__824" class="hit">
                           <td class="line" data-tooltip>824</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      return done.call(seneca, err)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  })</td>
                           
                         </tr>            <tr id="lib/api.js__825" class="hit">
                           <td class="line" data-tooltip>825</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__826" class="hit">
                           <td class="line" data-tooltip>826</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">  // Default transport is web</td>
                           
                         </tr>            <tr id="lib/api.js__827" class="hit">
                           <td class="line" data-tooltip>827</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  out.type &#x3D; out.type || &#x27;web&#x27;</td>
                           
                         </tr>            <tr id="lib/api.js__828" class="hit">
                           <td class="line" data-tooltip>828</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // don&#x27;t try to close twice</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__829" class="hit">
                           <td class="line" data-tooltip>829</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">  if (seneca.flags.closed) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // DEPRECATED: Remove in 4.0</td>
                           
                         </tr>            <tr id="lib/api.js__830" class="hit">
                           <td class="line" data-tooltip>830</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    return safe_done()</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  if (out.type &#x3D;&#x3D;&#x3D; &#x27;direct&#x27; || out.type &#x3D;&#x3D;&#x3D; &#x27;http&#x27;) {</td>
                           
                         </tr>            <tr id="lib/api.js__831" class="hit">
                           <td class="line" data-tooltip>831</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    out.type &#x3D; &#x27;web&#x27;</td>
                           
                         </tr>            <tr id="lib/api.js__832" class="hit">
                           <td class="line" data-tooltip>832</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__833" class="hit">
                           <td class="line" data-tooltip>833</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">  seneca.ready(do_close)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__834" class="hit">
                           <td class="line" data-tooltip>834</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">  var close_timeout &#x3D; setTimeout(do_close, options.close_delay)</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  var base &#x3D; options[out.type] || {}</td>
                           
                         </tr>            <tr id="lib/api.js__835" class="hit">
                           <td class="line" data-tooltip>835</td>
@@ -17387,164 +17436,164 @@
                         </tr>            <tr id="lib/api.js__836" class="hit">
                           <td class="line" data-tooltip>836</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  function do_close() {</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  out &#x3D; Object.assign({}, base, out)</td>
                           
                         </tr>            <tr id="lib/api.js__837" class="hit">
                           <td class="line" data-tooltip>837</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">    clearTimeout(close_timeout)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__838" class="hit">
                           <td class="line" data-tooltip>838</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  if (out.type &#x3D;&#x3D;&#x3D; &#x27;web&#x27; || out.type &#x3D;&#x3D;&#x3D; &#x27;tcp&#x27;) {</td>
                           
-                        </tr>            <tr id="lib/api.js__839" class="hit">
+                        </tr>            <tr id="lib/api.js__839" class="chunks">
                           <td class="line" data-tooltip>839</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">    if (seneca.flags.closed) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>    out.port &#x3D; </div><div class="miss false" data-tooltip>out.port &#x3D;&#x3D; null</div><div> ? </div><div class="miss never" data-tooltip>base.port</div><div> : out.port</div></td>
                           
                         </tr>            <tr id="lib/api.js__840" class="hit">
                           <td class="line" data-tooltip>840</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      return safe_done()</td>
+                          <td class="hits" data-tooltip>53</td>
+                          <td class="source">    out.host &#x3D; out.host &#x3D;&#x3D; null ? base.host : out.host</td>
                           
                         </tr>            <tr id="lib/api.js__841" class="hit">
                           <td class="line" data-tooltip>841</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>53</td>
+                          <td class="source">    out.path &#x3D; out.path &#x3D;&#x3D; null ? base.path : out.path</td>
                           
                         </tr>            <tr id="lib/api.js__842" class="hit">
                           <td class="line" data-tooltip>842</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__843" class="hit">
                           <td class="line" data-tooltip>843</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // TODO: remove in 4.x</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__844" class="hit">
                           <td class="line" data-tooltip>844</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">    seneca.closed &#x3D; true</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  return out</td>
                           
                         </tr>            <tr id="lib/api.js__845" class="hit">
                           <td class="line" data-tooltip>845</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__846" class="hit">
                           <td class="line" data-tooltip>846</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">    seneca.flags.closed &#x3D; true</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__847" class="hit">
                           <td class="line" data-tooltip>847</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">intern.close &#x3D; function (callpoint, done) {</td>
                           
                         </tr>            <tr id="lib/api.js__848" class="hit">
                           <td class="line" data-tooltip>848</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // cleanup process event listeners</td>
+                          <td class="source">  var seneca &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__849" class="hit">
                           <td class="line" data-tooltip>849</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">    Common.each(options.system.close_signals, function (active, signal) {</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">  var options &#x3D; seneca.options()</td>
                           
-                        </tr>            <tr id="lib/api.js__850" class="chunks">
+                        </tr>            <tr id="lib/api.js__850" class="hit">
                           <td class="line" data-tooltip>850</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>active</div><div>) {</div></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__851" class="miss">
+                        </tr>            <tr id="lib/api.js__851" class="hit">
                           <td class="line" data-tooltip>851</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        process.removeListener(signal, seneca.private$.exit_close)</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">  var done_called &#x3D; false</td>
                           
                         </tr>            <tr id="lib/api.js__852" class="hit">
                           <td class="line" data-tooltip>852</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">  var safe_done &#x3D; function safe_done(err) {</td>
                           
                         </tr>            <tr id="lib/api.js__853" class="hit">
                           <td class="line" data-tooltip>853</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source">    if (!done_called &amp;&amp; &#x27;function&#x27; &#x3D;&#x3D;&#x3D; typeof done) {</td>
                           
                         </tr>            <tr id="lib/api.js__854" class="hit">
                           <td class="line" data-tooltip>854</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      done_called &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__855" class="hit">
                           <td class="line" data-tooltip>855</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">    seneca.log.debug({</td>
+                          <td class="source">      return done.call(seneca, err)</td>
                           
                         </tr>            <tr id="lib/api.js__856" class="hit">
                           <td class="line" data-tooltip>856</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      kind: &#x27;close&#x27;,</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__857" class="hit">
                           <td class="line" data-tooltip>857</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      notice: &#x27;start&#x27;,</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__858" class="hit">
                           <td class="line" data-tooltip>858</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      callpoint: callpoint(true),</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__859" class="hit">
                           <td class="line" data-tooltip>859</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source">  // don&#x27;t try to close twice</td>
                           
                         </tr>            <tr id="lib/api.js__860" class="hit">
                           <td class="line" data-tooltip>860</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">  if (seneca.flags.closed) {</td>
                           
                         </tr>            <tr id="lib/api.js__861" class="hit">
                           <td class="line" data-tooltip>861</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">    seneca.act(&#x27;role:seneca,cmd:close,closing$:true&#x27;, function (err) {</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    return safe_done()</td>
                           
                         </tr>            <tr id="lib/api.js__862" class="hit">
                           <td class="line" data-tooltip>862</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      seneca.log.debug(errlog(err, { kind: &#x27;close&#x27;, notice: &#x27;end&#x27; }))</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__863" class="hit">
                           <td class="line" data-tooltip>863</td>
@@ -17556,73 +17605,73 @@
                           <td class="line" data-tooltip>864</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;act-in&#x27;)</td>
+                          <td class="source">  seneca.ready(do_close)</td>
                           
                         </tr>            <tr id="lib/api.js__865" class="hit">
                           <td class="line" data-tooltip>865</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;act-out&#x27;)</td>
+                          <td class="source">  var close_timeout &#x3D; setTimeout(do_close, options.close_delay)</td>
                           
                         </tr>            <tr id="lib/api.js__866" class="hit">
                           <td class="line" data-tooltip>866</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;act-err&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__867" class="hit">
                           <td class="line" data-tooltip>867</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;pin&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  function do_close() {</td>
                           
                         </tr>            <tr id="lib/api.js__868" class="hit">
                           <td class="line" data-tooltip>868</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;after-pin&#x27;)</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">    clearTimeout(close_timeout)</td>
                           
                         </tr>            <tr id="lib/api.js__869" class="hit">
                           <td class="line" data-tooltip>869</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;ready&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__870" class="hit">
                           <td class="line" data-tooltip>870</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">    if (seneca.flags.closed) {</td>
                           
                         </tr>            <tr id="lib/api.js__871" class="hit">
                           <td class="line" data-tooltip>871</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.private$.history.close()</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      return safe_done()</td>
                           
                         </tr>            <tr id="lib/api.js__872" class="hit">
                           <td class="line" data-tooltip>872</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    }</td>
                           
-                        </tr>            <tr id="lib/api.js__873" class="chunks">
+                        </tr>            <tr id="lib/api.js__873" class="hit">
                           <td class="line" data-tooltip>873</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>seneca.private$.status_interval</div><div>) {</div></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__874" class="miss">
+                        </tr>            <tr id="lib/api.js__874" class="hit">
                           <td class="line" data-tooltip>874</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        clearInterval(seneca.private$.status_interval)</td>
+                          <td class="source">    // TODO: remove in 4.x</td>
                           
                         </tr>            <tr id="lib/api.js__875" class="hit">
                           <td class="line" data-tooltip>875</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">    seneca.closed &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__876" class="hit">
                           <td class="line" data-tooltip>876</td>
@@ -17634,79 +17683,79 @@
                           <td class="line" data-tooltip>877</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">      return safe_done(err)</td>
+                          <td class="source">    seneca.flags.closed &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__878" class="hit">
                           <td class="line" data-tooltip>878</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__879" class="hit">
                           <td class="line" data-tooltip>879</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    // cleanup process event listeners</td>
                           
                         </tr>            <tr id="lib/api.js__880" class="hit">
                           <td class="line" data-tooltip>880</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">    Common.each(options.system.close_signals, function (active, signal) {</td>
                           
-                        </tr>            <tr id="lib/api.js__881" class="hit">
+                        </tr>            <tr id="lib/api.js__881" class="chunks">
                           <td class="line" data-tooltip>881</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">  return seneca</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>active</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__882" class="hit">
+                        </tr>            <tr id="lib/api.js__882" class="miss">
                           <td class="line" data-tooltip>882</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source" data-tooltip>        process.removeListener(signal, seneca.private$.exit_close)</td>
                           
                         </tr>            <tr id="lib/api.js__883" class="hit">
                           <td class="line" data-tooltip>883</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__884" class="hit">
                           <td class="line" data-tooltip>884</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">intern.fix_args &#x3D; function (origargs, patargs, msgargs, custom) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__885" class="hit">
                           <td class="line" data-tooltip>885</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var args &#x3D; Common.parsePattern(this, origargs, &#x27;rest:.*&#x27;, patargs)</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__886" class="hit">
                           <td class="line" data-tooltip>886</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  var fixargs &#x3D; [args.pattern]</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">    seneca.log.debug({</td>
                           
                         </tr>            <tr id="lib/api.js__887" class="hit">
                           <td class="line" data-tooltip>887</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    .concat({</td>
+                          <td class="source">      kind: &#x27;close&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__888" class="hit">
                           <td class="line" data-tooltip>888</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      fixed$: Object.assign({}, msgargs, args.pattern.fixed$),</td>
+                          <td class="source">      notice: &#x27;start&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__889" class="hit">
                           <td class="line" data-tooltip>889</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      custom$: Object.assign({}, custom, args.pattern.custom$),</td>
+                          <td class="source">      callpoint: callpoint(true),</td>
                           
                         </tr>            <tr id="lib/api.js__890" class="hit">
                           <td class="line" data-tooltip>890</td>
@@ -17718,22 +17767,208 @@
                           <td class="line" data-tooltip>891</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    .concat(args.rest)</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__892" class="hit">
                           <td class="line" data-tooltip>892</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  return fixargs</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">    seneca.act(&#x27;role:seneca,cmd:close,closing$:true&#x27;, function (err) {</td>
                           
                         </tr>            <tr id="lib/api.js__893" class="hit">
                           <td class="line" data-tooltip>893</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">      seneca.log.debug(errlog(err, { kind: &#x27;close&#x27;, notice: &#x27;end&#x27; }))</td>
                           
                         </tr>            <tr id="lib/api.js__894" class="hit">
                           <td class="line" data-tooltip>894</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
+                          
+                        </tr>            <tr id="lib/api.js__895" class="hit">
+                          <td class="line" data-tooltip>895</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;act-in&#x27;)</td>
+                          
+                        </tr>            <tr id="lib/api.js__896" class="hit">
+                          <td class="line" data-tooltip>896</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;act-out&#x27;)</td>
+                          
+                        </tr>            <tr id="lib/api.js__897" class="hit">
+                          <td class="line" data-tooltip>897</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;act-err&#x27;)</td>
+                          
+                        </tr>            <tr id="lib/api.js__898" class="hit">
+                          <td class="line" data-tooltip>898</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;pin&#x27;)</td>
+                          
+                        </tr>            <tr id="lib/api.js__899" class="hit">
+                          <td class="line" data-tooltip>899</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;after-pin&#x27;)</td>
+                          
+                        </tr>            <tr id="lib/api.js__900" class="hit">
+                          <td class="line" data-tooltip>900</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;ready&#x27;)</td>
+                          
+                        </tr>            <tr id="lib/api.js__901" class="hit">
+                          <td class="line" data-tooltip>901</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
+                          
+                        </tr>            <tr id="lib/api.js__902" class="hit">
+                          <td class="line" data-tooltip>902</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.private$.history.close()</td>
+                          
+                        </tr>            <tr id="lib/api.js__903" class="hit">
+                          <td class="line" data-tooltip>903</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
+                          
+                        </tr>            <tr id="lib/api.js__904" class="chunks">
+                          <td class="line" data-tooltip>904</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>seneca.private$.status_interval</div><div>) {</div></td>
+                          
+                        </tr>            <tr id="lib/api.js__905" class="miss">
+                          <td class="line" data-tooltip>905</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source" data-tooltip>        clearInterval(seneca.private$.status_interval)</td>
+                          
+                        </tr>            <tr id="lib/api.js__906" class="hit">
+                          <td class="line" data-tooltip>906</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      }</td>
+                          
+                        </tr>            <tr id="lib/api.js__907" class="hit">
+                          <td class="line" data-tooltip>907</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
+                          
+                        </tr>            <tr id="lib/api.js__908" class="hit">
+                          <td class="line" data-tooltip>908</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      return safe_done(err)</td>
+                          
+                        </tr>            <tr id="lib/api.js__909" class="hit">
+                          <td class="line" data-tooltip>909</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
+                          
+                        </tr>            <tr id="lib/api.js__910" class="hit">
+                          <td class="line" data-tooltip>910</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
+                          
+                        </tr>            <tr id="lib/api.js__911" class="hit">
+                          <td class="line" data-tooltip>911</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
+                          
+                        </tr>            <tr id="lib/api.js__912" class="hit">
+                          <td class="line" data-tooltip>912</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">  return seneca</td>
+                          
+                        </tr>            <tr id="lib/api.js__913" class="hit">
+                          <td class="line" data-tooltip>913</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
+                          
+                        </tr>            <tr id="lib/api.js__914" class="hit">
+                          <td class="line" data-tooltip>914</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
+                          
+                        </tr>            <tr id="lib/api.js__915" class="hit">
+                          <td class="line" data-tooltip>915</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">intern.fix_args &#x3D; function (origargs, patargs, msgargs, custom) {</td>
+                          
+                        </tr>            <tr id="lib/api.js__916" class="hit">
+                          <td class="line" data-tooltip>916</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var args &#x3D; Common.parsePattern(this, origargs, &#x27;rest:.*&#x27;, patargs)</td>
+                          
+                        </tr>            <tr id="lib/api.js__917" class="hit">
+                          <td class="line" data-tooltip>917</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  var fixargs &#x3D; [args.pattern]</td>
+                          
+                        </tr>            <tr id="lib/api.js__918" class="hit">
+                          <td class="line" data-tooltip>918</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    .concat({</td>
+                          
+                        </tr>            <tr id="lib/api.js__919" class="hit">
+                          <td class="line" data-tooltip>919</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      fixed$: Object.assign({}, msgargs, args.pattern.fixed$),</td>
+                          
+                        </tr>            <tr id="lib/api.js__920" class="hit">
+                          <td class="line" data-tooltip>920</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      custom$: Object.assign({}, custom, args.pattern.custom$),</td>
+                          
+                        </tr>            <tr id="lib/api.js__921" class="hit">
+                          <td class="line" data-tooltip>921</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
+                          
+                        </tr>            <tr id="lib/api.js__922" class="hit">
+                          <td class="line" data-tooltip>922</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    .concat(args.rest)</td>
+                          
+                        </tr>            <tr id="lib/api.js__923" class="hit">
+                          <td class="line" data-tooltip>923</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  return fixargs</td>
+                          
+                        </tr>            <tr id="lib/api.js__924" class="hit">
+                          <td class="line" data-tooltip>924</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
+                          
+                        </tr>            <tr id="lib/api.js__925" class="hit">
+                          <td class="line" data-tooltip>925</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
@@ -17744,10 +17979,10 @@
             <div class="file ">
                 <h2 id="lib/common.js">lib/common.js </h2>
                 <div class="stats high">
-                    <div class="percentage">87.69%</div>
+                    <div class="percentage">87.86%</div>
                     <div class="sloc">585</div>
-                    <div class="hits">513</div>
-                    <div class="misses">72</div>
+                    <div class="hits">514</div>
+                    <div class="misses">71</div>
                 </div>
                 <table>
                     <thead>
@@ -19269,7 +19504,7 @@
                         </tr>            <tr id="lib/common.js__252" class="hit">
                           <td class="line" data-tooltip>252</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>23639</td>
+                          <td class="hits" data-tooltip>23647</td>
                           <td class="source">  if (null &#x3D;&#x3D; obj) return obj</td>
                           
                         </tr>            <tr id="lib/common.js__253" class="hit">
@@ -19281,7 +19516,7 @@
                         </tr>            <tr id="lib/common.js__254" class="hit">
                           <td class="line" data-tooltip>254</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>23633</td>
+                          <td class="hits" data-tooltip>23641</td>
                           <td class="source">  var out &#x3D; Array.isArray(obj) ? [] : {}</td>
                           
                         </tr>            <tr id="lib/common.js__255" class="hit">
@@ -19293,19 +19528,19 @@
                         </tr>            <tr id="lib/common.js__256" class="hit">
                           <td class="line" data-tooltip>256</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>23633</td>
+                          <td class="hits" data-tooltip>23641</td>
                           <td class="source">  var pn &#x3D; Object.getOwnPropertyNames(obj)</td>
                           
                         </tr>            <tr id="lib/common.js__257" class="hit">
                           <td class="line" data-tooltip>257</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>23633</td>
+                          <td class="hits" data-tooltip>23641</td>
                           <td class="source">  for (var i &#x3D; 0; i &lt; pn.length; i++) {</td>
                           
                         </tr>            <tr id="lib/common.js__258" class="hit">
                           <td class="line" data-tooltip>258</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77689</td>
+                          <td class="hits" data-tooltip>77752</td>
                           <td class="source">    var p &#x3D; pn[i]</td>
                           
                         </tr>            <tr id="lib/common.js__259" class="hit">
@@ -19317,13 +19552,13 @@
                         </tr>            <tr id="lib/common.js__260" class="hit">
                           <td class="line" data-tooltip>260</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77689</td>
+                          <td class="hits" data-tooltip>77752</td>
                           <td class="source">    if (&#x27;$&#x27; !&#x3D; p[p.length - 1]) {</td>
                           
                         </tr>            <tr id="lib/common.js__261" class="hit">
                           <td class="line" data-tooltip>261</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>63782</td>
+                          <td class="hits" data-tooltip>63829</td>
                           <td class="source">      out[p] &#x3D; obj[p]</td>
                           
                         </tr>            <tr id="lib/common.js__262" class="hit">
@@ -19371,7 +19606,7 @@
                         </tr>            <tr id="lib/common.js__269" class="hit">
                           <td class="line" data-tooltip>269</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>23633</td>
+                          <td class="hits" data-tooltip>23641</td>
                           <td class="source">  return out</td>
                           
                         </tr>            <tr id="lib/common.js__270" class="hit">
@@ -19779,7 +20014,7 @@
                         </tr>            <tr id="lib/common.js__337" class="hit">
                           <td class="line" data-tooltip>337</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>25</td>
                           <td class="source">    var test &#x3D; so.test</td>
                           
                         </tr>            <tr id="lib/common.js__338" class="hit">
@@ -19803,7 +20038,7 @@
                         </tr>            <tr id="lib/common.js__341" class="hit">
                           <td class="line" data-tooltip>341</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>25</td>
                           <td class="source">    var full &#x3D;</td>
                           
                         </tr>            <tr id="lib/common.js__342" class="chunks">
@@ -19827,7 +20062,7 @@
                         </tr>            <tr id="lib/common.js__345" class="hit">
                           <td class="line" data-tooltip>345</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>25</td>
                           <td class="source">    if (0 &lt; diecount) {</td>
                           
                         </tr>            <tr id="lib/common.js__346" class="chunks">
@@ -19863,7 +20098,7 @@
                         </tr>            <tr id="lib/common.js__351" class="hit">
                           <td class="line" data-tooltip>351</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">      diecount++</td>
                           
                         </tr>            <tr id="lib/common.js__352" class="hit">
@@ -19881,7 +20116,7 @@
                         </tr>            <tr id="lib/common.js__354" class="hit">
                           <td class="line" data-tooltip>354</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">    try {</td>
                           
                         </tr>            <tr id="lib/common.js__355" class="chunks">
@@ -19923,7 +20158,7 @@
                         </tr>            <tr id="lib/common.js__361" class="hit">
                           <td class="line" data-tooltip>361</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">      err.fatal$ &#x3D; true</td>
                           
                         </tr>            <tr id="lib/common.js__362" class="hit">
@@ -19935,7 +20170,7 @@
                         </tr>            <tr id="lib/common.js__363" class="hit">
                           <td class="line" data-tooltip>363</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">      var logdesc &#x3D; {</td>
                           
                         </tr>            <tr id="lib/common.js__364" class="chunks">
@@ -20007,7 +20242,7 @@
                         </tr>            <tr id="lib/common.js__375" class="hit">
                           <td class="line" data-tooltip>375</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">      instance.log.fatal(logdesc)</td>
                           
                         </tr>            <tr id="lib/common.js__376" class="hit">
@@ -20025,7 +20260,7 @@
                         </tr>            <tr id="lib/common.js__378" class="hit">
                           <td class="line" data-tooltip>378</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">      stack &#x3D; stack</td>
                           
                         </tr>            <tr id="lib/common.js__379" class="hit">
@@ -20049,7 +20284,7 @@
                         </tr>            <tr id="lib/common.js__382" class="hit">
                           <td class="line" data-tooltip>382</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">      var procdesc &#x3D;</td>
                           
                         </tr>            <tr id="lib/common.js__383" class="hit">
@@ -20145,7 +20380,7 @@
                         </tr>            <tr id="lib/common.js__398" class="hit">
                           <td class="line" data-tooltip>398</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">      var when &#x3D; new Date()</td>
                           
                         </tr>            <tr id="lib/common.js__399" class="hit">
@@ -20157,7 +20392,7 @@
                         </tr>            <tr id="lib/common.js__400" class="hit">
                           <td class="line" data-tooltip>400</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">      var clean_details &#x3D; null</td>
                           
                         </tr>            <tr id="lib/common.js__401" class="hit">
@@ -20169,7 +20404,7 @@
                         </tr>            <tr id="lib/common.js__402" class="hit">
                           <td class="line" data-tooltip>402</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">      var stderrmsg &#x3D;</td>
                           
                         </tr>            <tr id="lib/common.js__403" class="hit">
@@ -20427,13 +20662,13 @@
                         </tr>            <tr id="lib/common.js__445" class="hit">
                           <td class="line" data-tooltip>445</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">      if (so.errhandler) {</td>
                           
                         </tr>            <tr id="lib/common.js__446" class="hit">
                           <td class="line" data-tooltip>446</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>14</td>
+                          <td class="hits" data-tooltip>18</td>
                           <td class="source">        so.errhandler.call(instance, err)</td>
                           
                         </tr>            <tr id="lib/common.js__447" class="hit">
@@ -20814,11 +21049,11 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source">    } catch (panic) {</td>
                           
-                        </tr>            <tr id="lib/common.js__510" class="miss">
+                        </tr>            <tr id="lib/common.js__510" class="hit">
                           <td class="line" data-tooltip>510</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>      this.log.fatal({</td>
+                          <td class="hits" data-tooltip>4</td>
+                          <td class="source">      this.log.fatal({</td>
                           
                         </tr>            <tr id="lib/common.js__511" class="hit">
                           <td class="line" data-tooltip>511</td>
@@ -20850,11 +21085,11 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/common.js__516" class="miss">
+                        </tr>            <tr id="lib/common.js__516" class="chunks">
                           <td class="line" data-tooltip>516</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>      if (so.test) {</td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>so.test</div><div>) {</div></td>
                           
                         </tr>            <tr id="lib/common.js__517" class="miss">
                           <td class="line" data-tooltip>517</td>
@@ -21027,13 +21262,13 @@
                         </tr>            <tr id="lib/common.js__545" class="hit">
                           <td class="line" data-tooltip>545</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5640</td>
+                          <td class="hits" data-tooltip>5644</td>
                           <td class="source">  var prior &#x3D; callmeta.prior || {}</td>
                           
                         </tr>            <tr id="lib/common.js__546" class="hit">
                           <td class="line" data-tooltip>546</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5640</td>
+                          <td class="hits" data-tooltip>5644</td>
                           <td class="source">  actdef &#x3D; actdef || {}</td>
                           
                         </tr>            <tr id="lib/common.js__547" class="hit">
@@ -21045,7 +21280,7 @@
                         </tr>            <tr id="lib/common.js__548" class="hit">
                           <td class="line" data-tooltip>548</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5640</td>
+                          <td class="hits" data-tooltip>5644</td>
                           <td class="source">  return Object.assign(</td>
                           
                         </tr>            <tr id="lib/common.js__549" class="hit">
@@ -21189,7 +21424,7 @@
                         </tr>            <tr id="lib/common.js__572" class="hit">
                           <td class="line" data-tooltip>572</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>113</td>
+                          <td class="hits" data-tooltip>117</td>
                           <td class="source">  if (err.details &amp;&amp; ctxt &amp;&amp; ctxt.caller) {</td>
                           
                         </tr>            <tr id="lib/common.js__573" class="hit">
@@ -21213,7 +21448,7 @@
                         </tr>            <tr id="lib/common.js__576" class="hit">
                           <td class="line" data-tooltip>576</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>113</td>
+                          <td class="hits" data-tooltip>117</td>
                           <td class="source">  return Object.assign(</td>
                           
                         </tr>            <tr id="lib/common.js__577" class="hit">
@@ -21807,13 +22042,13 @@
                         </tr>            <tr id="lib/common.js__675" class="hit">
                           <td class="line" data-tooltip>675</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>58658</td>
+                          <td class="hits" data-tooltip>66857</td>
                           <td class="source">  var s &#x3D; 0</td>
                           
                         </tr>            <tr id="lib/common.js__676" class="hit">
                           <td class="line" data-tooltip>676</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>58658</td>
+                          <td class="hits" data-tooltip>66857</td>
                           <td class="source">  var e &#x3D; i</td>
                           
                         </tr>            <tr id="lib/common.js__677" class="hit">
@@ -21825,13 +22060,13 @@
                         </tr>            <tr id="lib/common.js__678" class="hit">
                           <td class="line" data-tooltip>678</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>58658</td>
+                          <td class="hits" data-tooltip>66857</td>
                           <td class="source">  if (0 &#x3D;&#x3D;&#x3D; this._list.length) {</td>
                           
                         </tr>            <tr id="lib/common.js__679" class="hit">
                           <td class="line" data-tooltip>679</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9783</td>
+                          <td class="hits" data-tooltip>15751</td>
                           <td class="source">    return 0</td>
                           
                         </tr>            <tr id="lib/common.js__680" class="hit">
@@ -21849,13 +22084,13 @@
                         </tr>            <tr id="lib/common.js__682" class="hit">
                           <td class="line" data-tooltip>682</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>48875</td>
+                          <td class="hits" data-tooltip>51106</td>
                           <td class="source">  do {</td>
                           
                         </tr>            <tr id="lib/common.js__683" class="hit">
                           <td class="line" data-tooltip>683</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>101507</td>
+                          <td class="hits" data-tooltip>105748</td>
                           <td class="source">    i &#x3D; Math.floor((s + e) / 2)</td>
                           
                         </tr>            <tr id="lib/common.js__684" class="hit">
@@ -21867,31 +22102,31 @@
                         </tr>            <tr id="lib/common.js__685" class="hit">
                           <td class="line" data-tooltip>685</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>101507</td>
+                          <td class="hits" data-tooltip>105748</td>
                           <td class="source">    if (timelimit &gt; this._list[i].timelimit) {</td>
                           
                         </tr>            <tr id="lib/common.js__686" class="hit">
                           <td class="line" data-tooltip>686</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>216</td>
+                          <td class="hits" data-tooltip>260</td>
                           <td class="source">      s &#x3D; i + 1</td>
                           
                         </tr>            <tr id="lib/common.js__687" class="hit">
                           <td class="line" data-tooltip>687</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>216</td>
+                          <td class="hits" data-tooltip>260</td>
                           <td class="source">      i &#x3D; s</td>
                           
                         </tr>            <tr id="lib/common.js__688" class="hit">
                           <td class="line" data-tooltip>688</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>101291</td>
+                          <td class="hits" data-tooltip>105488</td>
                           <td class="source">    } else if (timelimit &lt; this._list[i].timelimit) {</td>
                           
                         </tr>            <tr id="lib/common.js__689" class="hit">
                           <td class="line" data-tooltip>689</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>101279</td>
+                          <td class="hits" data-tooltip>105475</td>
                           <td class="source">      e &#x3D; i</td>
                           
                         </tr>            <tr id="lib/common.js__690" class="hit">
@@ -21903,13 +22138,13 @@
                         </tr>            <tr id="lib/common.js__691" class="hit">
                           <td class="line" data-tooltip>691</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>12</td>
+                          <td class="hits" data-tooltip>13</td>
                           <td class="source">      i++</td>
                           
                         </tr>            <tr id="lib/common.js__692" class="hit">
                           <td class="line" data-tooltip>692</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>12</td>
+                          <td class="hits" data-tooltip>13</td>
                           <td class="source">      break</td>
                           
                         </tr>            <tr id="lib/common.js__693" class="hit">
@@ -21933,7 +22168,7 @@
                         </tr>            <tr id="lib/common.js__696" class="hit">
                           <td class="line" data-tooltip>696</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>48875</td>
+                          <td class="hits" data-tooltip>51106</td>
                           <td class="source">  return i</td>
                           
                         </tr>            <tr id="lib/common.js__697" class="hit">
@@ -21969,13 +22204,13 @@
                         </tr>            <tr id="lib/common.js__702" class="hit">
                           <td class="line" data-tooltip>702</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>58648</td>
+                          <td class="hits" data-tooltip>66847</td>
                           <td class="source">    for (var j &#x3D; 0; j &lt; i; j++) {</td>
                           
                         </tr>            <tr id="lib/common.js__703" class="hit">
                           <td class="line" data-tooltip>703</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>427</td>
+                          <td class="hits" data-tooltip>493</td>
                           <td class="source">      delete this._map[this._list[j].id]</td>
                           
                         </tr>            <tr id="lib/common.js__704" class="hit">
@@ -21987,7 +22222,7 @@
                         </tr>            <tr id="lib/common.js__705" class="hit">
                           <td class="line" data-tooltip>705</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>58648</td>
+                          <td class="hits" data-tooltip>66847</td>
                           <td class="source">    this._list &#x3D; this._list.slice(i)</td>
                           
                         </tr>            <tr id="lib/common.js__706" class="hit">
@@ -22159,8 +22394,8 @@
                 <h2 id="lib/errors.js">lib/errors.js </h2>
                 <div class="stats high">
                     <div class="percentage">100%</div>
-                    <div class="sloc">112</div>
-                    <div class="hits">112</div>
+                    <div class="sloc">114</div>
+                    <div class="hits">114</div>
                     <div class="misses">0</div>
                 </div>
                 <table>
@@ -23042,13 +23277,13 @@
                           <td class="line" data-tooltip>145</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  action_timeout:</td>
+                          <td class="source">  fail_wrong_number_of_args:</td>
                           
                         </tr>            <tr id="lib/errors.js__146" class="hit">
                           <td class="line" data-tooltip>146</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;&lt;%&#x3D;legacy_string%&gt;Action &lt;%&#x3D;pattern%&gt; timed out. Timeout was: &lt;%&#x3D;timeout%&gt; (start: &lt;%&#x3D;start%&gt;, end: &lt;%&#x3D;end%&gt;. Message was: &lt;%&#x3D;message%&gt;.&#x27;,</td>
+                          <td class="source">    &#x27;The Seneca.fail method was called with the wrong number of arguments: &lt;%&#x3D;num_args%&gt;&#x27;,</td>
                           
                         </tr>            <tr id="lib/errors.js__147" class="hit">
                           <td class="line" data-tooltip>147</td>
@@ -23060,13 +23295,13 @@
                           <td class="line" data-tooltip>148</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  use_no_args:</td>
+                          <td class="source">  action_timeout:</td>
                           
                         </tr>            <tr id="lib/errors.js__149" class="hit">
                           <td class="line" data-tooltip>149</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;The seneca.use method needs at least one argument to define a plugin.&#x27;,</td>
+                          <td class="source">    &#x27;&lt;%&#x3D;legacy_string%&gt;Action &lt;%&#x3D;pattern%&gt; timed out. Timeout was: &lt;%&#x3D;timeout%&gt; (start: &lt;%&#x3D;start%&gt;, end: &lt;%&#x3D;end%&gt;. Message was: &lt;%&#x3D;message%&gt;.&#x27;,</td>
                           
                         </tr>            <tr id="lib/errors.js__150" class="hit">
                           <td class="line" data-tooltip>150</td>
@@ -23078,82 +23313,100 @@
                           <td class="line" data-tooltip>151</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // Legacy error message codes</td>
+                          <td class="source">  use_no_args:</td>
                           
                         </tr>            <tr id="lib/errors.js__152" class="hit">
                           <td class="line" data-tooltip>152</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    &#x27;The seneca.use method needs at least one argument to define a plugin.&#x27;,</td>
                           
                         </tr>            <tr id="lib/errors.js__153" class="hit">
                           <td class="line" data-tooltip>153</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  act_invalid_args:</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/errors.js__154" class="hit">
                           <td class="line" data-tooltip>154</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;Action &lt;%&#x3D;pattern%&gt; has invalid arguments; &lt;%&#x3D;message%&gt;; &#x27; +</td>
+                          <td class="source">  // Legacy error message codes</td>
                           
                         </tr>            <tr id="lib/errors.js__155" class="hit">
                           <td class="line" data-tooltip>155</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;arguments were: &lt;%&#x3D;msg%&gt;.&#x27;,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/errors.js__156" class="hit">
                           <td class="line" data-tooltip>156</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  act_invalid_args:</td>
                           
                         </tr>            <tr id="lib/errors.js__157" class="hit">
                           <td class="line" data-tooltip>157</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    &#x27;Action &lt;%&#x3D;pattern%&gt; has invalid arguments; &lt;%&#x3D;message%&gt;; &#x27; +</td>
                           
                         </tr>            <tr id="lib/errors.js__158" class="hit">
                           <td class="line" data-tooltip>158</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">module.exports.deprecation &#x3D; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    &#x27;arguments were: &lt;%&#x3D;msg%&gt;.&#x27;,</td>
                           
                         </tr>            <tr id="lib/errors.js__159" class="hit">
                           <td class="line" data-tooltip>159</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  seneca_parent:</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/errors.js__160" class="hit">
                           <td class="line" data-tooltip>160</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;Seneca.parent has been renamed to Seneca.prior. Seneca.parent will be removed in Seneca 4.x.&#x27;,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/errors.js__161" class="hit">
                           <td class="line" data-tooltip>161</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">module.exports.deprecation &#x3D; {</td>
                           
                         </tr>            <tr id="lib/errors.js__162" class="hit">
                           <td class="line" data-tooltip>162</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  seneca_next_act: &#x27;Seneca.next_act will be removed in Seneca 3.x&#x27;,</td>
+                          <td class="source">  seneca_parent:</td>
                           
                         </tr>            <tr id="lib/errors.js__163" class="hit">
                           <td class="line" data-tooltip>163</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    &#x27;Seneca.parent has been renamed to Seneca.prior. Seneca.parent will be removed in Seneca 4.x.&#x27;,</td>
                           
                         </tr>            <tr id="lib/errors.js__164" class="hit">
                           <td class="line" data-tooltip>164</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
+                          
+                        </tr>            <tr id="lib/errors.js__165" class="hit">
+                          <td class="line" data-tooltip>165</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  seneca_next_act: &#x27;Seneca.next_act will be removed in Seneca 3.x&#x27;,</td>
+                          
+                        </tr>            <tr id="lib/errors.js__166" class="hit">
+                          <td class="line" data-tooltip>166</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
+                          
+                        </tr>            <tr id="lib/errors.js__167" class="hit">
+                          <td class="line" data-tooltip>167</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
@@ -28117,7 +28370,7 @@
                         </tr>            <tr id="lib/logging.js__255" class="hit">
                           <td class="line" data-tooltip>255</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    } else if (&#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof entry) {</td>
                           
                         </tr>            <tr id="lib/logging.js__256" class="hit">
@@ -28141,13 +28394,13 @@
                         </tr>            <tr id="lib/logging.js__259" class="hit">
                           <td class="line" data-tooltip>259</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    var logspec &#x3D; instance.private$.logspec</td>
                           
                         </tr>            <tr id="lib/logging.js__260" class="hit">
                           <td class="line" data-tooltip>260</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    entry.level &#x3D; entry.level || logspec.default_level</td>
                           
                         </tr>            <tr id="lib/logging.js__261" class="hit">
@@ -28159,7 +28412,7 @@
                         </tr>            <tr id="lib/logging.js__262" class="hit">
                           <td class="line" data-tooltip>262</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    if (&#x27;number&#x27; !&#x3D;&#x3D; typeof entry.level) {</td>
                           
                         </tr>            <tr id="lib/logging.js__263" class="hit">
@@ -28195,7 +28448,7 @@
                         </tr>            <tr id="lib/logging.js__268" class="hit">
                           <td class="line" data-tooltip>268</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    var now &#x3D; new Date()</td>
                           
                         </tr>            <tr id="lib/logging.js__269" class="hit">
@@ -28219,25 +28472,25 @@
                         </tr>            <tr id="lib/logging.js__272" class="hit">
                           <td class="line" data-tooltip>272</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    entry.isot &#x3D; entry.isot || now.toISOString()</td>
                           
                         </tr>            <tr id="lib/logging.js__273" class="hit">
                           <td class="line" data-tooltip>273</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    entry.when &#x3D; entry.when || now.getTime()</td>
                           
                         </tr>            <tr id="lib/logging.js__274" class="hit">
                           <td class="line" data-tooltip>274</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    entry.level_name &#x3D; entry.level_name || logspec.level_text[entry.level]</td>
                           
                         </tr>            <tr id="lib/logging.js__275" class="hit">
                           <td class="line" data-tooltip>275</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    entry.seneca_id &#x3D; entry.seneca_id || instance.id</td>
                           
                         </tr>            <tr id="lib/logging.js__276" class="hit">
@@ -28249,13 +28502,13 @@
                         </tr>            <tr id="lib/logging.js__277" class="hit">
                           <td class="line" data-tooltip>277</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    if (instance.did) {</td>
                           
                         </tr>            <tr id="lib/logging.js__278" class="hit">
                           <td class="line" data-tooltip>278</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11962</td>
+                          <td class="hits" data-tooltip>11974</td>
                           <td class="source">      entry.seneca_did &#x3D; entry.seneca_did || instance.did</td>
                           
                         </tr>            <tr id="lib/logging.js__279" class="hit">
@@ -28273,13 +28526,13 @@
                         </tr>            <tr id="lib/logging.js__281" class="hit">
                           <td class="line" data-tooltip>281</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    if (instance.fixedargs.plugin$) {</td>
                           
                         </tr>            <tr id="lib/logging.js__282" class="hit">
                           <td class="line" data-tooltip>282</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11823</td>
+                          <td class="hits" data-tooltip>11835</td>
                           <td class="source">      entry.plugin_name &#x3D; entry.plugin_name || instance.fixedargs.plugin$.name</td>
                           
                         </tr>            <tr id="lib/logging.js__283" class="chunks">
@@ -28303,13 +28556,13 @@
                         </tr>            <tr id="lib/logging.js__286" class="hit">
                           <td class="line" data-tooltip>286</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    if (instance.private$.act) {</td>
                           
                         </tr>            <tr id="lib/logging.js__287" class="hit">
                           <td class="line" data-tooltip>287</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5374</td>
+                          <td class="hits" data-tooltip>5382</td>
                           <td class="source">      intern.build_act_entry(instance.private$.act, entry)</td>
                           
                         </tr>            <tr id="lib/logging.js__288" class="hit">
@@ -28333,7 +28586,7 @@
                         </tr>            <tr id="lib/logging.js__291" class="hit">
                           <td class="line" data-tooltip>291</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    instance.emit(&#x27;log&#x27;, entry)</td>
                           
                         </tr>            <tr id="lib/logging.js__292" class="hit">
@@ -28345,7 +28598,7 @@
                         </tr>            <tr id="lib/logging.js__293" class="hit">
                           <td class="line" data-tooltip>293</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    var level_match &#x3D; logspec.live_level &lt;&#x3D; entry.level</td>
                           
                         </tr>            <tr id="lib/logging.js__294" class="hit">
@@ -28357,13 +28610,13 @@
                         </tr>            <tr id="lib/logging.js__295" class="hit">
                           <td class="line" data-tooltip>295</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    if (level_match) {</td>
                           
                         </tr>            <tr id="lib/logging.js__296" class="hit">
                           <td class="line" data-tooltip>296</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>610</td>
+                          <td class="hits" data-tooltip>627</td>
                           <td class="source">      instance.private$.logger.call(this, entry)</td>
                           
                         </tr>            <tr id="lib/logging.js__297" class="hit">
@@ -28381,7 +28634,7 @@
                         </tr>            <tr id="lib/logging.js__299" class="hit">
                           <td class="line" data-tooltip>299</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17813</td>
+                          <td class="hits" data-tooltip>17850</td>
                           <td class="source">    return this</td>
                           
                         </tr>            <tr id="lib/logging.js__300" class="hit">
@@ -28483,7 +28736,7 @@
                         </tr>            <tr id="lib/logging.js__316" class="hit">
                           <td class="line" data-tooltip>316</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17770</td>
+                          <td class="hits" data-tooltip>17807</td>
                           <td class="source">    if (&#x27;object&#x27; !&#x3D;&#x3D; typeof entry) {</td>
                           
                         </tr>            <tr id="lib/logging.js__317" class="hit">
@@ -28519,13 +28772,13 @@
                         </tr>            <tr id="lib/logging.js__322" class="hit">
                           <td class="line" data-tooltip>322</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17770</td>
+                          <td class="hits" data-tooltip>17807</td>
                           <td class="source">    entry.level &#x3D; level</td>
                           
                         </tr>            <tr id="lib/logging.js__323" class="hit">
                           <td class="line" data-tooltip>323</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17770</td>
+                          <td class="hits" data-tooltip>17807</td>
                           <td class="source">    return self.log(entry)</td>
                           
                         </tr>            <tr id="lib/logging.js__324" class="hit">
@@ -29185,19 +29438,19 @@
                         </tr>            <tr id="lib/logging.js__433" class="hit">
                           <td class="line" data-tooltip>433</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5376</td>
+                          <td class="hits" data-tooltip>5384</td>
                           <td class="source">    entry.actid &#x3D; entry.actid || act.meta.id</td>
                           
                         </tr>            <tr id="lib/logging.js__434" class="hit">
                           <td class="line" data-tooltip>434</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5376</td>
+                          <td class="hits" data-tooltip>5384</td>
                           <td class="source">    entry.pattern &#x3D; entry.pattern || act.meta.pattern</td>
                           
                         </tr>            <tr id="lib/logging.js__435" class="hit">
                           <td class="line" data-tooltip>435</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5376</td>
+                          <td class="hits" data-tooltip>5384</td>
                           <td class="source">    entry.action &#x3D; entry.action || act.def.id</td>
                           
                         </tr>            <tr id="lib/logging.js__436" class="hit">
@@ -29209,19 +29462,19 @@
                         </tr>            <tr id="lib/logging.js__437" class="hit">
                           <td class="line" data-tooltip>437</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5376</td>
+                          <td class="hits" data-tooltip>5384</td>
                           <td class="source">    entry.idpath &#x3D; (&#x27;&#x27; + act.meta.tx).substring(0, 5)</td>
                           
                         </tr>            <tr id="lib/logging.js__438" class="hit">
                           <td class="line" data-tooltip>438</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5376</td>
+                          <td class="hits" data-tooltip>5384</td>
                           <td class="source">    if (act.meta.parents) {</td>
                           
                         </tr>            <tr id="lib/logging.js__439" class="hit">
                           <td class="line" data-tooltip>439</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>4936</td>
+                          <td class="hits" data-tooltip>4944</td>
                           <td class="source">      for (var i &#x3D; 0; i &lt; act.meta.parents.length; i++) {</td>
                           
                         </tr>            <tr id="lib/logging.js__440" class="hit">
@@ -29257,7 +29510,7 @@
                         </tr>            <tr id="lib/logging.js__445" class="hit">
                           <td class="line" data-tooltip>445</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5376</td>
+                          <td class="hits" data-tooltip>5384</td>
                           <td class="source">    entry.idpath +&#x3D; (&#x27;.&#x27; + act.meta.mi).substring(0, 6)</td>
                           
                         </tr>            <tr id="lib/logging.js__446" class="hit">
@@ -30629,7 +30882,7 @@
                         </tr>            <tr id="lib/options.js__222" class="hit">
                           <td class="line" data-tooltip>222</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21205</td>
+                          <td class="hits" data-tooltip>21218</td>
                           <td class="source">    return options</td>
                           
                         </tr>            <tr id="lib/options.js__223" class="hit">
@@ -31209,7 +31462,7 @@
                         </tr>            <tr id="lib/outward.js__29" class="hit">
                           <td class="line" data-tooltip>29</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2822</td>
+                          <td class="hits" data-tooltip>2826</td>
                           <td class="source">  if (!ctxt.options.legacy.error) {</td>
                           
                         </tr>            <tr id="lib/outward.js__30" class="chunks">
@@ -31293,7 +31546,7 @@
                         </tr>            <tr id="lib/outward.js__43" class="hit">
                           <td class="line" data-tooltip>43</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  Assert(ctxt.options)</td>
                           
                         </tr>            <tr id="lib/outward.js__44" class="hit">
@@ -31305,19 +31558,19 @@
                         </tr>            <tr id="lib/outward.js__45" class="hit">
                           <td class="line" data-tooltip>45</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var so &#x3D; ctxt.options</td>
                           
                         </tr>            <tr id="lib/outward.js__46" class="hit">
                           <td class="line" data-tooltip>46</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var res &#x3D; data.res</td>
                           
                         </tr>            <tr id="lib/outward.js__47" class="hit">
                           <td class="line" data-tooltip>47</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__48" class="hit">
@@ -31329,13 +31582,13 @@
                         </tr>            <tr id="lib/outward.js__49" class="hit">
                           <td class="line" data-tooltip>49</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var actid &#x3D; meta.id</td>
                           
                         </tr>            <tr id="lib/outward.js__50" class="hit">
                           <td class="line" data-tooltip>50</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var private$ &#x3D; ctxt.seneca.private$</td>
                           
                         </tr>            <tr id="lib/outward.js__51" class="hit">
@@ -31353,7 +31606,7 @@
                         </tr>            <tr id="lib/outward.js__53" class="hit">
                           <td class="line" data-tooltip>53</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    var actdetails &#x3D; private$.history.get(actid)</td>
                           
                         </tr>            <tr id="lib/outward.js__54" class="hit">
@@ -31365,7 +31618,7 @@
                         </tr>            <tr id="lib/outward.js__55" class="hit">
                           <td class="line" data-tooltip>55</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">    if (actdetails) {</td>
                           
                         </tr>            <tr id="lib/outward.js__56" class="hit">
@@ -31407,7 +31660,7 @@
                         </tr>            <tr id="lib/outward.js__62" class="hit">
                           <td class="line" data-tooltip>62</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2821</td>
+                          <td class="hits" data-tooltip>2825</td>
                           <td class="source">  if (!ctxt.actdef || ctxt.cached$) {</td>
                           
                         </tr>            <tr id="lib/outward.js__63" class="hit">
@@ -31431,19 +31684,19 @@
                         </tr>            <tr id="lib/outward.js__66" class="hit">
                           <td class="line" data-tooltip>66</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2385</td>
+                          <td class="hits" data-tooltip>2389</td>
                           <td class="source">  var private$ &#x3D; ctxt.seneca.private$</td>
                           
                         </tr>            <tr id="lib/outward.js__67" class="hit">
                           <td class="line" data-tooltip>67</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2385</td>
+                          <td class="hits" data-tooltip>2389</td>
                           <td class="source">  var stats &#x3D; private$.stats.act</td>
                           
                         </tr>            <tr id="lib/outward.js__68" class="hit">
                           <td class="line" data-tooltip>68</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2385</td>
+                          <td class="hits" data-tooltip>2389</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__69" class="hit">
@@ -31455,7 +31708,7 @@
                         </tr>            <tr id="lib/outward.js__70" class="hit">
                           <td class="line" data-tooltip>70</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2385</td>
+                          <td class="hits" data-tooltip>2389</td>
                           <td class="source">  ++stats.done</td>
                           
                         </tr>            <tr id="lib/outward.js__71" class="hit">
@@ -31479,7 +31732,7 @@
                         </tr>            <tr id="lib/outward.js__74" class="hit">
                           <td class="line" data-tooltip>74</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2282</td>
+                          <td class="hits" data-tooltip>2286</td>
                           <td class="source">    private$.timestats.point(ctxt.duration, ctxt.actdef.pattern)</td>
                           
                         </tr>            <tr id="lib/outward.js__75" class="hit">
@@ -31497,7 +31750,7 @@
                         </tr>            <tr id="lib/outward.js__77" class="hit">
                           <td class="line" data-tooltip>77</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2385</td>
+                          <td class="hits" data-tooltip>2389</td>
                           <td class="source">  var pattern &#x3D; ctxt.actdef.pattern</td>
                           
                         </tr>            <tr id="lib/outward.js__78" class="hit">
@@ -31509,7 +31762,7 @@
                         </tr>            <tr id="lib/outward.js__79" class="hit">
                           <td class="line" data-tooltip>79</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2385</td>
+                          <td class="hits" data-tooltip>2389</td>
                           <td class="source">  var actstats &#x3D; (private$.stats.actmap[pattern] &#x3D;</td>
                           
                         </tr>            <tr id="lib/outward.js__80" class="hit">
@@ -31533,13 +31786,13 @@
                         </tr>            <tr id="lib/outward.js__83" class="hit">
                           <td class="line" data-tooltip>83</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>62</td>
+                          <td class="hits" data-tooltip>66</td>
                           <td class="source">    ++stats.fails</td>
                           
                         </tr>            <tr id="lib/outward.js__84" class="hit">
                           <td class="line" data-tooltip>84</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>62</td>
+                          <td class="hits" data-tooltip>66</td>
                           <td class="source">    ++actstats.fails</td>
                           
                         </tr>            <tr id="lib/outward.js__85" class="hit">
@@ -31581,7 +31834,7 @@
                         </tr>            <tr id="lib/outward.js__91" class="hit">
                           <td class="line" data-tooltip>91</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  Assert(ctxt.options)</td>
                           
                         </tr>            <tr id="lib/outward.js__92" class="hit">
@@ -31593,19 +31846,19 @@
                         </tr>            <tr id="lib/outward.js__93" class="hit">
                           <td class="line" data-tooltip>93</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var so &#x3D; ctxt.options</td>
                           
                         </tr>            <tr id="lib/outward.js__94" class="hit">
                           <td class="line" data-tooltip>94</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var msg &#x3D; data.msg</td>
                           
                         </tr>            <tr id="lib/outward.js__95" class="hit">
                           <td class="line" data-tooltip>95</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var res &#x3D; data.res</td>
                           
                         </tr>            <tr id="lib/outward.js__96" class="hit">
@@ -31617,7 +31870,7 @@
                         </tr>            <tr id="lib/outward.js__97" class="hit">
                           <td class="line" data-tooltip>97</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  if (void 0 &#x3D;&#x3D;&#x3D; data.res) {</td>
                           
                         </tr>            <tr id="lib/outward.js__98" class="hit">
@@ -31641,7 +31894,7 @@
                         </tr>            <tr id="lib/outward.js__101" class="hit">
                           <td class="line" data-tooltip>101</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var not_object &#x3D;</td>
                           
                         </tr>            <tr id="lib/outward.js__102" class="hit">
@@ -31713,7 +31966,7 @@
                         </tr>            <tr id="lib/outward.js__113" class="hit">
                           <td class="line" data-tooltip>113</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  if (data.out instanceof Error) {</td>
                           
                         </tr>            <tr id="lib/outward.js__114" class="hit">
@@ -31737,7 +31990,7 @@
                         </tr>            <tr id="lib/outward.js__117" class="hit">
                           <td class="line" data-tooltip>117</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var not_legacy &#x3D; !(</td>
                           
                         </tr>            <tr id="lib/outward.js__118" class="chunks">
@@ -31863,7 +32116,7 @@
                         </tr>            <tr id="lib/outward.js__138" class="hit">
                           <td class="line" data-tooltip>138</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__139" class="hit">
@@ -31875,13 +32128,13 @@
                         </tr>            <tr id="lib/outward.js__140" class="hit">
                           <td class="line" data-tooltip>140</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  if (meta.error) {</td>
                           
                         </tr>            <tr id="lib/outward.js__141" class="hit">
                           <td class="line" data-tooltip>141</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">    return</td>
                           
                         </tr>            <tr id="lib/outward.js__142" class="hit">
@@ -32007,7 +32260,7 @@
                         </tr>            <tr id="lib/outward.js__162" class="hit">
                           <td class="line" data-tooltip>162</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var private$ &#x3D; ctxt.seneca.private$</td>
                           
                         </tr>            <tr id="lib/outward.js__163" class="hit">
@@ -32019,13 +32272,13 @@
                         </tr>            <tr id="lib/outward.js__164" class="hit">
                           <td class="line" data-tooltip>164</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__165" class="hit">
                           <td class="line" data-tooltip>165</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var reply_meta &#x3D; data.reply_meta</td>
                           
                         </tr>            <tr id="lib/outward.js__166" class="hit">
@@ -32091,7 +32344,7 @@
                         </tr>            <tr id="lib/outward.js__176" class="hit">
                           <td class="line" data-tooltip>176</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  if (parent_meta) {</td>
                           
                         </tr>            <tr id="lib/outward.js__177" class="hit">
@@ -32151,13 +32404,13 @@
                         </tr>            <tr id="lib/outward.js__186" class="hit">
                           <td class="line" data-tooltip>186</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__187" class="hit">
                           <td class="line" data-tooltip>187</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var reply_meta &#x3D; data.reply_meta</td>
                           
                         </tr>            <tr id="lib/outward.js__188" class="hit">
@@ -32205,19 +32458,19 @@
                         </tr>            <tr id="lib/outward.js__195" class="hit">
                           <td class="line" data-tooltip>195</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var delegate &#x3D; ctxt.seneca</td>
                           
                         </tr>            <tr id="lib/outward.js__196" class="hit">
                           <td class="line" data-tooltip>196</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var actdef &#x3D; ctxt.actdef</td>
                           
                         </tr>            <tr id="lib/outward.js__197" class="hit">
                           <td class="line" data-tooltip>197</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__198" class="hit">
@@ -32229,13 +32482,13 @@
                         </tr>            <tr id="lib/outward.js__199" class="hit">
                           <td class="line" data-tooltip>199</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  if (meta.error) {</td>
                           
                         </tr>            <tr id="lib/outward.js__200" class="hit">
                           <td class="line" data-tooltip>200</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">    data.error_desc &#x3D; intern.act_error(delegate, ctxt, data)</td>
                           
                         </tr>            <tr id="lib/outward.js__201" class="hit">
@@ -32247,7 +32500,7 @@
                         </tr>            <tr id="lib/outward.js__202" class="hit">
                           <td class="line" data-tooltip>202</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">    if (meta.fatal) {</td>
                           
                         </tr>            <tr id="lib/outward.js__203" class="hit">
@@ -32259,7 +32512,7 @@
                         </tr>            <tr id="lib/outward.js__204" class="hit">
                           <td class="line" data-tooltip>204</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
+                          <td class="hits" data-tooltip>9</td>
                           <td class="source">      return delegate.die(data.error_desc.err)</td>
                           
                         </tr>            <tr id="lib/outward.js__205" class="hit">
@@ -32391,7 +32644,7 @@
                         </tr>            <tr id="lib/outward.js__226" class="hit">
                           <td class="line" data-tooltip>226</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var delegate &#x3D; ctxt.seneca</td>
                           
                         </tr>            <tr id="lib/outward.js__227" class="chunks">
@@ -32433,13 +32686,13 @@
                         </tr>            <tr id="lib/outward.js__233" class="hit">
                           <td class="line" data-tooltip>233</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__234" class="hit">
                           <td class="line" data-tooltip>234</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  var private$ &#x3D; ctxt.seneca.private$</td>
                           
                         </tr>            <tr id="lib/outward.js__235" class="hit">
@@ -32457,7 +32710,7 @@
                         </tr>            <tr id="lib/outward.js__237" class="hit">
                           <td class="line" data-tooltip>237</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2820</td>
+                          <td class="hits" data-tooltip>2824</td>
                           <td class="source">  if (meta.prior) {</td>
                           
                         </tr>            <tr id="lib/outward.js__238" class="hit">
@@ -32481,7 +32734,7 @@
                         </tr>            <tr id="lib/outward.js__241" class="hit">
                           <td class="line" data-tooltip>241</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2717</td>
+                          <td class="hits" data-tooltip>2721</td>
                           <td class="source">  var submsg &#x3D; ctxt.seneca.util.clean(data.msg)</td>
                           
                         </tr>            <tr id="lib/outward.js__242" class="hit">
@@ -32505,7 +32758,7 @@
                         </tr>            <tr id="lib/outward.js__245" class="hit">
                           <td class="line" data-tooltip>245</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2717</td>
+                          <td class="hits" data-tooltip>2721</td>
                           <td class="source">  var sub_actions_list &#x3D; private$.subrouter.outward.find(submsg, false, true)</td>
                           
                         </tr>            <tr id="lib/outward.js__246" class="hit">
@@ -32517,7 +32770,7 @@
                         </tr>            <tr id="lib/outward.js__247" class="hit">
                           <td class="line" data-tooltip>247</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2717</td>
+                          <td class="hits" data-tooltip>2721</td>
                           <td class="source">  submsg.out$ &#x3D; true</td>
                           
                         </tr>            <tr id="lib/outward.js__248" class="hit">
@@ -32547,7 +32800,7 @@
                         </tr>            <tr id="lib/outward.js__252" class="hit">
                           <td class="line" data-tooltip>252</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2717</td>
+                          <td class="hits" data-tooltip>2721</td>
                           <td class="source">  for (var alI &#x3D; 0; alI &lt; sub_actions_list.length; alI++) {</td>
                           
                         </tr>            <tr id="lib/outward.js__253" class="hit">
@@ -32673,25 +32926,25 @@
                         </tr>            <tr id="lib/outward.js__273" class="hit">
                           <td class="line" data-tooltip>273</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  var act_callpoint &#x3D; ctxt.callpoint</td>
                           
                         </tr>            <tr id="lib/outward.js__274" class="hit">
                           <td class="line" data-tooltip>274</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  var actdef &#x3D; ctxt.actdef || {}</td>
                           
                         </tr>            <tr id="lib/outward.js__275" class="hit">
                           <td class="line" data-tooltip>275</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  var origmsg &#x3D; ctxt.origmsg</td>
                           
                         </tr>            <tr id="lib/outward.js__276" class="hit">
                           <td class="line" data-tooltip>276</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  var reply &#x3D; ctxt.reply</td>
                           
                         </tr>            <tr id="lib/outward.js__277" class="hit">
@@ -32703,13 +32956,13 @@
                         </tr>            <tr id="lib/outward.js__278" class="hit">
                           <td class="line" data-tooltip>278</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__279" class="hit">
                           <td class="line" data-tooltip>279</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  var msg &#x3D; data.msg</td>
                           
                         </tr>            <tr id="lib/outward.js__280" class="hit">
@@ -32721,7 +32974,7 @@
                         </tr>            <tr id="lib/outward.js__281" class="hit">
                           <td class="line" data-tooltip>281</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  var opts &#x3D; instance.options()</td>
                           
                         </tr>            <tr id="lib/outward.js__282" class="hit">
@@ -32733,7 +32986,7 @@
                         </tr>            <tr id="lib/outward.js__283" class="hit">
                           <td class="line" data-tooltip>283</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  var call_cb &#x3D; true</td>
                           
                         </tr>            <tr id="lib/outward.js__284" class="hit">
@@ -32757,7 +33010,7 @@
                         </tr>            <tr id="lib/outward.js__287" class="hit">
                           <td class="line" data-tooltip>287</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  if (!err.seneca) {</td>
                           
                         </tr>            <tr id="lib/outward.js__288" class="hit">
@@ -32949,7 +33202,7 @@
                         </tr>            <tr id="lib/outward.js__319" class="hit">
                           <td class="line" data-tooltip>319</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
+                          <td class="hits" data-tooltip>47</td>
                           <td class="source">  } else if (</td>
                           
                         </tr>            <tr id="lib/outward.js__320" class="hit">
@@ -33003,7 +33256,7 @@
                         </tr>            <tr id="lib/outward.js__328" class="hit">
                           <td class="line" data-tooltip>328</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  if (opts.legacy.error) {</td>
                           
                         </tr>            <tr id="lib/outward.js__329" class="chunks">
@@ -33015,7 +33268,7 @@
                         </tr>            <tr id="lib/outward.js__330" class="hit">
                           <td class="line" data-tooltip>330</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>58</td>
+                          <td class="hits" data-tooltip>61</td>
                           <td class="source">    err.details.plugin &#x3D; err.details.plugin || {}</td>
                           
                         </tr>            <tr id="lib/outward.js__331" class="hit">
@@ -33033,7 +33286,7 @@
                         </tr>            <tr id="lib/outward.js__333" class="hit">
                           <td class="line" data-tooltip>333</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  var entry &#x3D; ctxt.actlog(actdef, msg, meta, origmsg, {</td>
                           
                         </tr>            <tr id="lib/outward.js__334" class="hit">
@@ -33069,7 +33322,7 @@
                         </tr>            <tr id="lib/outward.js__339" class="hit">
                           <td class="line" data-tooltip>339</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  entry &#x3D; ctxt.errlog(err, entry)</td>
                           
                         </tr>            <tr id="lib/outward.js__340" class="hit">
@@ -33081,13 +33334,13 @@
                         </tr>            <tr id="lib/outward.js__341" class="hit">
                           <td class="line" data-tooltip>341</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  instance.log.error(entry)</td>
                           
                         </tr>            <tr id="lib/outward.js__342" class="hit">
                           <td class="line" data-tooltip>342</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  instance.emit(&#x27;act-err&#x27;, msg, err)</td>
                           
                         </tr>            <tr id="lib/outward.js__343" class="hit">
@@ -33129,7 +33382,7 @@
                         </tr>            <tr id="lib/outward.js__349" class="hit">
                           <td class="line" data-tooltip>349</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>86</td>
+                          <td class="hits" data-tooltip>90</td>
                           <td class="source">  return {</td>
                           
                         </tr>            <tr id="lib/outward.js__350" class="hit">
@@ -38085,7 +38338,7 @@
                         </tr>            <tr id="lib/ready.js__48" class="hit">
                           <td class="line" data-tooltip>48</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>609</td>
+                          <td class="hits" data-tooltip>608</td>
                           <td class="source">        execute_ready(self, ready_call)</td>
                           
                         </tr>            <tr id="lib/ready.js__49" class="hit">
@@ -38097,7 +38350,7 @@
                         </tr>            <tr id="lib/ready.js__50" class="hit">
                           <td class="line" data-tooltip>50</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>24</td>
+                          <td class="hits" data-tooltip>25</td>
                           <td class="source">        private$.ready_list.push(ready_call)</td>
                           
                         </tr>            <tr id="lib/ready.js__51" class="hit">
@@ -38151,13 +38404,13 @@
                         </tr>            <tr id="lib/ready.js__59" class="hit">
                           <td class="line" data-tooltip>59</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>543</td>
+                          <td class="hits" data-tooltip>546</td>
                           <td class="source">  const root &#x3D; this</td>
                           
                         </tr>            <tr id="lib/ready.js__60" class="hit">
                           <td class="line" data-tooltip>60</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>543</td>
+                          <td class="hits" data-tooltip>546</td>
                           <td class="source">  var private$ &#x3D; root.private$</td>
                           
                         </tr>            <tr id="lib/ready.js__61" class="hit">
@@ -38169,13 +38422,13 @@
                         </tr>            <tr id="lib/ready.js__62" class="hit">
                           <td class="line" data-tooltip>62</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>543</td>
+                          <td class="hits" data-tooltip>546</td>
                           <td class="source">  root.emit(&#x27;ready&#x27;)</td>
                           
                         </tr>            <tr id="lib/ready.js__63" class="hit">
                           <td class="line" data-tooltip>63</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>543</td>
+                          <td class="hits" data-tooltip>546</td>
                           <td class="source">  execute_ready(root, private$.ready_list.shift())</td>
                           
                         </tr>            <tr id="lib/ready.js__64" class="hit">
@@ -38187,13 +38440,13 @@
                         </tr>            <tr id="lib/ready.js__65" class="hit">
                           <td class="line" data-tooltip>65</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>543</td>
+                          <td class="hits" data-tooltip>546</td>
                           <td class="source">  if (private$.ge.isclear()) {</td>
                           
                         </tr>            <tr id="lib/ready.js__66" class="hit">
                           <td class="line" data-tooltip>66</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>542</td>
+                          <td class="hits" data-tooltip>544</td>
                           <td class="source">    while (0 &lt; private$.ready_list.length) {</td>
                           
                         </tr>            <tr id="lib/ready.js__67" class="hit">
@@ -38241,7 +38494,7 @@
                         </tr>            <tr id="lib/ready.js__74" class="hit">
                           <td class="line" data-tooltip>74</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>625</td>
+                          <td class="hits" data-tooltip>629</td>
                           <td class="source">  var opts &#x3D; instance.options()</td>
                           
                         </tr>            <tr id="lib/ready.js__75" class="hit">
@@ -38253,19 +38506,19 @@
                         </tr>            <tr id="lib/ready.js__76" class="hit">
                           <td class="line" data-tooltip>76</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>625</td>
+                          <td class="hits" data-tooltip>629</td>
                           <td class="source">  try {</td>
                           
                         </tr>            <tr id="lib/ready.js__77" class="hit">
                           <td class="line" data-tooltip>77</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>625</td>
+                          <td class="hits" data-tooltip>629</td>
                           <td class="source">    instance.log.debug({ kind: &#x27;ready&#x27;, case: &#x27;call&#x27;, name: ready_func.name })</td>
                           
                         </tr>            <tr id="lib/ready.js__78" class="hit">
                           <td class="line" data-tooltip>78</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>625</td>
+                          <td class="hits" data-tooltip>629</td>
                           <td class="source">    ready_func()</td>
                           
                         </tr>            <tr id="lib/ready.js__79" class="hit">

--- a/test/coverage.html
+++ b/test/coverage.html
@@ -552,11 +552,11 @@
             <a href="#lib/add.js"><span class="dirname">lib/</span><span class="basename">add.js</span></a>
         </li>
         <li class="">
-            <span class="cov high">92.63</span>
+            <span class="cov high">92.46</span>
             <a href="#lib/api.js"><span class="dirname">lib/</span><span class="basename">api.js</span></a>
         </li>
         <li class="">
-            <span class="cov high">87.86</span>
+            <span class="cov high">87.69</span>
             <a href="#lib/common.js"><span class="dirname">lib/</span><span class="basename">common.js</span></a>
         </li>
         <li class="">
@@ -610,8 +610,8 @@
       <div class="stats high">
           <div class="failures">0</div>
           <div class="skipped">0</div>
-          <div class="test-count">351</div>
-          <div class="duration">44338</div>
+          <div class="test-count">346</div>
+          <div class="duration">36751</div>
       </div>
       <div id="filters">
           <input type="checkbox" checked="" onchange="filter(this)" value="success" id="show-success">
@@ -627,20 +627,6 @@
           <label for="show-add">add</label>
           <input type="checkbox" checked="" onchange="filter(this)" value="api" id="show-api">
           <label for="show-api">api</label>
-          <input type="checkbox" checked="" onchange="filter(this)" value="fail" id="show-fail">
-          <label for="show-fail">fail</label>
-          <input type="checkbox" checked="" onchange="filter(this)" value="invoked_with_a_condition,_code_and_details" id="show-invoked_with_a_condition,_code_and_details">
-          <label for="show-invoked_with_a_condition,_code_and_details">invoked with a condition, code and details</label>
-          <input type="checkbox" checked="" onchange="filter(this)" value="when_the_condition_is_true" id="show-when_the_condition_is_true">
-          <label for="show-when_the_condition_is_true">when the condition is true</label>
-          <input type="checkbox" checked="" onchange="filter(this)" value="when_the_condition_is_false" id="show-when_the_condition_is_false">
-          <label for="show-when_the_condition_is_false">when the condition is false</label>
-          <input type="checkbox" checked="" onchange="filter(this)" value="when_the_condition_is_not_a_boolean" id="show-when_the_condition_is_not_a_boolean">
-          <label for="show-when_the_condition_is_not_a_boolean">when the condition is not a boolean</label>
-          <input type="checkbox" checked="" onchange="filter(this)" value="when_given_no_arguments" id="show-when_given_no_arguments">
-          <label for="show-when_given_no_arguments">when given no arguments</label>
-          <input type="checkbox" checked="" onchange="filter(this)" value="when_given_too_many_arguments" id="show-when_given_too_many_arguments">
-          <label for="show-when_given_too_many_arguments">when given too many arguments</label>
           <input type="checkbox" checked="" onchange="filter(this)" value="close" id="show-close">
           <label for="show-close">close</label>
           <input type="checkbox" checked="" onchange="filter(this)" value="common" id="show-common">
@@ -735,2450 +721,2415 @@
               <td class="test-title">act process_outward
                   
               </td>
-              <td class="test-duration">78</td>
+              <td class="test-duration">63</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">3</td>
               <td class="test-title">actions cmd_ping
                   
               </td>
-              <td class="test-duration">259</td>
+              <td class="test-duration">290</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">4</td>
               <td class="test-title">actions cmd_stats
                   
               </td>
-              <td class="test-duration">48</td>
+              <td class="test-duration">40</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">5</td>
               <td class="test-title">actions cmd_close
                   
               </td>
-              <td class="test-duration">148</td>
+              <td class="test-duration">138</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">6</td>
               <td class="test-title">actions info_fatal
                   
               </td>
-              <td class="test-duration">142</td>
+              <td class="test-duration">128</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">7</td>
               <td class="test-title">actions get_options
                   
               </td>
-              <td class="test-duration">52</td>
+              <td class="test-duration">56</td>
           </tr>
           <tr class="show add success">
               <td class="test-id">8</td>
               <td class="test-title">add name
                   
               </td>
-              <td class="test-duration">26</td>
+              <td class="test-duration">28</td>
           </tr>
           <tr class="show add success">
               <td class="test-id">9</td>
               <td class="test-title">add action_modifier
                   
               </td>
-              <td class="test-duration">132</td>
+              <td class="test-duration">128</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">10</td>
               <td class="test-title">api error
                   
               </td>
-              <td class="test-duration">7</td>
+              <td class="test-duration">6</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">11</td>
-              <td class="test-title">api list
+              <td class="test-title">api fail
                   
               </td>
-              <td class="test-duration">21</td>
+              <td class="test-duration">2</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">12</td>
-              <td class="test-title">api translate
+              <td class="test-title">api list
                   
               </td>
-              <td class="test-duration">150</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">13</td>
-              <td class="test-title">api test-mode
+              <td class="test-title">api translate
                   
               </td>
-              <td class="test-duration">71</td>
+              <td class="test-duration">144</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">14</td>
-              <td class="test-title">api find_plugin
+              <td class="test-title">api test-mode
                   
               </td>
-              <td class="test-duration">167</td>
+              <td class="test-duration">54</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">15</td>
-              <td class="test-title">api has_plugin
+              <td class="test-title">api find_plugin
                   
               </td>
-              <td class="test-duration">271</td>
+              <td class="test-duration">137</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">16</td>
-              <td class="test-title">api ignore_plugin
+              <td class="test-title">api has_plugin
                   
               </td>
-              <td class="test-duration">416</td>
+              <td class="test-duration">246</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">17</td>
-              <td class="test-title">api has
+              <td class="test-title">api ignore_plugin
                   
               </td>
-              <td class="test-duration">12</td>
+              <td class="test-duration">364</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">18</td>
-              <td class="test-title">api find
+              <td class="test-title">api has
                   
               </td>
-              <td class="test-duration">58</td>
+              <td class="test-duration">5</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">19</td>
-              <td class="test-title">api status
+              <td class="test-title">api find
                   
               </td>
-              <td class="test-duration">141</td>
+              <td class="test-duration">17</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">20</td>
-              <td class="test-title">api reply
+              <td class="test-title">api status
                   
               </td>
-              <td class="test-duration">18</td>
+              <td class="test-duration">125</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">21</td>
+              <td class="test-title">api reply
+                  
+              </td>
+              <td class="test-duration">16</td>
+          </tr>
+          <tr class="show api success">
+              <td class="test-id">22</td>
               <td class="test-title">api delegate
                   
               </td>
-              <td class="test-duration">23</td>
-          </tr>
-          <tr class="show api fail success">
-              <td class="test-id">22</td>
-              <td class="test-title">api fail invoked with a code and details
-                  
-              </td>
-              <td class="test-duration">3</td>
-          </tr>
-          <tr class="show api fail invoked_with_a_condition,_code_and_details when_the_condition_is_true success">
-              <td class="test-id">23</td>
-              <td class="test-title">api fail invoked with a condition, code and details when the condition is true throws
-                  
-              </td>
-              <td class="test-duration">2</td>
-          </tr>
-          <tr class="show api fail invoked_with_a_condition,_code_and_details when_the_condition_is_false success">
-              <td class="test-id">24</td>
-              <td class="test-title">api fail invoked with a condition, code and details when the condition is false does not throw
-                  
-              </td>
-              <td class="test-duration">0</td>
-          </tr>
-          <tr class="show api fail invoked_with_a_condition,_code_and_details when_the_condition_is_not_a_boolean success">
-              <td class="test-id">25</td>
-              <td class="test-title">api fail invoked with a condition, code and details when the condition is not a boolean throws an assertion error
-                  
-              </td>
-              <td class="test-duration">1</td>
-          </tr>
-          <tr class="show api fail when_given_no_arguments success">
-              <td class="test-id">26</td>
-              <td class="test-title">api fail when given no arguments throws a seneca error
-                  
-              </td>
-              <td class="test-duration">1</td>
-          </tr>
-          <tr class="show api fail when_given_too_many_arguments success">
-              <td class="test-id">27</td>
-              <td class="test-title">api fail when given too many arguments throws a seneca error
-                  
-              </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">11</td>
           </tr>
           <tr class="show close success">
-              <td class="test-id">28</td>
+              <td class="test-id">23</td>
               <td class="test-title">close happy
                   
               </td>
-              <td class="test-duration">131</td>
+              <td class="test-duration">124</td>
           </tr>
           <tr class="show close success">
-              <td class="test-id">29</td>
+              <td class="test-id">24</td>
               <td class="test-title">close add
                   
               </td>
-              <td class="test-duration">134</td>
+              <td class="test-duration">130</td>
           </tr>
           <tr class="show close success">
-              <td class="test-id">30</td>
+              <td class="test-id">25</td>
               <td class="test-title">close graceful
                   
               </td>
-              <td class="test-duration">252</td>
+              <td class="test-duration">240</td>
           </tr>
           <tr class="show close success">
-              <td class="test-id">31</td>
+              <td class="test-id">26</td>
               <td class="test-title">close timeout
                   
               </td>
-              <td class="test-duration">152</td>
+              <td class="test-duration">125</td>
           </tr>
           <tr class="show close success">
-              <td class="test-id">32</td>
+              <td class="test-id">27</td>
               <td class="test-title">close handle-signal
                   
               </td>
-              <td class="test-duration">145</td>
+              <td class="test-duration">124</td>
           </tr>
           <tr class="show close success">
-              <td class="test-id">33</td>
+              <td class="test-id">28</td>
               <td class="test-title">close error
                   
               </td>
-              <td class="test-duration">123</td>
+              <td class="test-duration">125</td>
           </tr>
           <tr class="show close success">
-              <td class="test-id">34</td>
+              <td class="test-id">29</td>
               <td class="test-title">close no-promise
                   
               </td>
-              <td class="test-duration">131</td>
+              <td class="test-duration">125</td>
           </tr>
           <tr class="show close success">
-              <td class="test-id">35</td>
+              <td class="test-id">30</td>
               <td class="test-title">close with-promise
                   
               </td>
-              <td class="test-duration">172</td>
+              <td class="test-duration">125</td>
           </tr>
           <tr class="show close success">
-              <td class="test-id">36</td>
+              <td class="test-id">31</td>
               <td class="test-title">close with-async-await
                   
               </td>
-              <td class="test-duration">132</td>
+              <td class="test-duration">124</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">37</td>
+              <td class="test-id">32</td>
               <td class="test-title">common misc
                   
               </td>
-              <td class="test-duration">12</td>
+              <td class="test-duration">7</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">38</td>
+              <td class="test-id">33</td>
               <td class="test-title">common deepextend-empty
                   
               </td>
               <td class="test-duration">1</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">39</td>
+              <td class="test-id">34</td>
               <td class="test-title">common deepextend-dups
                   
               </td>
-              <td class="test-duration">1</td>
+              <td class="test-duration">0</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">40</td>
+              <td class="test-id">35</td>
               <td class="test-title">common deepextend-objs
                   
               </td>
-              <td class="test-duration">6</td>
+              <td class="test-duration">4</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">41</td>
+              <td class="test-id">36</td>
               <td class="test-title">common deepextend-objs with functions
                   
               </td>
               <td class="test-duration">0</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">42</td>
+              <td class="test-id">37</td>
               <td class="test-title">common pattern
                   
               </td>
               <td class="test-duration">1</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">43</td>
+              <td class="test-id">38</td>
               <td class="test-title">common nil
                   
               </td>
               <td class="test-duration">0</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">44</td>
+              <td class="test-id">39</td>
               <td class="test-title">common recurse
                   
               </td>
-              <td class="test-duration">1</td>
+              <td class="test-duration">0</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">45</td>
+              <td class="test-id">40</td>
               <td class="test-title">common pincanon
                   
               </td>
               <td class="test-duration">1</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">46</td>
+              <td class="test-id">41</td>
               <td class="test-title">common history
                   
               </td>
-              <td class="test-duration">9</td>
+              <td class="test-duration">7</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">47</td>
+              <td class="test-id">42</td>
               <td class="test-title">common clean
                   
               </td>
-              <td class="test-duration">4</td>
+              <td class="test-duration">2</td>
           </tr>
           <tr class="show common success">
-              <td class="test-id">48</td>
+              <td class="test-id">43</td>
               <td class="test-title">common parse_jsonic
+                  
+              </td>
+              <td class="test-duration">2</td>
+          </tr>
+          <tr class="show common success">
+              <td class="test-id">44</td>
+              <td class="test-title">common make_plugin_key
                   
               </td>
               <td class="test-duration">5</td>
           </tr>
-          <tr class="show common success">
-              <td class="test-id">49</td>
-              <td class="test-title">common make_plugin_key
-                  
-              </td>
-              <td class="test-duration">8</td>
-          </tr>
           <tr class="show custom success">
-              <td class="test-id">50</td>
+              <td class="test-id">45</td>
               <td class="test-title">custom custom-basic
                   
               </td>
-              <td class="test-duration">45</td>
+              <td class="test-duration">32</td>
           </tr>
           <tr class="show custom success">
-              <td class="test-id">51</td>
+              <td class="test-id">46</td>
               <td class="test-title">custom custom-deep
                   
               </td>
-              <td class="test-duration">151</td>
+              <td class="test-duration">133</td>
+          </tr>
+          <tr class="show custom success">
+              <td class="test-id">47</td>
+              <td class="test-title">custom custom-reply
+                  
+              </td>
+              <td class="test-duration">132</td>
+          </tr>
+          <tr class="show custom success">
+              <td class="test-id">48</td>
+              <td class="test-title">custom custom-entity
+                  
+              </td>
+              <td class="test-duration">156</td>
+          </tr>
+          <tr class="show custom success">
+              <td class="test-id">49</td>
+              <td class="test-title">custom custom-prior
+                  
+              </td>
+              <td class="test-duration">23</td>
+          </tr>
+          <tr class="show custom success">
+              <td class="test-id">50</td>
+              <td class="test-title">custom custom-simple-transport
+                  
+              </td>
+              <td class="test-duration">160</td>
+          </tr>
+          <tr class="show custom success">
+              <td class="test-id">51</td>
+              <td class="test-title">custom custom-bells-transport
+                  
+              </td>
+              <td class="test-duration">280</td>
           </tr>
           <tr class="show custom success">
               <td class="test-id">52</td>
-              <td class="test-title">custom custom-reply
+              <td class="test-title">custom custom-add-basic
                   
               </td>
               <td class="test-duration">135</td>
           </tr>
           <tr class="show custom success">
               <td class="test-id">53</td>
-              <td class="test-title">custom custom-entity
-                  
-              </td>
-              <td class="test-duration">220</td>
-          </tr>
-          <tr class="show custom success">
-              <td class="test-id">54</td>
-              <td class="test-title">custom custom-prior
-                  
-              </td>
-              <td class="test-duration">37</td>
-          </tr>
-          <tr class="show custom success">
-              <td class="test-id">55</td>
-              <td class="test-title">custom custom-simple-transport
-                  
-              </td>
-              <td class="test-duration">196</td>
-          </tr>
-          <tr class="show custom success">
-              <td class="test-id">56</td>
-              <td class="test-title">custom custom-bells-transport
-                  
-              </td>
-              <td class="test-duration">413</td>
-          </tr>
-          <tr class="show custom success">
-              <td class="test-id">57</td>
-              <td class="test-title">custom custom-add-basic
-                  
-              </td>
-              <td class="test-duration">182</td>
-          </tr>
-          <tr class="show custom success">
-              <td class="test-id">58</td>
               <td class="test-title">custom custom-add-fix
                   
               </td>
-              <td class="test-duration">67</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show debug success">
-              <td class="test-id">59</td>
+              <td class="test-id">54</td>
               <td class="test-title">debug logroute
                   
               </td>
-              <td class="test-duration">13</td>
+              <td class="test-duration">11</td>
           </tr>
           <tr class="show delegation success">
-              <td class="test-id">60</td>
+              <td class="test-id">55</td>
               <td class="test-title">delegation happy
                   
               </td>
-              <td class="test-duration">155</td>
+              <td class="test-duration">149</td>
           </tr>
           <tr class="show delegation success">
-              <td class="test-id">61</td>
+              <td class="test-id">56</td>
               <td class="test-title">delegation dynamic
                   
               </td>
-              <td class="test-duration">244</td>
+              <td class="test-duration">134</td>
           </tr>
           <tr class="show delegation success">
-              <td class="test-id">62</td>
+              <td class="test-id">57</td>
               <td class="test-title">delegation prior.basic
                   
               </td>
-              <td class="test-duration">229</td>
+              <td class="test-duration">133</td>
           </tr>
           <tr class="show delegation success">
-              <td class="test-id">63</td>
+              <td class="test-id">58</td>
               <td class="test-title">delegation parent.plugin
                   
               </td>
-              <td class="test-duration">242</td>
+              <td class="test-duration">149</td>
           </tr>
           <tr class="show entity success">
-              <td class="test-id">64</td>
+              <td class="test-id">59</td>
               <td class="test-title">entity happy
                   
               </td>
-              <td class="test-duration">173</td>
+              <td class="test-duration">40</td>
           </tr>
           <tr class="show entity success">
-              <td class="test-id">65</td>
+              <td class="test-id">60</td>
               <td class="test-title">entity entity-msg
                   
               </td>
-              <td class="test-duration">139</td>
+              <td class="test-duration">143</td>
           </tr>
           <tr class="show entity success">
-              <td class="test-id">66</td>
+              <td class="test-id">61</td>
               <td class="test-title">entity mem-ops
                   
               </td>
-              <td class="test-duration">278</td>
+              <td class="test-duration">179</td>
           </tr>
           <tr class="show error success">
-              <td class="test-id">67</td>
+              <td class="test-id">62</td>
               <td class="test-title">error fail
                   
               </td>
-              <td class="test-duration">16</td>
+              <td class="test-duration">10</td>
           </tr>
           <tr class="show error success">
-              <td class="test-id">68</td>
+              <td class="test-id">63</td>
               <td class="test-title">error response_is_error
                   
               </td>
-              <td class="test-duration">34</td>
+              <td class="test-duration">24</td>
           </tr>
           <tr class="show error success">
-              <td class="test-id">69</td>
+              <td class="test-id">64</td>
               <td class="test-title">error action_callback
                   
               </td>
               <td class="test-duration">33</td>
           </tr>
           <tr class="show error success">
-              <td class="test-id">70</td>
+              <td class="test-id">65</td>
               <td class="test-title">error plugin_load
-                  
-              </td>
-              <td class="test-duration">29</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">71</td>
-              <td class="test-title">error act_not_found
-                  
-              </td>
-              <td class="test-duration">64</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">72</td>
-              <td class="test-title">error exec_action_throw_basic
-                  
-              </td>
-              <td class="test-duration">30</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">73</td>
-              <td class="test-title">error exec_action_throw_basic_legacy
-                  
-              </td>
-              <td class="test-duration">51</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">74</td>
-              <td class="test-title">error exec_action_throw_nolog
                   
               </td>
               <td class="test-duration">20</td>
           </tr>
           <tr class="show error success">
-              <td class="test-id">75</td>
+              <td class="test-id">66</td>
+              <td class="test-title">error act_not_found
+                  
+              </td>
+              <td class="test-duration">61</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">67</td>
+              <td class="test-title">error exec_action_throw_basic
+                  
+              </td>
+              <td class="test-duration">15</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">68</td>
+              <td class="test-title">error exec_action_throw_basic_legacy
+                  
+              </td>
+              <td class="test-duration">36</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">69</td>
+              <td class="test-title">error exec_action_throw_nolog
+                  
+              </td>
+              <td class="test-duration">17</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">70</td>
               <td class="test-title">error exec_action_errhandler_throw
                   
               </td>
-              <td class="test-duration">60</td>
+              <td class="test-duration">53</td>
           </tr>
           <tr class="show error success">
-              <td class="test-id">76</td>
+              <td class="test-id">71</td>
               <td class="test-title">error exec_action_result
                   
               </td>
-              <td class="test-duration">28</td>
+              <td class="test-duration">14</td>
           </tr>
           <tr class="show error success">
-              <td class="test-id">77</td>
+              <td class="test-id">72</td>
               <td class="test-title">error exec_deep_action_result
-                  
-              </td>
-              <td class="test-duration">31</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">78</td>
-              <td class="test-title">error exec_remote_action_result
-                  
-              </td>
-              <td class="test-duration">209</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">79</td>
-              <td class="test-title">error exec_action_result_legacy
-                  
-              </td>
-              <td class="test-duration">52</td>
-          </tr>
-          <tr class="show error success">
-              <td class="test-id">80</td>
-              <td class="test-title">error exec_action_result_nolog
                   
               </td>
               <td class="test-duration">19</td>
           </tr>
           <tr class="show error success">
-              <td class="test-id">81</td>
+              <td class="test-id">73</td>
+              <td class="test-title">error exec_remote_action_result
+                  
+              </td>
+              <td class="test-duration">149</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">74</td>
+              <td class="test-title">error exec_action_result_legacy
+                  
+              </td>
+              <td class="test-duration">33</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">75</td>
+              <td class="test-title">error exec_action_result_nolog
+                  
+              </td>
+              <td class="test-duration">27</td>
+          </tr>
+          <tr class="show error success">
+              <td class="test-id">76</td>
               <td class="test-title">error exec_action_errhandler_result
                   
               </td>
-              <td class="test-duration">56</td>
+              <td class="test-duration">58</td>
           </tr>
           <tr class="show error success">
-              <td class="test-id">82</td>
+              <td class="test-id">77</td>
               <td class="test-title">error action_callback
                   
               </td>
-              <td class="test-duration">186</td>
+              <td class="test-duration">173</td>
           </tr>
           <tr class="show error success">
-              <td class="test-id">83</td>
+              <td class="test-id">78</td>
               <td class="test-title">error legacy_fail
                   
               </td>
-              <td class="test-duration">76</td>
+              <td class="test-duration">10</td>
           </tr>
           <tr class="show error success">
-              <td class="test-id">84</td>
+              <td class="test-id">79</td>
               <td class="test-title">error types
                   
               </td>
-              <td class="test-duration">47</td>
+              <td class="test-duration">21</td>
           </tr>
           <tr class="show explain success">
-              <td class="test-id">85</td>
+              <td class="test-id">80</td>
               <td class="test-title">explain explain-basic
                   
               </td>
-              <td class="test-duration">50</td>
+              <td class="test-duration">42</td>
           </tr>
           <tr class="show explain success">
-              <td class="test-id">86</td>
+              <td class="test-id">81</td>
               <td class="test-title">explain explain-data
                   
               </td>
-              <td class="test-duration">71</td>
+              <td class="test-duration">46</td>
           </tr>
           <tr class="show explain success">
-              <td class="test-id">87</td>
+              <td class="test-id">82</td>
               <td class="test-title">explain explain-deep
                   
               </td>
-              <td class="test-duration">48</td>
+              <td class="test-duration">41</td>
           </tr>
           <tr class="show explain success">
-              <td class="test-id">88</td>
+              <td class="test-id">83</td>
               <td class="test-title">explain explain-toplevel
                   
               </td>
-              <td class="test-duration">168</td>
+              <td class="test-duration">131</td>
           </tr>
           <tr class="show explain success">
-              <td class="test-id">89</td>
+              <td class="test-id">84</td>
               <td class="test-title">explain explain-transport
                   
               </td>
-              <td class="test-duration">378</td>
+              <td class="test-duration">297</td>
           </tr>
           <tr class="show exports success">
-              <td class="test-id">90</td>
+              <td class="test-id">85</td>
               <td class="test-title">exports happy
                   
               </td>
-              <td class="test-duration">201</td>
+              <td class="test-duration">122</td>
           </tr>
           <tr class="show exports success">
-              <td class="test-id">91</td>
+              <td class="test-id">86</td>
               <td class="test-title">exports with-init
                   
               </td>
-              <td class="test-duration">176</td>
+              <td class="test-duration">122</td>
           </tr>
           <tr class="show exports success">
-              <td class="test-id">92</td>
+              <td class="test-id">87</td>
               <td class="test-title">exports with-preload
                   
               </td>
-              <td class="test-duration">133</td>
+              <td class="test-duration">125</td>
           </tr>
           <tr class="show exports success">
-              <td class="test-id">93</td>
+              <td class="test-id">88</td>
               <td class="test-title">exports with-preload-and-init
                   
               </td>
-              <td class="test-duration">138</td>
+              <td class="test-duration">123</td>
           </tr>
           <tr class="show outward success">
-              <td class="test-id">94</td>
+              <td class="test-id">89</td>
               <td class="test-title">outward act_error
                   
               </td>
-              <td class="test-duration">0</td>
+              <td class="test-duration">1</td>
           </tr>
           <tr class="show inward success">
-              <td class="test-id">95</td>
+              <td class="test-id">90</td>
               <td class="test-title">inward announce
                   
               </td>
-              <td class="test-duration">126</td>
+              <td class="test-duration">120</td>
           </tr>
           <tr class="show inward success">
-              <td class="test-id">96</td>
+              <td class="test-id">91</td>
               <td class="test-title">inward arg-check
                   
               </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">3</td>
           </tr>
           <tr class="show legacy success">
-              <td class="test-id">97</td>
+              <td class="test-id">92</td>
               <td class="test-title">legacy fail
                   
               </td>
-              <td class="test-duration">3</td>
+              <td class="test-duration">1</td>
           </tr>
           <tr class="show legacy success">
-              <td class="test-id">98</td>
+              <td class="test-id">93</td>
               <td class="test-title">legacy argprops
                   
               </td>
-              <td class="test-duration">3</td>
+              <td class="test-duration">1</td>
           </tr>
           <tr class="show legacy success">
-              <td class="test-id">99</td>
+              <td class="test-id">94</td>
               <td class="test-title">legacy router
                   
               </td>
               <td class="test-duration">1</td>
           </tr>
           <tr class="show legacy success">
-              <td class="test-id">100</td>
+              <td class="test-id">95</td>
               <td class="test-title">legacy no-default-transport
+                  
+              </td>
+              <td class="test-duration">118</td>
+          </tr>
+          <tr class="show legacy success">
+              <td class="test-id">96</td>
+              <td class="test-title">legacy actdef
+                  
+              </td>
+              <td class="test-duration">9</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">97</td>
+              <td class="test-title">logging happy
                   
               </td>
               <td class="test-duration">122</td>
           </tr>
-          <tr class="show legacy success">
-              <td class="test-id">101</td>
-              <td class="test-title">legacy actdef
-                  
-              </td>
-              <td class="test-duration">29</td>
-          </tr>
           <tr class="show logging success">
-              <td class="test-id">102</td>
-              <td class="test-title">logging happy
-                  
-              </td>
-              <td class="test-duration">138</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">103</td>
+              <td class="test-id">98</td>
               <td class="test-title">logging happy-ng
                   
               </td>
-              <td class="test-duration">159</td>
+              <td class="test-duration">122</td>
           </tr>
           <tr class="show logging success">
-              <td class="test-id">104</td>
+              <td class="test-id">99</td>
               <td class="test-title">logging level-text-values
                   
               </td>
-              <td class="test-duration">58</td>
+              <td class="test-duration">10</td>
           </tr>
           <tr class="show logging success">
-              <td class="test-id">105</td>
+              <td class="test-id">100</td>
               <td class="test-title">logging build_log_spec
                   
               </td>
-              <td class="test-duration">11</td>
+              <td class="test-duration">2</td>
           </tr>
           <tr class="show logging success">
-              <td class="test-id">106</td>
+              <td class="test-id">101</td>
               <td class="test-title">logging event
-                  
-              </td>
-              <td class="test-duration">160</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">107</td>
-              <td class="test-title">logging quiet
-                  
-              </td>
-              <td class="test-duration">199</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">108</td>
-              <td class="test-title">logging bad_logspec
-                  
-              </td>
-              <td class="test-duration">6</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">109</td>
-              <td class="test-title">logging basic
-                  
-              </td>
-              <td class="test-duration">123</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">110</td>
-              <td class="test-title">logging logger-output
-                  
-              </td>
-              <td class="test-duration">895</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">111</td>
-              <td class="test-title">logging shortcuts
-                  
-              </td>
-              <td class="test-duration">1788</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">112</td>
-              <td class="test-title">logging test-mode-basic
-                  
-              </td>
-              <td class="test-duration">194</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">113</td>
-              <td class="test-title">logging test-mode-option
-                  
-              </td>
-              <td class="test-duration">157</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">114</td>
-              <td class="test-title">logging test-mode-argv
-                  
-              </td>
-              <td class="test-duration">197</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">115</td>
-              <td class="test-title">logging test-mode-argv-opts
-                  
-              </td>
-              <td class="test-duration">184</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">116</td>
-              <td class="test-title">logging test-mode-env
-                  
-              </td>
-              <td class="test-duration">156</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">117</td>
-              <td class="test-title">logging quiet-mode-basic
-                  
-              </td>
-              <td class="test-duration">189</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">118</td>
-              <td class="test-title">logging quiet-mode-option
-                  
-              </td>
-              <td class="test-duration">165</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">119</td>
-              <td class="test-title">logging quiet-mode-argv
-                  
-              </td>
-              <td class="test-duration">183</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">120</td>
-              <td class="test-title">logging quiet-mode-argv-opts
-                  
-              </td>
-              <td class="test-duration">153</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">121</td>
-              <td class="test-title">logging quiet-mode-env
-                  
-              </td>
-              <td class="test-duration">197</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">122</td>
-              <td class="test-title">logging test-quiet-mode-basic
-                  
-              </td>
-              <td class="test-duration">198</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">123</td>
-              <td class="test-title">logging quiet-test-mode-basic
-                  
-              </td>
-              <td class="test-duration">155</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">124</td>
-              <td class="test-title">logging test-ready-quiet-mode-basic
-                  
-              </td>
-              <td class="test-duration">309</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">125</td>
-              <td class="test-title">logging quiet-ready-test-mode-basic
-                  
-              </td>
-              <td class="test-duration">288</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">126</td>
-              <td class="test-title">logging quiet-argv-override
-                  
-              </td>
-              <td class="test-duration">135</td>
-          </tr>
-          <tr class="show logging success">
-              <td class="test-id">127</td>
-              <td class="test-title">logging test-argv-override
                   
               </td>
               <td class="test-duration">132</td>
           </tr>
           <tr class="show logging success">
-              <td class="test-id">128</td>
-              <td class="test-title">logging quiet-env-override
+              <td class="test-id">102</td>
+              <td class="test-title">logging quiet
                   
               </td>
-              <td class="test-duration">140</td>
+              <td class="test-duration">124</td>
           </tr>
           <tr class="show logging success">
-              <td class="test-id">129</td>
-              <td class="test-title">logging test-env-override
+              <td class="test-id">103</td>
+              <td class="test-title">logging bad_logspec
+                  
+              </td>
+              <td class="test-duration">7</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">104</td>
+              <td class="test-title">logging basic
+                  
+              </td>
+              <td class="test-duration">121</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">105</td>
+              <td class="test-title">logging logger-output
+                  
+              </td>
+              <td class="test-duration">854</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">106</td>
+              <td class="test-title">logging shortcuts
+                  
+              </td>
+              <td class="test-duration">1487</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">107</td>
+              <td class="test-title">logging test-mode-basic
+                  
+              </td>
+              <td class="test-duration">121</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">108</td>
+              <td class="test-title">logging test-mode-option
+                  
+              </td>
+              <td class="test-duration">121</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">109</td>
+              <td class="test-title">logging test-mode-argv
+                  
+              </td>
+              <td class="test-duration">127</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">110</td>
+              <td class="test-title">logging test-mode-argv-opts
+                  
+              </td>
+              <td class="test-duration">124</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">111</td>
+              <td class="test-title">logging test-mode-env
+                  
+              </td>
+              <td class="test-duration">152</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">112</td>
+              <td class="test-title">logging quiet-mode-basic
                   
               </td>
               <td class="test-duration">136</td>
           </tr>
           <tr class="show logging success">
-              <td class="test-id">130</td>
-              <td class="test-title">logging intern.build_act_entry
+              <td class="test-id">113</td>
+              <td class="test-title">logging quiet-mode-option
                   
               </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">123</td>
           </tr>
-          <tr class="show message success">
-              <td class="test-id">131</td>
-              <td class="test-title">message happy-vanilla
+          <tr class="show logging success">
+              <td class="test-id">114</td>
+              <td class="test-title">logging quiet-mode-argv
                   
               </td>
-              <td class="test-duration">87</td>
+              <td class="test-duration">123</td>
           </tr>
-          <tr class="show message success">
-              <td class="test-id">132</td>
-              <td class="test-title">message happy-msg
+          <tr class="show logging success">
+              <td class="test-id">115</td>
+              <td class="test-title">logging quiet-mode-argv-opts
                   
               </td>
-              <td class="test-duration">48</td>
+              <td class="test-duration">125</td>
           </tr>
-          <tr class="show message success">
-              <td class="test-id">133</td>
-              <td class="test-title">message loop
+          <tr class="show logging success">
+              <td class="test-id">116</td>
+              <td class="test-title">logging quiet-mode-env
                   
               </td>
-              <td class="test-duration">30</td>
+              <td class="test-duration">124</td>
           </tr>
-          <tr class="show message success">
-              <td class="test-id">134</td>
-              <td class="test-title">message branch
+          <tr class="show logging success">
+              <td class="test-id">117</td>
+              <td class="test-title">logging test-quiet-mode-basic
                   
               </td>
-              <td class="test-duration">70</td>
+              <td class="test-duration">122</td>
           </tr>
-          <tr class="show message success">
-              <td class="test-id">135</td>
-              <td class="test-title">message empty-response
+          <tr class="show logging success">
+              <td class="test-id">118</td>
+              <td class="test-title">logging quiet-test-mode-basic
                   
               </td>
-              <td class="test-duration">132</td>
+              <td class="test-duration">125</td>
           </tr>
-          <tr class="show message success">
-              <td class="test-id">136</td>
-              <td class="test-title">message reply
+          <tr class="show logging success">
+              <td class="test-id">119</td>
+              <td class="test-title">logging test-ready-quiet-mode-basic
                   
               </td>
-              <td class="test-duration">184</td>
+              <td class="test-duration">240</td>
           </tr>
-          <tr class="show message success">
-              <td class="test-id">137</td>
-              <td class="test-title">message prior
+          <tr class="show logging success">
+              <td class="test-id">120</td>
+              <td class="test-title">logging quiet-ready-test-mode-basic
+                  
+              </td>
+              <td class="test-duration">237</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">121</td>
+              <td class="test-title">logging quiet-argv-override
                   
               </td>
               <td class="test-duration">129</td>
           </tr>
+          <tr class="show logging success">
+              <td class="test-id">122</td>
+              <td class="test-title">logging test-argv-override
+                  
+              </td>
+              <td class="test-duration">123</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">123</td>
+              <td class="test-title">logging quiet-env-override
+                  
+              </td>
+              <td class="test-duration">123</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">124</td>
+              <td class="test-title">logging test-env-override
+                  
+              </td>
+              <td class="test-duration">123</td>
+          </tr>
+          <tr class="show logging success">
+              <td class="test-id">125</td>
+              <td class="test-title">logging intern.build_act_entry
+                  
+              </td>
+              <td class="test-duration">1</td>
+          </tr>
           <tr class="show message success">
-              <td class="test-id">138</td>
+              <td class="test-id">126</td>
+              <td class="test-title">message happy-vanilla
+                  
+              </td>
+              <td class="test-duration">24</td>
+          </tr>
+          <tr class="show message success">
+              <td class="test-id">127</td>
+              <td class="test-title">message happy-msg
+                  
+              </td>
+              <td class="test-duration">25</td>
+          </tr>
+          <tr class="show message success">
+              <td class="test-id">128</td>
+              <td class="test-title">message loop
+                  
+              </td>
+              <td class="test-duration">23</td>
+          </tr>
+          <tr class="show message success">
+              <td class="test-id">129</td>
+              <td class="test-title">message branch
+                  
+              </td>
+              <td class="test-duration">31</td>
+          </tr>
+          <tr class="show message success">
+              <td class="test-id">130</td>
+              <td class="test-title">message empty-response
+                  
+              </td>
+              <td class="test-duration">124</td>
+          </tr>
+          <tr class="show message success">
+              <td class="test-id">131</td>
+              <td class="test-title">message reply
+                  
+              </td>
+              <td class="test-duration">124</td>
+          </tr>
+          <tr class="show message success">
+              <td class="test-id">132</td>
+              <td class="test-title">message prior
+                  
+              </td>
+              <td class="test-duration">126</td>
+          </tr>
+          <tr class="show message success">
+              <td class="test-id">133</td>
               <td class="test-title">message entity
                   
               </td>
-              <td class="test-duration">62</td>
+              <td class="test-duration">35</td>
           </tr>
           <tr class="show message success">
-              <td class="test-id">139</td>
+              <td class="test-id">134</td>
               <td class="test-title">message single-simple-transport
                   
               </td>
-              <td class="test-duration">170</td>
+              <td class="test-duration">175</td>
           </tr>
           <tr class="show message success">
-              <td class="test-id">140</td>
+              <td class="test-id">135</td>
               <td class="test-title">message simple-transport
                   
               </td>
-              <td class="test-duration">688</td>
+              <td class="test-duration">600</td>
           </tr>
           <tr class="show message success">
-              <td class="test-id">141</td>
+              <td class="test-id">136</td>
               <td class="test-title">message partial-patterns
                   
               </td>
-              <td class="test-duration">178</td>
+              <td class="test-duration">124</td>
           </tr>
           <tr class="show meta success">
-              <td class="test-id">142</td>
+              <td class="test-id">137</td>
               <td class="test-title">meta custom-parents
                   
               </td>
-              <td class="test-duration">186</td>
+              <td class="test-duration">30</td>
           </tr>
           <tr class="show meta success">
-              <td class="test-id">143</td>
+              <td class="test-id">138</td>
               <td class="test-title">meta custom-priors
                   
               </td>
-              <td class="test-duration">99</td>
+              <td class="test-duration">34</td>
           </tr>
           <tr class="show meta success">
-              <td class="test-id">144</td>
+              <td class="test-id">139</td>
               <td class="test-title">meta custom-fixed
                   
               </td>
-              <td class="test-duration">26</td>
+              <td class="test-duration">24</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">145</td>
+              <td class="test-id">140</td>
               <td class="test-title">options strict.find
                   
               </td>
-              <td class="test-duration">9</td>
+              <td class="test-duration">7</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">146</td>
+              <td class="test-id">141</td>
               <td class="test-title">options internal.routers
                   
               </td>
-              <td class="test-duration">14</td>
+              <td class="test-duration">13</td>
           </tr>
           <tr class="show order success">
-              <td class="test-id">147</td>
+              <td class="test-id">142</td>
               <td class="test-title">order happy
                   
               </td>
-              <td class="test-duration">252</td>
+              <td class="test-duration">261</td>
           </tr>
           <tr class="show outward success">
-              <td class="test-id">148</td>
+              <td class="test-id">143</td>
               <td class="test-title">outward make_error
-                  
-              </td>
-              <td class="test-duration">5</td>
-          </tr>
-          <tr class="show outward success">
-              <td class="test-id">149</td>
-              <td class="test-title">outward act_stats
                   
               </td>
               <td class="test-duration">2</td>
           </tr>
           <tr class="show outward success">
-              <td class="test-id">150</td>
+              <td class="test-id">144</td>
+              <td class="test-title">outward act_stats
+                  
+              </td>
+              <td class="test-duration">1</td>
+          </tr>
+          <tr class="show outward success">
+              <td class="test-id">145</td>
               <td class="test-title">outward arg-check
+                  
+              </td>
+              <td class="test-duration">1</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">146</td>
+              <td class="test-title">plugin use.intern
+                  
+              </td>
+              <td class="test-duration">10</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">147</td>
+              <td class="test-title">plugin plugin-edges
+                  
+              </td>
+              <td class="test-duration">9</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">148</td>
+              <td class="test-title">plugin plugin-internal-ordu
                   
               </td>
               <td class="test-duration">8</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">151</td>
-              <td class="test-title">plugin use.intern
-                  
-              </td>
-              <td class="test-duration">87</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">152</td>
-              <td class="test-title">plugin plugin-edges
-                  
-              </td>
-              <td class="test-duration">35</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">153</td>
-              <td class="test-title">plugin plugin-internal-ordu
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">154</td>
+              <td class="test-id">149</td>
               <td class="test-title">plugin standard-test-plugin
-                  
-              </td>
-              <td class="test-duration">152</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">155</td>
-              <td class="test-title">plugin standard-test-plugin-full-ignore
-                  
-              </td>
-              <td class="test-duration">299</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">156</td>
-              <td class="test-title">plugin plugin-ignore-via-options
-                  
-              </td>
-              <td class="test-duration">193</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">157</td>
-              <td class="test-title">plugin plugin-ignore-null
-                  
-              </td>
-              <td class="test-duration">194</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">158</td>
-              <td class="test-title">plugin plugin-delegate-init
-                  
-              </td>
-              <td class="test-duration">130</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">159</td>
-              <td class="test-title">plugin load-defaults
-                  
-              </td>
-              <td class="test-duration">187</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">160</td>
-              <td class="test-title">plugin load-relative-to-root
-                  
-              </td>
-              <td class="test-duration">140</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">161</td>
-              <td class="test-title">plugin good-default-options
-                  
-              </td>
-              <td class="test-duration">164</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">162</td>
-              <td class="test-title">plugin bad-default-options
-                  
-              </td>
-              <td class="test-duration">20</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">163</td>
-              <td class="test-title">plugin legacy-options
-                  
-              </td>
-              <td class="test-duration">13</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">164</td>
-              <td class="test-title">plugin should return &quot;no errors created.&quot; when passing test false
-                  
-              </td>
-              <td class="test-duration">421</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">165</td>
-              <td class="test-title">plugin should return &quot;error caught!&quot; when passing test true
-                  
-              </td>
-              <td class="test-duration">398</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">166</td>
-              <td class="test-title">plugin works with exportmap
                   
               </td>
               <td class="test-duration">153</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">167</td>
-              <td class="test-title">plugin bad
+              <td class="test-id">150</td>
+              <td class="test-title">plugin standard-test-plugin-full-ignore
                   
               </td>
-              <td class="test-duration">217</td>
+              <td class="test-duration">239</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">168</td>
-              <td class="test-title">plugin plugin-error-def
+              <td class="test-id">151</td>
+              <td class="test-title">plugin plugin-ignore-via-options
                   
               </td>
-              <td class="test-duration">76</td>
+              <td class="test-duration">122</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">169</td>
-              <td class="test-title">plugin plugin-error-deprecated
+              <td class="test-id">152</td>
+              <td class="test-title">plugin plugin-ignore-null
+                  
+              </td>
+              <td class="test-duration">123</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">153</td>
+              <td class="test-title">plugin plugin-delegate-init
+                  
+              </td>
+              <td class="test-duration">129</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">154</td>
+              <td class="test-title">plugin load-defaults
+                  
+              </td>
+              <td class="test-duration">127</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">155</td>
+              <td class="test-title">plugin load-relative-to-root
+                  
+              </td>
+              <td class="test-duration">133</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">156</td>
+              <td class="test-title">plugin good-default-options
+                  
+              </td>
+              <td class="test-duration">130</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">157</td>
+              <td class="test-title">plugin bad-default-options
                   
               </td>
               <td class="test-duration">21</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">170</td>
+              <td class="test-id">158</td>
+              <td class="test-title">plugin legacy-options
+                  
+              </td>
+              <td class="test-duration">16</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">159</td>
+              <td class="test-title">plugin should return &quot;no errors created.&quot; when passing test false
+                  
+              </td>
+              <td class="test-duration">403</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">160</td>
+              <td class="test-title">plugin should return &quot;error caught!&quot; when passing test true
+                  
+              </td>
+              <td class="test-duration">376</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">161</td>
+              <td class="test-title">plugin works with exportmap
+                  
+              </td>
+              <td class="test-duration">123</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">162</td>
+              <td class="test-title">plugin bad
+                  
+              </td>
+              <td class="test-duration">132</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">163</td>
+              <td class="test-title">plugin plugin-error-def
+                  
+              </td>
+              <td class="test-duration">22</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">164</td>
+              <td class="test-title">plugin plugin-error-deprecated
+                  
+              </td>
+              <td class="test-duration">23</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">165</td>
               <td class="test-title">plugin plugin-error-add
                   
               </td>
-              <td class="test-duration">15</td>
+              <td class="test-duration">20</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">171</td>
+              <td class="test-id">166</td>
               <td class="test-title">plugin plugin-error-act
                   
               </td>
-              <td class="test-duration">29</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">172</td>
+              <td class="test-id">167</td>
               <td class="test-title">plugin depends
                   
               </td>
               <td class="test-duration">143</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">173</td>
+              <td class="test-id">168</td>
               <td class="test-title">plugin plugin-fix
                   
               </td>
-              <td class="test-duration">197</td>
+              <td class="test-duration">153</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">174</td>
+              <td class="test-id">169</td>
               <td class="test-title">plugin export
                   
               </td>
-              <td class="test-duration">18</td>
+              <td class="test-duration">12</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">175</td>
+              <td class="test-id">170</td>
               <td class="test-title">plugin handles plugin with action that timesout
                   
               </td>
-              <td class="test-duration">247</td>
+              <td class="test-duration">245</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">176</td>
+              <td class="test-id">171</td>
               <td class="test-title">plugin handles plugin action that throws an error
                   
               </td>
-              <td class="test-duration">178</td>
+              <td class="test-duration">134</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">177</td>
+              <td class="test-id">172</td>
               <td class="test-title">plugin calling act from init actor is deprecated
                   
               </td>
-              <td class="test-duration">42</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">178</td>
+              <td class="test-id">173</td>
               <td class="test-title">plugin plugin actions receive errors in callback function
                   
               </td>
-              <td class="test-duration">148</td>
+              <td class="test-duration">143</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">179</td>
+              <td class="test-id">174</td>
               <td class="test-title">plugin dynamic-load-sequence
                   
               </td>
-              <td class="test-duration">401</td>
+              <td class="test-duration">354</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">180</td>
+              <td class="test-id">175</td>
               <td class="test-title">plugin serial-load-sequence
                   
               </td>
-              <td class="test-duration">144</td>
+              <td class="test-duration">126</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">181</td>
+              <td class="test-id">176</td>
               <td class="test-title">plugin plugin options can be modified by plugins during load sequence
                   
               </td>
-              <td class="test-duration">148</td>
+              <td class="test-duration">123</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">182</td>
+              <td class="test-id">177</td>
               <td class="test-title">plugin plugin options can be modified by plugins during init sequence
                   
               </td>
-              <td class="test-duration">151</td>
+              <td class="test-duration">127</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">183</td>
+              <td class="test-id">178</td>
               <td class="test-title">plugin plugin init can add actions for future init actions to call
                   
               </td>
-              <td class="test-duration">152</td>
+              <td class="test-duration">125</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">184</td>
+              <td class="test-id">179</td>
               <td class="test-title">plugin plugin-init-error
-                  
-              </td>
-              <td class="test-duration">60</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">185</td>
-              <td class="test-title">plugin plugin-extend-action-modifier
-                  
-              </td>
-              <td class="test-duration">170</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">186</td>
-              <td class="test-title">plugin plugin-extend-logger
-                  
-              </td>
-              <td class="test-duration">138</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">187</td>
-              <td class="test-title">plugin plugins-from-options
-                  
-              </td>
-              <td class="test-duration">158</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">188</td>
-              <td class="test-title">plugin plugins-from-bad-options
-                  
-              </td>
-              <td class="test-duration">71</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">189</td>
-              <td class="test-title">plugin plugins-options-precedence
-                  
-              </td>
-              <td class="test-duration">158</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">190</td>
-              <td class="test-title">plugin error-plugin-define
-                  
-              </td>
-              <td class="test-duration">82</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">191</td>
-              <td class="test-title">plugin error-plugin-init
                   
               </td>
               <td class="test-duration">34</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">192</td>
-              <td class="test-title">plugin error-plugin-action
+              <td class="test-id">180</td>
+              <td class="test-title">plugin plugin-extend-action-modifier
                   
               </td>
-              <td class="test-duration">19</td>
+              <td class="test-duration">172</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">193</td>
-              <td class="test-title">plugin no-name
+              <td class="test-id">181</td>
+              <td class="test-title">plugin plugin-extend-logger
                   
               </td>
-              <td class="test-duration">140</td>
+              <td class="test-duration">129</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">194</td>
-              <td class="test-title">plugin seneca-prefix-wins
+              <td class="test-id">182</td>
+              <td class="test-title">plugin plugins-from-options
                   
               </td>
-              <td class="test-duration">194</td>
+              <td class="test-duration">127</td>
           </tr>
           <tr class="show plugin success">
-              <td class="test-id">195</td>
-              <td class="test-title">plugin plugin-defaults-top-level-joi
-                  
-              </td>
-              <td class="test-duration">199</td>
-          </tr>
-          <tr class="show plugin success">
-              <td class="test-id">196</td>
-              <td class="test-title">plugin plugin-order-task-args
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show print success">
-              <td class="test-id">197</td>
-              <td class="test-title">print init
-                  
-              </td>
-              <td class="test-duration">29</td>
-          </tr>
-          <tr class="show print success">
-              <td class="test-id">198</td>
-              <td class="test-title">print options
-                  
-              </td>
-              <td class="test-duration">18</td>
-          </tr>
-          <tr class="show print success">
-              <td class="test-id">199</td>
-              <td class="test-title">print print
-                  
-              </td>
-              <td class="test-duration">11</td>
-          </tr>
-          <tr class="show print success">
-              <td class="test-id">200</td>
-              <td class="test-title">print custom-print
-                  
-              </td>
-              <td class="test-duration">23</td>
-          </tr>
-          <tr class="show prior success">
-              <td class="test-id">201</td>
-              <td class="test-title">prior happy
-                  
-              </td>
-              <td class="test-duration">39</td>
-          </tr>
-          <tr class="show prior success">
-              <td class="test-id">202</td>
-              <td class="test-title">prior top-level
+              <td class="test-id">183</td>
+              <td class="test-title">plugin plugins-from-bad-options
                   
               </td>
               <td class="test-duration">15</td>
           </tr>
-          <tr class="show prior success">
-              <td class="test-id">203</td>
-              <td class="test-title">prior add-general-to-specific
+          <tr class="show plugin success">
+              <td class="test-id">184</td>
+              <td class="test-title">plugin plugins-options-precedence
                   
               </td>
-              <td class="test-duration">28</td>
+              <td class="test-duration">128</td>
           </tr>
-          <tr class="show prior success">
-              <td class="test-id">204</td>
-              <td class="test-title">prior add-strict-general-to-specific
+          <tr class="show plugin success">
+              <td class="test-id">185</td>
+              <td class="test-title">plugin error-plugin-define
+                  
+              </td>
+              <td class="test-duration">19</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">186</td>
+              <td class="test-title">plugin error-plugin-init
                   
               </td>
               <td class="test-duration">21</td>
           </tr>
-          <tr class="show prior success">
-              <td class="test-id">205</td>
-              <td class="test-title">prior add-specific-to-general
+          <tr class="show plugin success">
+              <td class="test-id">187</td>
+              <td class="test-title">plugin error-plugin-action
                   
               </td>
-              <td class="test-duration">18</td>
+              <td class="test-duration">32</td>
           </tr>
-          <tr class="show prior success">
-              <td class="test-id">206</td>
-              <td class="test-title">prior add-strict-specific-to-general
+          <tr class="show plugin success">
+              <td class="test-id">188</td>
+              <td class="test-title">plugin no-name
                   
               </td>
-              <td class="test-duration">23</td>
+              <td class="test-duration">130</td>
           </tr>
-          <tr class="show prior success">
-              <td class="test-id">207</td>
-              <td class="test-title">prior add-general-to-specific-alpha
+          <tr class="show plugin success">
+              <td class="test-id">189</td>
+              <td class="test-title">plugin seneca-prefix-wins
                   
               </td>
-              <td class="test-duration">22</td>
+              <td class="test-duration">126</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">190</td>
+              <td class="test-title">plugin plugin-defaults-top-level-joi
+                  
+              </td>
+              <td class="test-duration">126</td>
+          </tr>
+          <tr class="show plugin success">
+              <td class="test-id">191</td>
+              <td class="test-title">plugin plugin-order-task-args
+                  
+              </td>
+              <td class="test-duration">14</td>
+          </tr>
+          <tr class="show print success">
+              <td class="test-id">192</td>
+              <td class="test-title">print init
+                  
+              </td>
+              <td class="test-duration">9</td>
+          </tr>
+          <tr class="show print success">
+              <td class="test-id">193</td>
+              <td class="test-title">print options
+                  
+              </td>
+              <td class="test-duration">14</td>
+          </tr>
+          <tr class="show print success">
+              <td class="test-id">194</td>
+              <td class="test-title">print print
+                  
+              </td>
+              <td class="test-duration">10</td>
+          </tr>
+          <tr class="show print success">
+              <td class="test-id">195</td>
+              <td class="test-title">print custom-print
+                  
+              </td>
+              <td class="test-duration">24</td>
           </tr>
           <tr class="show prior success">
-              <td class="test-id">208</td>
-              <td class="test-title">prior add-general-to-specific-reverse-alpha
+              <td class="test-id">196</td>
+              <td class="test-title">prior happy
+                  
+              </td>
+              <td class="test-duration">105</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">197</td>
+              <td class="test-title">prior top-level
+                  
+              </td>
+              <td class="test-duration">12</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">198</td>
+              <td class="test-title">prior add-general-to-specific
+                  
+              </td>
+              <td class="test-duration">51</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">199</td>
+              <td class="test-title">prior add-strict-general-to-specific
                   
               </td>
               <td class="test-duration">27</td>
           </tr>
           <tr class="show prior success">
-              <td class="test-id">209</td>
+              <td class="test-id">200</td>
+              <td class="test-title">prior add-specific-to-general
+                  
+              </td>
+              <td class="test-duration">41</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">201</td>
+              <td class="test-title">prior add-strict-specific-to-general
+                  
+              </td>
+              <td class="test-duration">29</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">202</td>
+              <td class="test-title">prior add-general-to-specific-alpha
+                  
+              </td>
+              <td class="test-duration">30</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">203</td>
+              <td class="test-title">prior add-general-to-specific-reverse-alpha
+                  
+              </td>
+              <td class="test-duration">23</td>
+          </tr>
+          <tr class="show prior success">
+              <td class="test-id">204</td>
               <td class="test-title">prior add-strict-default
                   
               </td>
-              <td class="test-duration">32</td>
+              <td class="test-duration">30</td>
           </tr>
           <tr class="show prior success">
-              <td class="test-id">210</td>
+              <td class="test-id">205</td>
               <td class="test-title">prior add-strict-true
                   
               </td>
-              <td class="test-duration">23</td>
+              <td class="test-duration">28</td>
           </tr>
           <tr class="show private success">
-              <td class="test-id">211</td>
+              <td class="test-id">206</td>
               <td class="test-title">private exit_close
                   
               </td>
-              <td class="test-duration">452</td>
+              <td class="test-duration">415</td>
           </tr>
           <tr class="show ready success">
-              <td class="test-id">212</td>
+              <td class="test-id">207</td>
               <td class="test-title">ready ready_die
                   
               </td>
-              <td class="test-duration">123</td>
+              <td class="test-duration">121</td>
           </tr>
           <tr class="show ready success">
-              <td class="test-id">213</td>
+              <td class="test-id">208</td>
               <td class="test-title">ready ready_die_no_errhandler
                   
               </td>
-              <td class="test-duration">164</td>
+              <td class="test-duration">119</td>
           </tr>
           <tr class="show ready success">
-              <td class="test-id">214</td>
+              <td class="test-id">209</td>
               <td class="test-title">ready ready_null_name
                   
               </td>
-              <td class="test-duration">131</td>
+              <td class="test-duration">125</td>
           </tr>
           <tr class="show ready success">
-              <td class="test-id">215</td>
+              <td class="test-id">210</td>
               <td class="test-title">ready ready-complex
                   
               </td>
-              <td class="test-duration">291</td>
+              <td class="test-duration">270</td>
           </tr>
           <tr class="show ready success">
-              <td class="test-id">216</td>
+              <td class="test-id">211</td>
               <td class="test-title">ready ready-always-called
                   
               </td>
-              <td class="test-duration">238</td>
+              <td class="test-duration">233</td>
           </tr>
           <tr class="show ready success">
-              <td class="test-id">217</td>
+              <td class="test-id">212</td>
               <td class="test-title">ready ready-error-test
                   
               </td>
-              <td class="test-duration">140</td>
+              <td class="test-duration">124</td>
           </tr>
           <tr class="show ready success">
-              <td class="test-id">218</td>
+              <td class="test-id">213</td>
               <td class="test-title">ready ready-event
                   
               </td>
-              <td class="test-duration">74</td>
+              <td class="test-duration">85</td>
           </tr>
           <tr class="show ready success">
-              <td class="test-id">219</td>
+              <td class="test-id">214</td>
               <td class="test-title">ready ready-both
                   
               </td>
-              <td class="test-duration">126</td>
+              <td class="test-duration">179</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">220</td>
+              <td class="test-id">215</td>
               <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log&#x3D;level:warn
                   
               </td>
-              <td class="test-duration">35</td>
+              <td class="test-duration">12</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">221</td>
+              <td class="test-id">216</td>
               <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log&#x3D;level:warn+
                   
               </td>
-              <td class="test-duration">16</td>
+              <td class="test-duration">8</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">222</td>
+              <td class="test-id">217</td>
               <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log.level.warn
-                  
-              </td>
-              <td class="test-duration">23</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">223</td>
-              <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log.level.warn+
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">224</td>
-              <td class="test-title">seneca --seneca.log arguments tests:  duplicate param --seneca.log
-                  
-              </td>
-              <td class="test-duration">20</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">225</td>
-              <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log&#x3D;level:
-                  
-              </td>
-              <td class="test-duration">15</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">226</td>
-              <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log.level.abc
                   
               </td>
               <td class="test-duration">14</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
-              <td class="test-id">227</td>
+              <td class="test-id">218</td>
+              <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log.level.warn+
+                  
+              </td>
+              <td class="test-duration">42</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
+              <td class="test-id">219</td>
+              <td class="test-title">seneca --seneca.log arguments tests:  duplicate param --seneca.log
+                  
+              </td>
+              <td class="test-duration">31</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
+              <td class="test-id">220</td>
+              <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log&#x3D;level:
+                  
+              </td>
+              <td class="test-duration">25</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
+              <td class="test-id">221</td>
+              <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log.level.abc
+                  
+              </td>
+              <td class="test-duration">25</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_arguments_tests:_ success">
+              <td class="test-id">222</td>
               <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log.abc
                   
               </td>
-              <td class="test-duration">9</td>
+              <td class="test-duration">12</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">228</td>
+              <td class="test-id">223</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.quiet
+                  
+              </td>
+              <td class="test-duration">25</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">224</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.silent
+                  
+              </td>
+              <td class="test-duration">13</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">225</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.all
+                  
+              </td>
+              <td class="test-duration">28</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">226</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.any
                   
               </td>
               <td class="test-duration">15</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">229</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.silent
+              <td class="test-id">227</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.print
+                  
+              </td>
+              <td class="test-duration">19</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">228</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.test
                   
               </td>
               <td class="test-duration">17</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">230</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.all
+              <td class="test-id">229</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.standard
                   
               </td>
               <td class="test-duration">21</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">231</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.any
-                  
-              </td>
-              <td class="test-duration">14</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">232</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.print
-                  
-              </td>
-              <td class="test-duration">20</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">233</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.test
-                  
-              </td>
-              <td class="test-duration">16</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">234</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.standard
-                  
-              </td>
-              <td class="test-duration">30</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">235</td>
+              <td class="test-id">230</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.quiet
                   
               </td>
               <td class="test-duration">14</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">236</td>
+              <td class="test-id">231</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.silent
                   
               </td>
-              <td class="test-duration">16</td>
+              <td class="test-duration">32</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">237</td>
+              <td class="test-id">232</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.all
+                  
+              </td>
+              <td class="test-duration">15</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">233</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.any
+                  
+              </td>
+              <td class="test-duration">12</td>
+          </tr>
+          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">234</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.print
                   
               </td>
               <td class="test-duration">19</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">238</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.any
+              <td class="test-id">235</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.test
                   
               </td>
-              <td class="test-duration">21</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
+              <td class="test-id">236</td>
+              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.standard
+                  
+              </td>
+              <td class="test-duration">15</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">237</td>
+              <td class="test-title">seneca happy
+                  
+              </td>
+              <td class="test-duration">32</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">238</td>
+              <td class="test-title">seneca require-abbrev
+                  
+              </td>
+              <td class="test-duration">242</td>
+          </tr>
+          <tr class="show seneca success">
               <td class="test-id">239</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.print
+              <td class="test-title">seneca version
+                  
+              </td>
+              <td class="test-duration">9</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">240</td>
+              <td class="test-title">seneca tag
+                  
+              </td>
+              <td class="test-duration">9</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">241</td>
+              <td class="test-title">seneca json-inspect
                   
               </td>
               <td class="test-duration">16</td>
           </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">240</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.test
-                  
-              </td>
-              <td class="test-duration">17</td>
-          </tr>
-          <tr class="show seneca_--seneca.log_aliases_tests:_ success">
-              <td class="test-id">241</td>
-              <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.standard
-                  
-              </td>
-              <td class="test-duration">18</td>
-          </tr>
           <tr class="show seneca success">
               <td class="test-id">242</td>
-              <td class="test-title">seneca happy
+              <td class="test-title">seneca quick
                   
               </td>
               <td class="test-duration">39</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">243</td>
-              <td class="test-title">seneca require-abbrev
-                  
-              </td>
-              <td class="test-duration">248</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">244</td>
-              <td class="test-title">seneca version
-                  
-              </td>
-              <td class="test-duration">39</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">245</td>
-              <td class="test-title">seneca tag
-                  
-              </td>
-              <td class="test-duration">16</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">246</td>
-              <td class="test-title">seneca json-inspect
-                  
-              </td>
-              <td class="test-duration">18</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">247</td>
-              <td class="test-title">seneca quick
-                  
-              </td>
-              <td class="test-duration">32</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">248</td>
               <td class="test-title">seneca happy-error
                   
               </td>
-              <td class="test-duration">14</td>
+              <td class="test-duration">13</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">249</td>
+              <td class="test-id">244</td>
               <td class="test-title">seneca errhandler
                   
               </td>
               <td class="test-duration">115</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">250</td>
+              <td class="test-id">245</td>
               <td class="test-title">seneca action-basic
-                  
-              </td>
-              <td class="test-duration">26</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">251</td>
-              <td class="test-title">seneca action-callback-instance
-                  
-              </td>
-              <td class="test-duration">15</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">252</td>
-              <td class="test-title">seneca action-act-invalid-args
-                  
-              </td>
-              <td class="test-duration">15</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">253</td>
-              <td class="test-title">seneca action-default
-                  
-              </td>
-              <td class="test-duration">20</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">254</td>
-              <td class="test-title">seneca action-override
-                  
-              </td>
-              <td class="test-duration">149</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">255</td>
-              <td class="test-title">seneca action-callback-args
-                  
-              </td>
-              <td class="test-duration">24</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">256</td>
-              <td class="test-title">seneca action-extend
-                  
-              </td>
-              <td class="test-duration">153</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">257</td>
-              <td class="test-title">seneca prior-nocache
-                  
-              </td>
-              <td class="test-duration">360</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">258</td>
-              <td class="test-title">seneca gating
-                  
-              </td>
-              <td class="test-duration">146</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">259</td>
-              <td class="test-title">seneca act_if
-                  
-              </td>
-              <td class="test-duration">82</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">260</td>
-              <td class="test-title">seneca loading-plugins
-                  
-              </td>
-              <td class="test-duration">213</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">261</td>
-              <td class="test-title">seneca fire-and-forget
                   
               </td>
               <td class="test-duration">17</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">262</td>
+              <td class="test-id">246</td>
+              <td class="test-title">seneca action-callback-instance
+                  
+              </td>
+              <td class="test-duration">16</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">247</td>
+              <td class="test-title">seneca action-act-invalid-args
+                  
+              </td>
+              <td class="test-duration">19</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">248</td>
+              <td class="test-title">seneca action-default
+                  
+              </td>
+              <td class="test-duration">17</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">249</td>
+              <td class="test-title">seneca action-override
+                  
+              </td>
+              <td class="test-duration">131</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">250</td>
+              <td class="test-title">seneca action-callback-args
+                  
+              </td>
+              <td class="test-duration">19</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">251</td>
+              <td class="test-title">seneca action-extend
+                  
+              </td>
+              <td class="test-duration">129</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">252</td>
+              <td class="test-title">seneca prior-nocache
+                  
+              </td>
+              <td class="test-duration">351</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">253</td>
+              <td class="test-title">seneca gating
+                  
+              </td>
+              <td class="test-duration">126</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">254</td>
+              <td class="test-title">seneca act_if
+                  
+              </td>
+              <td class="test-duration">35</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">255</td>
+              <td class="test-title">seneca loading-plugins
+                  
+              </td>
+              <td class="test-duration">150</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">256</td>
+              <td class="test-title">seneca fire-and-forget
+                  
+              </td>
+              <td class="test-duration">11</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">257</td>
               <td class="test-title">seneca strargs
                   
               </td>
-              <td class="test-duration">88</td>
+              <td class="test-duration">42</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">263</td>
+              <td class="test-id">258</td>
               <td class="test-title">seneca string-add
                   
               </td>
-              <td class="test-duration">29</td>
+              <td class="test-duration">22</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">264</td>
+              <td class="test-id">259</td>
               <td class="test-title">seneca fix-basic
+                  
+              </td>
+              <td class="test-duration">11</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">260</td>
+              <td class="test-title">seneca act-history
+                  
+              </td>
+              <td class="test-duration">59</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">261</td>
+              <td class="test-title">seneca wrap
+                  
+              </td>
+              <td class="test-duration">45</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">262</td>
+              <td class="test-title">seneca meta
+                  
+              </td>
+              <td class="test-duration">25</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">263</td>
+              <td class="test-title">seneca strict-result
                   
               </td>
               <td class="test-duration">9</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">265</td>
-              <td class="test-title">seneca act-history
-                  
-              </td>
-              <td class="test-duration">56</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">266</td>
-              <td class="test-title">seneca wrap
-                  
-              </td>
-              <td class="test-duration">60</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">267</td>
-              <td class="test-title">seneca meta
-                  
-              </td>
-              <td class="test-duration">43</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">268</td>
-              <td class="test-title">seneca strict-result
-                  
-              </td>
-              <td class="test-duration">19</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">269</td>
+              <td class="test-id">264</td>
               <td class="test-title">seneca add-noop
-                  
-              </td>
-              <td class="test-duration">25</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">270</td>
-              <td class="test-title">seneca supports jsonic params to has
-                  
-              </td>
-              <td class="test-duration">15</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">271</td>
-              <td class="test-title">seneca supports a function to trace actions
-                  
-              </td>
-              <td class="test-duration">48</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">272</td>
-              <td class="test-title">seneca supports true to be passed as trace action option
-                  
-              </td>
-              <td class="test-duration">15</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">273</td>
-              <td class="test-title">seneca strict-find-false
                   
               </td>
               <td class="test-duration">16</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">274</td>
+              <td class="test-id">265</td>
+              <td class="test-title">seneca supports jsonic params to has
+                  
+              </td>
+              <td class="test-duration">10</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">266</td>
+              <td class="test-title">seneca supports a function to trace actions
+                  
+              </td>
+              <td class="test-duration">30</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">267</td>
+              <td class="test-title">seneca supports true to be passed as trace action option
+                  
+              </td>
+              <td class="test-duration">13</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">268</td>
+              <td class="test-title">seneca strict-find-false
+                  
+              </td>
+              <td class="test-duration">20</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">269</td>
               <td class="test-title">seneca strict-find-true
                   
               </td>
-              <td class="test-duration">14</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">275</td>
+              <td class="test-id">270</td>
               <td class="test-title">seneca strict-find-default
                   
               </td>
-              <td class="test-duration">18</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">276</td>
+              <td class="test-id">271</td>
               <td class="test-title">seneca catchall-pattern
-                  
-              </td>
-              <td class="test-duration">121</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">277</td>
-              <td class="test-title">seneca memory
-                  
-              </td>
-              <td class="test-duration">503</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">278</td>
-              <td class="test-title">seneca use-shortcut
-                  
-              </td>
-              <td class="test-duration">26</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">279</td>
-              <td class="test-title">seneca status-log
-                  
-              </td>
-              <td class="test-duration">18</td>
-          </tr>
-          <tr class="show seneca success">
-              <td class="test-id">280</td>
-              <td class="test-title">seneca reply-seneca
                   
               </td>
               <td class="test-duration">123</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">281</td>
+              <td class="test-id">272</td>
+              <td class="test-title">seneca memory
+                  
+              </td>
+              <td class="test-duration">414</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">273</td>
+              <td class="test-title">seneca use-shortcut
+                  
+              </td>
+              <td class="test-duration">22</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">274</td>
+              <td class="test-title">seneca status-log
+                  
+              </td>
+              <td class="test-duration">12</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">275</td>
+              <td class="test-title">seneca reply-seneca
+                  
+              </td>
+              <td class="test-duration">129</td>
+          </tr>
+          <tr class="show seneca success">
+              <td class="test-id">276</td>
               <td class="test-title">seneca pattern-types
                   
               </td>
-              <td class="test-duration">146</td>
+              <td class="test-duration">138</td>
           </tr>
           <tr class="show seneca success">
-              <td class="test-id">282</td>
+              <td class="test-id">277</td>
               <td class="test-title">seneca order
                   
               </td>
-              <td class="test-duration">44</td>
+              <td class="test-duration">11</td>
           </tr>
           <tr class="show seneca #decorate success">
-              <td class="test-id">283</td>
+              <td class="test-id">278</td>
               <td class="test-title">seneca #decorate can add a property to seneca
                   
               </td>
-              <td class="test-duration">45</td>
+              <td class="test-duration">8</td>
           </tr>
           <tr class="show seneca #decorate success">
-              <td class="test-id">284</td>
+              <td class="test-id">279</td>
               <td class="test-title">seneca #decorate cannot override core property
-                  
-              </td>
-              <td class="test-duration">21</td>
-          </tr>
-          <tr class="show seneca #decorate success">
-              <td class="test-id">285</td>
-              <td class="test-title">seneca #decorate cannot overwrite a decorated property
                   
               </td>
               <td class="test-duration">16</td>
           </tr>
           <tr class="show seneca #decorate success">
-              <td class="test-id">286</td>
+              <td class="test-id">280</td>
+              <td class="test-title">seneca #decorate cannot overwrite a decorated property
+                  
+              </td>
+              <td class="test-duration">30</td>
+          </tr>
+          <tr class="show seneca #decorate success">
+              <td class="test-id">281</td>
               <td class="test-title">seneca #decorate cannot prefix a property with an underscore
                   
               </td>
-              <td class="test-duration">12</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show seneca #intercept success">
-              <td class="test-id">287</td>
+              <td class="test-id">282</td>
               <td class="test-title">seneca #intercept intercept
                   
               </td>
-              <td class="test-duration">25</td>
+              <td class="test-duration">30</td>
           </tr>
           <tr class="show sequence success">
-              <td class="test-id">288</td>
+              <td class="test-id">283</td>
               <td class="test-title">sequence single-add-act
                   
               </td>
-              <td class="test-duration">19</td>
+              <td class="test-duration">26</td>
           </tr>
           <tr class="show sequence success">
-              <td class="test-id">289</td>
+              <td class="test-id">284</td>
               <td class="test-title">sequence double-add-act
                   
               </td>
-              <td class="test-duration">19</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show sequence success">
-              <td class="test-id">290</td>
+              <td class="test-id">285</td>
               <td class="test-title">sequence single-add-act-ready
                   
               </td>
               <td class="test-duration">123</td>
           </tr>
           <tr class="show sequence success">
-              <td class="test-id">291</td>
+              <td class="test-id">286</td>
               <td class="test-title">sequence single-add-act-gate-action
                   
               </td>
-              <td class="test-duration">37</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show sequence success">
-              <td class="test-id">292</td>
+              <td class="test-id">287</td>
               <td class="test-title">sequence single-add-act-gate-instance
                   
               </td>
-              <td class="test-duration">23</td>
+              <td class="test-duration">21</td>
           </tr>
           <tr class="show smoke success">
-              <td class="test-id">293</td>
+              <td class="test-id">288</td>
               <td class="test-title">smoke seneca-smoke
                   
               </td>
-              <td class="test-duration">15</td>
+              <td class="test-duration">34</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">294</td>
+              <td class="test-id">289</td>
               <td class="test-title">options options-happy
                   
               </td>
-              <td class="test-duration">131</td>
+              <td class="test-duration">125</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">295</td>
+              <td class="test-id">290</td>
               <td class="test-title">options options-getset
                   
               </td>
-              <td class="test-duration">137</td>
+              <td class="test-duration">124</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">296</td>
+              <td class="test-id">291</td>
               <td class="test-title">options options-legacy
                   
               </td>
-              <td class="test-duration">130</td>
+              <td class="test-duration">125</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">297</td>
+              <td class="test-id">292</td>
               <td class="test-title">options options-file-js
                   
               </td>
-              <td class="test-duration">135</td>
+              <td class="test-duration">122</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">298</td>
+              <td class="test-id">293</td>
               <td class="test-title">options legacy-options-file-js
                   
               </td>
-              <td class="test-duration">133</td>
+              <td class="test-duration">123</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">299</td>
+              <td class="test-id">294</td>
               <td class="test-title">options options-file-json
                   
               </td>
-              <td class="test-duration">149</td>
+              <td class="test-duration">126</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">300</td>
+              <td class="test-id">295</td>
               <td class="test-title">options options-file-json-nomore
                   
               </td>
-              <td class="test-duration">143</td>
+              <td class="test-duration">121</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">301</td>
+              <td class="test-id">296</td>
               <td class="test-title">options options-env
                   
               </td>
-              <td class="test-duration">144</td>
+              <td class="test-duration">121</td>
           </tr>
           <tr class="show options success">
-              <td class="test-id">302</td>
+              <td class="test-id">297</td>
               <td class="test-title">options options-cmdline
                   
               </td>
-              <td class="test-duration">150</td>
+              <td class="test-duration">122</td>
           </tr>
           <tr class="show sub success">
-              <td class="test-id">303</td>
+              <td class="test-id">298</td>
               <td class="test-title">sub happy-sub
-                  
-              </td>
-              <td class="test-duration">39</td>
-          </tr>
-          <tr class="show sub success">
-              <td class="test-id">304</td>
-              <td class="test-title">sub inwards-outwards-sub
-                  
-              </td>
-              <td class="test-duration">30</td>
-          </tr>
-          <tr class="show sub success">
-              <td class="test-id">305</td>
-              <td class="test-title">sub specific-sub
                   
               </td>
               <td class="test-duration">26</td>
           </tr>
           <tr class="show sub success">
-              <td class="test-id">306</td>
+              <td class="test-id">299</td>
+              <td class="test-title">sub inwards-outwards-sub
+                  
+              </td>
+              <td class="test-duration">45</td>
+          </tr>
+          <tr class="show sub success">
+              <td class="test-id">300</td>
+              <td class="test-title">sub specific-sub
+                  
+              </td>
+              <td class="test-duration">45</td>
+          </tr>
+          <tr class="show sub success">
+              <td class="test-id">301</td>
               <td class="test-title">sub error-sub
                   
               </td>
-              <td class="test-duration">17</td>
+              <td class="test-duration">21</td>
           </tr>
           <tr class="show sub success">
-              <td class="test-id">307</td>
+              <td class="test-id">302</td>
               <td class="test-title">sub mixed-sub
                   
               </td>
-              <td class="test-duration">27</td>
+              <td class="test-duration">23</td>
           </tr>
           <tr class="show sub success">
-              <td class="test-id">308</td>
+              <td class="test-id">303</td>
               <td class="test-title">sub sub-prior
-                  
-              </td>
-              <td class="test-duration">125</td>
-          </tr>
-          <tr class="show sub success">
-              <td class="test-id">309</td>
-              <td class="test-title">sub sub-close
-                  
-              </td>
-              <td class="test-duration">159</td>
-          </tr>
-          <tr class="show sub success">
-              <td class="test-id">310</td>
-              <td class="test-title">sub sub-fix
-                  
-              </td>
-              <td class="test-duration">32</td>
-          </tr>
-          <tr class="show timeout success">
-              <td class="test-id">311</td>
-              <td class="test-title">timeout happy
                   
               </td>
               <td class="test-duration">129</td>
           </tr>
+          <tr class="show sub success">
+              <td class="test-id">304</td>
+              <td class="test-title">sub sub-close
+                  
+              </td>
+              <td class="test-duration">126</td>
+          </tr>
+          <tr class="show sub success">
+              <td class="test-id">305</td>
+              <td class="test-title">sub sub-fix
+                  
+              </td>
+              <td class="test-duration">17</td>
+          </tr>
           <tr class="show timeout success">
-              <td class="test-id">312</td>
+              <td class="test-id">306</td>
+              <td class="test-title">timeout happy
+                  
+              </td>
+              <td class="test-duration">122</td>
+          </tr>
+          <tr class="show timeout success">
+              <td class="test-id">307</td>
               <td class="test-title">timeout error-handler
                   
               </td>
-              <td class="test-duration">146</td>
+              <td class="test-duration">126</td>
           </tr>
           <tr class="show timeout success">
-              <td class="test-id">313</td>
+              <td class="test-id">308</td>
               <td class="test-title">timeout should accept a timeout value from options
                   
               </td>
-              <td class="test-duration">262</td>
+              <td class="test-duration">235</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">314</td>
+              <td class="test-id">309</td>
               <td class="test-title">transport happy-nextgen
                   
               </td>
-              <td class="test-duration">428</td>
+              <td class="test-duration">391</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">315</td>
+              <td class="test-id">310</td>
               <td class="test-title">transport config-legacy-nextgen
                   
               </td>
-              <td class="test-duration">537</td>
+              <td class="test-duration">483</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">316</td>
+              <td class="test-id">311</td>
               <td class="test-title">transport error-nextgen
                   
               </td>
-              <td class="test-duration">390</td>
+              <td class="test-duration">367</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">317</td>
+              <td class="test-id">312</td>
               <td class="test-title">transport interop-nextgen
                   
               </td>
-              <td class="test-duration">330</td>
+              <td class="test-duration">271</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">318</td>
+              <td class="test-id">313</td>
               <td class="test-title">transport config-nextgen
                   
               </td>
-              <td class="test-duration">544</td>
+              <td class="test-duration">511</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">319</td>
+              <td class="test-id">314</td>
               <td class="test-title">transport nextgen-transport-local-override
                   
               </td>
-              <td class="test-duration">446</td>
+              <td class="test-duration">379</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">320</td>
+              <td class="test-id">315</td>
               <td class="test-title">transport nextgen-meta
                   
               </td>
-              <td class="test-duration">444</td>
+              <td class="test-duration">383</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">321</td>
+              <td class="test-id">316</td>
               <td class="test-title">transport nextgen-ordering
                   
               </td>
-              <td class="test-duration">579</td>
+              <td class="test-duration">493</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">322</td>
+              <td class="test-id">317</td>
               <td class="test-title">transport transport-exact-single
                   
               </td>
-              <td class="test-duration">275</td>
+              <td class="test-duration">174</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">323</td>
+              <td class="test-id">318</td>
               <td class="test-title">transport transport-local-override
                   
               </td>
-              <td class="test-duration">226</td>
+              <td class="test-duration">157</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">324</td>
+              <td class="test-id">319</td>
               <td class="test-title">transport transport-star
                   
               </td>
-              <td class="test-duration">334</td>
+              <td class="test-duration">276</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">325</td>
+              <td class="test-id">320</td>
               <td class="test-title">transport transport-star-pin-object
                   
               </td>
-              <td class="test-duration">355</td>
+              <td class="test-duration">282</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">326</td>
+              <td class="test-id">321</td>
               <td class="test-title">transport transport-single-notdef
                   
               </td>
-              <td class="test-duration">216</td>
+              <td class="test-duration">159</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">327</td>
+              <td class="test-id">322</td>
               <td class="test-title">transport transport-pins-notdef
                   
               </td>
-              <td class="test-duration">220</td>
+              <td class="test-duration">183</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">328</td>
+              <td class="test-id">323</td>
               <td class="test-title">transport transport-single-wrap-and-star
-                  
-              </td>
-              <td class="test-duration">340</td>
-          </tr>
-          <tr class="show transport success">
-              <td class="test-id">329</td>
-              <td class="test-title">transport transport-local-single-and-star
-                  
-              </td>
-              <td class="test-duration">352</td>
-          </tr>
-          <tr class="show transport success">
-              <td class="test-id">330</td>
-              <td class="test-title">transport transport-local-over-wrap
-                  
-              </td>
-              <td class="test-duration">316</td>
-          </tr>
-          <tr class="show transport success">
-              <td class="test-id">331</td>
-              <td class="test-title">transport transport-local-prior-wrap
-                  
-              </td>
-              <td class="test-duration">301</td>
-          </tr>
-          <tr class="show transport success">
-              <td class="test-id">332</td>
-              <td class="test-title">transport transport-init-ordering
-                  
-              </td>
-              <td class="test-duration">248</td>
-          </tr>
-          <tr class="show transport success">
-              <td class="test-id">333</td>
-              <td class="test-title">transport transport-no-plugin-init
                   
               </td>
               <td class="test-duration">309</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">334</td>
+              <td class="test-id">324</td>
+              <td class="test-title">transport transport-local-single-and-star
+                  
+              </td>
+              <td class="test-duration">277</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">325</td>
+              <td class="test-title">transport transport-local-over-wrap
+                  
+              </td>
+              <td class="test-duration">249</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">326</td>
+              <td class="test-title">transport transport-local-prior-wrap
+                  
+              </td>
+              <td class="test-duration">165</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">327</td>
+              <td class="test-title">transport transport-init-ordering
+                  
+              </td>
+              <td class="test-duration">242</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">328</td>
+              <td class="test-title">transport transport-no-plugin-init
+                  
+              </td>
+              <td class="test-duration">281</td>
+          </tr>
+          <tr class="show transport success">
+              <td class="test-id">329</td>
               <td class="test-title">transport transport-balance-exact
                   
               </td>
-              <td class="test-duration">1104</td>
+              <td class="test-duration">919</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">335</td>
+              <td class="test-id">330</td>
               <td class="test-title">transport multi-layer-error
                   
               </td>
-              <td class="test-duration">795</td>
+              <td class="test-duration">731</td>
           </tr>
           <tr class="show transport success">
-              <td class="test-id">336</td>
+              <td class="test-id">331</td>
               <td class="test-title">transport server can be restarted without issues to clients
                   
               </td>
-              <td class="test-duration">689</td>
+              <td class="test-duration">631</td>
           </tr>
           <tr class="show transport transport-listen success">
-              <td class="test-id">337</td>
+              <td class="test-id">332</td>
               <td class="test-title">transport transport-listen supports-null-options
                   
               </td>
-              <td class="test-duration">161</td>
+              <td class="test-duration">126</td>
           </tr>
           <tr class="show transport transport-listen success">
-              <td class="test-id">338</td>
+              <td class="test-id">333</td>
               <td class="test-title">transport transport-listen supports type as tcp option
                   
               </td>
-              <td class="test-duration">149</td>
+              <td class="test-duration">124</td>
           </tr>
           <tr class="show transport transport-listen success">
-              <td class="test-id">339</td>
+              <td class="test-id">334</td>
               <td class="test-title">transport transport-listen supports type as http option
                   
               </td>
-              <td class="test-duration">147</td>
+              <td class="test-duration">128</td>
           </tr>
           <tr class="show transport transport-listen success">
-              <td class="test-id">340</td>
+              <td class="test-id">335</td>
               <td class="test-title">transport transport-listen supports the port number as an argument
                   
               </td>
-              <td class="test-duration">130</td>
+              <td class="test-duration">128</td>
           </tr>
           <tr class="show transport transport-listen success">
-              <td class="test-id">341</td>
+              <td class="test-id">336</td>
               <td class="test-title">transport transport-listen supports the port number and host as an argument
                   
               </td>
-              <td class="test-duration">148</td>
+              <td class="test-duration">125</td>
           </tr>
           <tr class="show transport transport-listen success">
-              <td class="test-id">342</td>
+              <td class="test-id">337</td>
               <td class="test-title">transport transport-listen supports the port number, host, and path as an argument
                   
               </td>
-              <td class="test-duration">184</td>
+              <td class="test-duration">124</td>
           </tr>
           <tr class="show transport transport-listen success">
-              <td class="test-id">343</td>
+              <td class="test-id">338</td>
               <td class="test-title">transport transport-listen action-error
                   
               </td>
-              <td class="test-duration">157</td>
+              <td class="test-duration">122</td>
           </tr>
           <tr class="show transport client() success">
-              <td class="test-id">344</td>
+              <td class="test-id">339</td>
               <td class="test-title">transport client() supports null options
                   
               </td>
-              <td class="test-duration">167</td>
+              <td class="test-duration">128</td>
           </tr>
           <tr class="show util success">
-              <td class="test-id">345</td>
+              <td class="test-id">340</td>
               <td class="test-title">util seneca.util.deepextend.happy
                   
               </td>
-              <td class="test-duration">5</td>
+              <td class="test-duration">1</td>
           </tr>
           <tr class="show util success">
-              <td class="test-id">346</td>
+              <td class="test-id">341</td>
               <td class="test-title">util seneca.util.deepextend.types with new
-                  
-              </td>
-              <td class="test-duration">17</td>
-          </tr>
-          <tr class="show util success">
-              <td class="test-id">347</td>
-              <td class="test-title">util seneca.util.deepextend.types
-                  
-              </td>
-              <td class="test-duration">16</td>
-          </tr>
-          <tr class="show util success">
-              <td class="test-id">348</td>
-              <td class="test-title">util seneca.util.deepextend.mixed
-                  
-              </td>
-              <td class="test-duration">7</td>
-          </tr>
-          <tr class="show util success">
-              <td class="test-id">349</td>
-              <td class="test-title">util seneca.util.deepextend.entity
                   
               </td>
               <td class="test-duration">2</td>
           </tr>
+          <tr class="show util success">
+              <td class="test-id">342</td>
+              <td class="test-title">util seneca.util.deepextend.types
+                  
+              </td>
+              <td class="test-duration">1</td>
+          </tr>
+          <tr class="show util success">
+              <td class="test-id">343</td>
+              <td class="test-title">util seneca.util.deepextend.mixed
+                  
+              </td>
+              <td class="test-duration">2</td>
+          </tr>
+          <tr class="show util success">
+              <td class="test-id">344</td>
+              <td class="test-title">util seneca.util.deepextend.entity
+                  
+              </td>
+              <td class="test-duration">0</td>
+          </tr>
           <tr class="show xward success">
-              <td class="test-id">350</td>
+              <td class="test-id">345</td>
               <td class="test-title">xward happy-inward
                   
               </td>
-              <td class="test-duration">38</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show xward success">
-              <td class="test-id">351</td>
+              <td class="test-id">346</td>
               <td class="test-title">xward happy-outward
                   
               </td>
-              <td class="test-duration">35</td>
+              <td class="test-duration">15</td>
           </tr>
           </tbody>
       </table>
@@ -3186,10 +3137,10 @@
     </div>    <div id="coverage">
         <h1>Code Coverage Report</h1>
         <div class="stats high">
-            <div class="percentage">91.66%</div>
-            <div class="sloc">4809</div>
-            <div class="hits">4408</div>
-            <div class="misses">401</div>
+            <div class="percentage">91.61%</div>
+            <div class="sloc">4792</div>
+            <div class="hits">4390</div>
+            <div class="misses">402</div>
         </div>
         <div id="filters">
           <input type="checkbox" checked="" onchange="filter(this)" value="generated" id="show-generated">
@@ -7766,7 +7717,7 @@
                         </tr>            <tr id="seneca.js__759" class="hit">
                           <td class="line" data-tooltip>759</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10362</td>
+                          <td class="hits" data-tooltip>10358</td>
                           <td class="source">      return void 0</td>
                           
                         </tr>            <tr id="seneca.js__760" class="hit">
@@ -8328,7 +8279,7 @@
                         </tr>            <tr id="lib/act.js__86" class="hit">
                           <td class="line" data-tooltip>86</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
+                          <td class="hits" data-tooltip>5</td>
                           <td class="source">      var timeout_err &#x3D; Common.error(&#x27;action_timeout&#x27;, {</td>
                           
                         </tr>            <tr id="lib/act.js__87" class="hit">
@@ -8394,7 +8345,7 @@
                         </tr>            <tr id="lib/act.js__97" class="hit">
                           <td class="line" data-tooltip>97</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
+                          <td class="hits" data-tooltip>5</td>
                           <td class="source">      intern.handle_reply(meta, actctxt, actmsg, timeout_err)</td>
                           
                         </tr>            <tr id="lib/act.js__98" class="hit">
@@ -9132,13 +9083,13 @@
                         </tr>            <tr id="lib/act.js__220" class="hit">
                           <td class="line" data-tooltip>220</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    var delegate &#x3D; actctxt.seneca</td>
                           
                         </tr>            <tr id="lib/act.js__221" class="hit">
                           <td class="line" data-tooltip>221</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    var reply &#x3D; actctxt.reply</td>
                           
                         </tr>            <tr id="lib/act.js__222" class="hit">
@@ -9150,7 +9101,7 @@
                         </tr>            <tr id="lib/act.js__223" class="hit">
                           <td class="line" data-tooltip>223</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    var data &#x3D; {</td>
                           
                         </tr>            <tr id="lib/act.js__224" class="hit">
@@ -9210,25 +9161,25 @@
                         </tr>            <tr id="lib/act.js__233" class="hit">
                           <td class="line" data-tooltip>233</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    actctxt.duration &#x3D; meta.end - meta.start</td>
                           
                         </tr>            <tr id="lib/act.js__234" class="hit">
                           <td class="line" data-tooltip>234</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    actctxt.actlog &#x3D; intern.actlog</td>
                           
                         </tr>            <tr id="lib/act.js__235" class="hit">
                           <td class="line" data-tooltip>235</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    actctxt.errlog &#x3D; intern.errlog</td>
                           
                         </tr>            <tr id="lib/act.js__236" class="hit">
                           <td class="line" data-tooltip>236</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    actctxt.error &#x3D; Common.error</td>
                           
                         </tr>            <tr id="lib/act.js__237" class="hit">
@@ -9240,7 +9191,7 @@
                         </tr>            <tr id="lib/act.js__238" class="hit">
                           <td class="line" data-tooltip>238</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    meta.error &#x3D; Util.isError(data.res)</td>
                           
                         </tr>            <tr id="lib/act.js__239" class="hit">
@@ -9258,7 +9209,7 @@
                         </tr>            <tr id="lib/act.js__241" class="hit">
                           <td class="line" data-tooltip>241</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    if (!meta.error &amp;&amp; data.res &#x3D;&#x3D;&#x3D; data.err) {</td>
                           
                         </tr>            <tr id="lib/act.js__242" class="hit">
@@ -9288,7 +9239,7 @@
                         </tr>            <tr id="lib/act.js__246" class="hit">
                           <td class="line" data-tooltip>246</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    if (</td>
                           
                         </tr>            <tr id="lib/act.js__247" class="hit">
@@ -9354,7 +9305,7 @@
                         </tr>            <tr id="lib/act.js__257" class="hit">
                           <td class="line" data-tooltip>257</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    intern.process_outward(actctxt, data, delegate)</td>
                           
                         </tr>            <tr id="lib/act.js__258" class="hit">
@@ -9366,19 +9317,19 @@
                         </tr>            <tr id="lib/act.js__259" class="hit">
                           <td class="line" data-tooltip>259</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    if (data.has_callback) {</td>
                           
                         </tr>            <tr id="lib/act.js__260" class="hit">
                           <td class="line" data-tooltip>260</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2819</td>
+                          <td class="hits" data-tooltip>2815</td>
                           <td class="source">      try {</td>
                           
                         </tr>            <tr id="lib/act.js__261" class="hit">
                           <td class="line" data-tooltip>261</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2819</td>
+                          <td class="hits" data-tooltip>2815</td>
                           <td class="source">        reply.call(delegate, data.err, data.res, data.meta)</td>
                           
                         </tr>            <tr id="lib/act.js__262" class="hit">
@@ -9456,7 +9407,7 @@
                         </tr>            <tr id="lib/act.js__274" class="hit">
                           <td class="line" data-tooltip>274</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2829</td>
+                          <td class="hits" data-tooltip>2825</td>
                           <td class="source">    if (outward) {</td>
                           
                         </tr>            <tr id="lib/act.js__275" class="hit">
@@ -12407,9 +12358,9 @@
             <div class="file ">
                 <h2 id="lib/api.js">lib/api.js </h2>
                 <div class="stats high">
-                    <div class="percentage">92.63%</div>
-                    <div class="sloc">665</div>
-                    <div class="hits">616</div>
+                    <div class="percentage">92.46%</div>
+                    <div class="sloc">650</div>
+                    <div class="hits">601</div>
                     <div class="misses">49</div>
                 </div>
                 <table>
@@ -12768,7 +12719,7 @@
                         </tr>            <tr id="lib/api.js__58" class="hit">
                           <td class="line" data-tooltip>58</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>22107</td>
+                          <td class="hits" data-tooltip>22095</td>
                           <td class="source">  var private$ &#x3D; self.private$</td>
                           
                         </tr>            <tr id="lib/api.js__59" class="hit">
@@ -12780,13 +12731,13 @@
                         </tr>            <tr id="lib/api.js__60" class="hit">
                           <td class="line" data-tooltip>60</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>22107</td>
+                          <td class="hits" data-tooltip>22095</td>
                           <td class="source">  if (null &#x3D;&#x3D; options) {</td>
                           
                         </tr>            <tr id="lib/api.js__61" class="hit">
                           <td class="line" data-tooltip>61</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>20836</td>
+                          <td class="hits" data-tooltip>20824</td>
                           <td class="source">    return private$.optioner.get()</td>
                           
                         </tr>            <tr id="lib/api.js__62" class="hit">
@@ -13302,7 +13253,7 @@
                         </tr>            <tr id="lib/api.js__147" class="hit">
                           <td class="line" data-tooltip>147</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
+                          <td class="hits" data-tooltip>16</td>
                           <td class="source">    if (null &#x3D;&#x3D; first) {</td>
                           
                         </tr>            <tr id="lib/api.js__148" class="hit">
@@ -13326,7 +13277,7 @@
                         </tr>            <tr id="lib/api.js__151" class="hit">
                           <td class="line" data-tooltip>151</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>15</td>
+                          <td class="hits" data-tooltip>14</td>
                           <td class="source">    var plugin_fullname &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__152" class="chunks">
@@ -13344,7 +13295,7 @@
                         </tr>            <tr id="lib/api.js__154" class="hit">
                           <td class="line" data-tooltip>154</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>15</td>
+                          <td class="hits" data-tooltip>14</td>
                           <td class="source">    var plugin &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__155" class="hit">
@@ -13374,13 +13325,13 @@
                         </tr>            <tr id="lib/api.js__159" class="hit">
                           <td class="line" data-tooltip>159</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>15</td>
+                          <td class="hits" data-tooltip>14</td>
                           <td class="source">    var error &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__160" class="hit">
                           <td class="line" data-tooltip>160</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>15</td>
+                          <td class="hits" data-tooltip>14</td>
                           <td class="source">    if (plugin &amp;&amp; plugin.eraro &amp;&amp; plugin.eraro.has(first)) {</td>
                           
                         </tr>            <tr id="lib/api.js__161" class="hit">
@@ -13398,7 +13349,7 @@
                         </tr>            <tr id="lib/api.js__163" class="hit">
                           <td class="line" data-tooltip>163</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>12</td>
+                          <td class="hits" data-tooltip>11</td>
                           <td class="source">      error &#x3D; Common.eraro.apply(this, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__164" class="hit">
@@ -13416,7 +13367,7 @@
                         </tr>            <tr id="lib/api.js__166" class="hit">
                           <td class="line" data-tooltip>166</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>15</td>
+                          <td class="hits" data-tooltip>14</td>
                           <td class="source">    return error</td>
                           
                         </tr>            <tr id="lib/api.js__167" class="hit">
@@ -13447,43 +13398,43 @@
                           <td class="line" data-tooltip>171</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.fail &#x3D; function (...args) {</td>
+                          <td class="source">exports.fail &#x3D; function (code, args) {</td>
                           
                         </tr>            <tr id="lib/api.js__172" class="hit">
                           <td class="line" data-tooltip>172</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  if (args.length &#x3D;&#x3D;&#x3D; 2) {</td>
+                          <td class="source">  var error &#x3D; this.error(code, args)</td>
                           
                         </tr>            <tr id="lib/api.js__173" class="hit">
                           <td class="line" data-tooltip>173</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">    return failIf(this, true, ...args)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__174" class="hit">
+                        </tr>            <tr id="lib/api.js__174" class="chunks">
                           <td class="line" data-tooltip>174</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"><div>  if (</div><div class="miss true" data-tooltip>args</div><div> &amp;&amp; </div><div class="miss false" data-tooltip>false &#x3D;&#x3D;&#x3D; args.throw$</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__175" class="hit">
+                        </tr>            <tr id="lib/api.js__175" class="miss">
                           <td class="line" data-tooltip>175</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source" data-tooltip>    return error</td>
                           
                         </tr>            <tr id="lib/api.js__176" class="hit">
                           <td class="line" data-tooltip>176</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">  if (args.length &#x3D;&#x3D;&#x3D; 3) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  } else {</td>
                           
                         </tr>            <tr id="lib/api.js__177" class="hit">
                           <td class="line" data-tooltip>177</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    return failIf(this, ...args)</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">    throw error</td>
                           
                         </tr>            <tr id="lib/api.js__178" class="hit">
                           <td class="line" data-tooltip>178</td>
@@ -13495,49 +13446,49 @@
                           <td class="line" data-tooltip>179</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__180" class="hit">
                           <td class="line" data-tooltip>180</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">  throw this.util.error(&#x27;fail_wrong_number_of_args&#x27;,</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__181" class="hit">
                           <td class="line" data-tooltip>181</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    { num_args: args.length })</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.inward &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__182" class="hit">
                           <td class="line" data-tooltip>182</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  // TODO: norma should support f/x where x &#x3D; # args</td>
                           
                         </tr>            <tr id="lib/api.js__183" class="hit">
                           <td class="line" data-tooltip>183</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  var args &#x3D; Norma(&#x27;inward:f&#x27;, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__184" class="hit">
                           <td class="line" data-tooltip>184</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  function failIf(self, cond, code, args) {</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  this.private$.inward.add(args.inward)</td>
                           
                         </tr>            <tr id="lib/api.js__185" class="hit">
                           <td class="line" data-tooltip>185</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">    Assert(typeof cond &#x3D;&#x3D;&#x3D; &#x27;boolean&#x27;,</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__186" class="hit">
                           <td class="line" data-tooltip>186</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      &#x27;Expected the &#x60;cond&#x60; param to be a boolean.&#x27;)</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__187" class="hit">
                           <td class="line" data-tooltip>187</td>
@@ -13548,32 +13499,32 @@
                         </tr>            <tr id="lib/api.js__188" class="hit">
                           <td class="line" data-tooltip>188</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">    if (!cond) {</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.outward &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__189" class="hit">
                           <td class="line" data-tooltip>189</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      return</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var args &#x3D; Norma(&#x27;outward:f&#x27;, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__190" class="hit">
                           <td class="line" data-tooltip>190</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  this.private$.outward.add(args.outward)</td>
                           
                         </tr>            <tr id="lib/api.js__191" class="hit">
                           <td class="line" data-tooltip>191</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__192" class="hit">
                           <td class="line" data-tooltip>192</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">    const error &#x3D; self.error(code, args)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__193" class="hit">
                           <td class="line" data-tooltip>193</td>
@@ -13581,89 +13532,89 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__194" class="chunks">
+                        </tr>            <tr id="lib/api.js__194" class="hit">
                           <td class="line" data-tooltip>194</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    if (</div><div class="miss true" data-tooltip>args</div><div> &amp;&amp; </div><div class="miss false" data-tooltip>false &#x3D;&#x3D;&#x3D; args.throw$</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.prior &#x3D; function () {</td>
                           
-                        </tr>            <tr id="lib/api.js__195" class="miss">
+                        </tr>            <tr id="lib/api.js__195" class="hit">
                           <td class="line" data-tooltip>195</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>      return error</td>
+                          <td class="source">  if (null &#x3D;&#x3D; this.private$.act) {</td>
                           
                         </tr>            <tr id="lib/api.js__196" class="hit">
                           <td class="line" data-tooltip>196</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    } else {</td>
+                          <td class="source">    // TODO: should be a top level api method: seneca.fail</td>
                           
                         </tr>            <tr id="lib/api.js__197" class="hit">
                           <td class="line" data-tooltip>197</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">      throw error</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    throw this.util.error(&#x27;no_prior_action&#x27;, { args: arguments })</td>
                           
                         </tr>            <tr id="lib/api.js__198" class="hit">
                           <td class="line" data-tooltip>198</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__199" class="hit">
                           <td class="line" data-tooltip>199</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__200" class="hit">
                           <td class="line" data-tooltip>200</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  // Get definition of prior action</td>
                           
                         </tr>            <tr id="lib/api.js__201" class="hit">
                           <td class="line" data-tooltip>201</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  var priordef &#x3D; this.private$.act.def.priordef</td>
                           
                         </tr>            <tr id="lib/api.js__202" class="hit">
                           <td class="line" data-tooltip>202</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.inward &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__203" class="hit">
                           <td class="line" data-tooltip>203</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // TODO: norma should support f/x where x &#x3D; # args</td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  var spec &#x3D; Common.build_message(this, arguments, &#x27;reply:f?&#x27;, this.fixedargs)</td>
                           
                         </tr>            <tr id="lib/api.js__204" class="hit">
                           <td class="line" data-tooltip>204</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var args &#x3D; Norma(&#x27;inward:f&#x27;, arguments)</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__205" class="hit">
                           <td class="line" data-tooltip>205</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  this.private$.inward.add(args.inward)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // TODO: clean sufficiently so that seneca.util.clean not needed</td>
                           
                         </tr>            <tr id="lib/api.js__206" class="hit">
                           <td class="line" data-tooltip>206</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  var msg &#x3D; spec.msg</td>
                           
                         </tr>            <tr id="lib/api.js__207" class="hit">
                           <td class="line" data-tooltip>207</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  var reply &#x3D; spec.reply</td>
                           
                         </tr>            <tr id="lib/api.js__208" class="hit">
                           <td class="line" data-tooltip>208</td>
@@ -13674,98 +13625,98 @@
                         </tr>            <tr id="lib/api.js__209" class="hit">
                           <td class="line" data-tooltip>209</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.outward &#x3D; function () {</td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  if (priordef) {</td>
                           
                         </tr>            <tr id="lib/api.js__210" class="hit">
                           <td class="line" data-tooltip>210</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var args &#x3D; Norma(&#x27;outward:f&#x27;, arguments)</td>
+                          <td class="hits" data-tooltip>103</td>
+                          <td class="source">    msg.prior$ &#x3D; priordef.id</td>
                           
                         </tr>            <tr id="lib/api.js__211" class="hit">
                           <td class="line" data-tooltip>211</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  this.private$.outward.add(args.outward)</td>
+                          <td class="hits" data-tooltip>103</td>
+                          <td class="source">    this.act(msg, reply)</td>
                           
                         </tr>            <tr id="lib/api.js__212" class="hit">
                           <td class="line" data-tooltip>212</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  } else {</td>
                           
-                        </tr>            <tr id="lib/api.js__213" class="hit">
+                        </tr>            <tr id="lib/api.js__213" class="chunks">
                           <td class="line" data-tooltip>213</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"><div>    var meta &#x3D; </div><div class="miss false" data-tooltip>msg.meta$</div><div> || {}</div></td>
                           
-                        </tr>            <tr id="lib/api.js__214" class="hit">
+                        </tr>            <tr id="lib/api.js__214" class="chunks">
                           <td class="line" data-tooltip>214</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>    var out &#x3D; msg.default$ || </div><div class="miss false" data-tooltip>meta.dflt</div><div> || null</div></td>
                           
                         </tr>            <tr id="lib/api.js__215" class="hit">
                           <td class="line" data-tooltip>215</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.prior &#x3D; function () {</td>
+                          <td class="hits" data-tooltip>25</td>
+                          <td class="source">    out &#x3D; null &#x3D;&#x3D; out ? out : Object.assign({}, out)</td>
                           
                         </tr>            <tr id="lib/api.js__216" class="hit">
                           <td class="line" data-tooltip>216</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  if (null &#x3D;&#x3D; this.private$.act) {</td>
+                          <td class="hits" data-tooltip>25</td>
+                          <td class="source">    return reply.call(this, null, out, meta)</td>
                           
                         </tr>            <tr id="lib/api.js__217" class="hit">
                           <td class="line" data-tooltip>217</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // TODO: should be a top level api method: seneca.fail</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__218" class="hit">
                           <td class="line" data-tooltip>218</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    throw this.util.error(&#x27;no_prior_action&#x27;, { args: arguments })</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__219" class="hit">
                           <td class="line" data-tooltip>219</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__220" class="hit">
                           <td class="line" data-tooltip>220</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">// TODO: rename fixedargs</td>
                           
                         </tr>            <tr id="lib/api.js__221" class="hit">
                           <td class="line" data-tooltip>221</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // Get definition of prior action</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.delegate &#x3D; function (fixedargs, fixedmeta) {</td>
                           
                         </tr>            <tr id="lib/api.js__222" class="hit">
                           <td class="line" data-tooltip>222</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  var priordef &#x3D; this.private$.act.def.priordef</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__223" class="hit">
                           <td class="line" data-tooltip>223</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var root &#x3D; this.root</td>
                           
                         </tr>            <tr id="lib/api.js__224" class="hit">
                           <td class="line" data-tooltip>224</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  var spec &#x3D; Common.build_message(this, arguments, &#x27;reply:f?&#x27;, this.fixedargs)</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var opts &#x3D; this.options()</td>
                           
                         </tr>            <tr id="lib/api.js__225" class="hit">
                           <td class="line" data-tooltip>225</td>
@@ -13776,74 +13727,74 @@
                         </tr>            <tr id="lib/api.js__226" class="hit">
                           <td class="line" data-tooltip>226</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // TODO: clean sufficiently so that seneca.util.clean not needed</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  fixedargs &#x3D; fixedargs || {}</td>
                           
                         </tr>            <tr id="lib/api.js__227" class="hit">
                           <td class="line" data-tooltip>227</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  var msg &#x3D; spec.msg</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  fixedmeta &#x3D; fixedmeta || {}</td>
                           
                         </tr>            <tr id="lib/api.js__228" class="hit">
                           <td class="line" data-tooltip>228</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  var reply &#x3D; spec.reply</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__229" class="hit">
                           <td class="line" data-tooltip>229</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var delegate &#x3D; Object.create(self)</td>
                           
                         </tr>            <tr id="lib/api.js__230" class="hit">
                           <td class="line" data-tooltip>230</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  if (priordef) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__231" class="hit">
                           <td class="line" data-tooltip>231</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>103</td>
-                          <td class="source">    msg.prior$ &#x3D; priordef.id</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  delegate.private$ &#x3D; Object.create(self.private$)</td>
                           
                         </tr>            <tr id="lib/api.js__232" class="hit">
                           <td class="line" data-tooltip>232</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>103</td>
-                          <td class="source">    this.act(msg, reply)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__233" class="hit">
                           <td class="line" data-tooltip>233</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  delegate.did &#x3D;</td>
                           
-                        </tr>            <tr id="lib/api.js__234" class="chunks">
+                        </tr>            <tr id="lib/api.js__234" class="hit">
                           <td class="line" data-tooltip>234</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var meta &#x3D; </div><div class="miss false" data-tooltip>msg.meta$</div><div> || {}</div></td>
+                          <td class="source">    (delegate.did ? delegate.did + &#x27;/&#x27; : &#x27;&#x27;) + self.private$.didnid()</td>
                           
-                        </tr>            <tr id="lib/api.js__235" class="chunks">
+                        </tr>            <tr id="lib/api.js__235" class="hit">
                           <td class="line" data-tooltip>235</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var out &#x3D; msg.default$ || </div><div class="miss false" data-tooltip>meta.dflt</div><div> || null</div></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__236" class="hit">
                           <td class="line" data-tooltip>236</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>25</td>
-                          <td class="source">    out &#x3D; null &#x3D;&#x3D; out ? out : Object.assign({}, out)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  function delegate_log() {</td>
                           
                         </tr>            <tr id="lib/api.js__237" class="hit">
                           <td class="line" data-tooltip>237</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>25</td>
-                          <td class="source">    return reply.call(this, null, out, meta)</td>
+                          <td class="hits" data-tooltip>11962</td>
+                          <td class="source">    return root.log.apply(delegate, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__238" class="hit">
                           <td class="line" data-tooltip>238</td>
@@ -13855,85 +13806,85 @@
                           <td class="line" data-tooltip>239</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__240" class="hit">
                           <td class="line" data-tooltip>240</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  Object.assign(delegate_log, root.log)</td>
                           
                         </tr>            <tr id="lib/api.js__241" class="hit">
                           <td class="line" data-tooltip>241</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// TODO: rename fixedargs</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  delegate_log.self &#x3D; () &#x3D;&gt; delegate</td>
                           
                         </tr>            <tr id="lib/api.js__242" class="hit">
                           <td class="line" data-tooltip>242</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.delegate &#x3D; function (fixedargs, fixedmeta) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__243" class="hit">
                           <td class="line" data-tooltip>243</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var self &#x3D; this</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var strdesc</td>
                           
                         </tr>            <tr id="lib/api.js__244" class="hit">
                           <td class="line" data-tooltip>244</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var root &#x3D; this.root</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__245" class="hit">
                           <td class="line" data-tooltip>245</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var opts &#x3D; this.options()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  function delegate_toString() {</td>
                           
                         </tr>            <tr id="lib/api.js__246" class="hit">
                           <td class="line" data-tooltip>246</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>94</td>
+                          <td class="source">    if (strdesc) return strdesc</td>
                           
                         </tr>            <tr id="lib/api.js__247" class="hit">
                           <td class="line" data-tooltip>247</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  fixedargs &#x3D; fixedargs || {}</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">    var vfa &#x3D; {}</td>
                           
                         </tr>            <tr id="lib/api.js__248" class="hit">
                           <td class="line" data-tooltip>248</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  fixedmeta &#x3D; fixedmeta || {}</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">    Object.keys(fixedargs).forEach((k) &#x3D;&gt; {</td>
                           
                         </tr>            <tr id="lib/api.js__249" class="hit">
                           <td class="line" data-tooltip>249</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      var v &#x3D; fixedargs[k]</td>
                           
                         </tr>            <tr id="lib/api.js__250" class="hit">
                           <td class="line" data-tooltip>250</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var delegate &#x3D; Object.create(self)</td>
+                          <td class="hits" data-tooltip>193</td>
+                          <td class="source">      if (~k.indexOf(&#x27;$&#x27;)) return</td>
                           
                         </tr>            <tr id="lib/api.js__251" class="hit">
                           <td class="line" data-tooltip>251</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      vfa[k] &#x3D; v</td>
                           
                         </tr>            <tr id="lib/api.js__252" class="hit">
                           <td class="line" data-tooltip>252</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  delegate.private$ &#x3D; Object.create(self.private$)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__253" class="hit">
                           <td class="line" data-tooltip>253</td>
@@ -13944,32 +13895,32 @@
                         </tr>            <tr id="lib/api.js__254" class="hit">
                           <td class="line" data-tooltip>254</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  delegate.did &#x3D;</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">    strdesc &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__255" class="hit">
                           <td class="line" data-tooltip>255</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    (delegate.did ? delegate.did + &#x27;/&#x27; : &#x27;&#x27;) + self.private$.didnid()</td>
+                          <td class="source">      self.toString() +</td>
                           
                         </tr>            <tr id="lib/api.js__256" class="hit">
                           <td class="line" data-tooltip>256</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      (Object.keys(vfa).length ? &#x27;/&#x27; + Jsonic.stringify(vfa) : &#x27;&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__257" class="hit">
                           <td class="line" data-tooltip>257</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  function delegate_log() {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__258" class="hit">
                           <td class="line" data-tooltip>258</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11974</td>
-                          <td class="source">    return root.log.apply(delegate, arguments)</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">    return strdesc</td>
                           
                         </tr>            <tr id="lib/api.js__259" class="hit">
                           <td class="line" data-tooltip>259</td>
@@ -13983,83 +13934,83 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__261" class="hit">
+                        </tr>            <tr id="lib/api.js__261" class="chunks">
                           <td class="line" data-tooltip>261</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  Object.assign(delegate_log, root.log)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>  var delegate_fixedargs &#x3D; </div><div class="miss true" data-tooltip>opts.strict.fixedargs</div></td>
                           
                         </tr>            <tr id="lib/api.js__262" class="hit">
                           <td class="line" data-tooltip>262</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  delegate_log.self &#x3D; () &#x3D;&gt; delegate</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    ? Object.assign({}, fixedargs, self.fixedargs)</td>
                           
-                        </tr>            <tr id="lib/api.js__263" class="hit">
+                        </tr>            <tr id="lib/api.js__263" class="chunks">
                           <td class="line" data-tooltip>263</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>    : </div><div class="miss never" data-tooltip>Object.assign({}, self.fixedargs, fixedargs)</div></td>
                           
                         </tr>            <tr id="lib/api.js__264" class="hit">
                           <td class="line" data-tooltip>264</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var strdesc</td>
-                          
-                        </tr>            <tr id="lib/api.js__265" class="hit">
-                          <td class="line" data-tooltip>265</td>
-                          <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__266" class="hit">
+                        </tr>            <tr id="lib/api.js__265" class="chunks">
+                          <td class="line" data-tooltip>265</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>  var delegate_fixedmeta &#x3D; </div><div class="miss false" data-tooltip>opts.strict.fixedmeta</div></td>
+                          
+                        </tr>            <tr id="lib/api.js__266" class="chunks">
                           <td class="line" data-tooltip>266</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  function delegate_toString() {</td>
+                          <td class="source"><div>    ? </div><div class="miss never" data-tooltip>Object.assign({}, fixedmeta, self.fixedmeta)</div></td>
                           
                         </tr>            <tr id="lib/api.js__267" class="hit">
                           <td class="line" data-tooltip>267</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>98</td>
-                          <td class="source">    if (strdesc) return strdesc</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    : Object.assign({}, self.fixedmeta, fixedmeta)</td>
                           
                         </tr>            <tr id="lib/api.js__268" class="hit">
                           <td class="line" data-tooltip>268</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>82</td>
-                          <td class="source">    var vfa &#x3D; {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__269" class="hit">
                           <td class="line" data-tooltip>269</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>82</td>
-                          <td class="source">    Object.keys(fixedargs).forEach((k) &#x3D;&gt; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  function delegate_delegate(further_fixedargs, further_fixedmeta) {</td>
                           
                         </tr>            <tr id="lib/api.js__270" class="hit">
                           <td class="line" data-tooltip>270</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      var v &#x3D; fixedargs[k]</td>
+                          <td class="hits" data-tooltip>2131</td>
+                          <td class="source">    var args &#x3D; Object.assign({}, delegate.fixedargs, further_fixedargs || {})</td>
                           
                         </tr>            <tr id="lib/api.js__271" class="hit">
                           <td class="line" data-tooltip>271</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>209</td>
-                          <td class="source">      if (~k.indexOf(&#x27;$&#x27;)) return</td>
+                          <td class="hits" data-tooltip>2131</td>
+                          <td class="source">    var meta &#x3D; Object.assign({}, delegate.fixedmeta, further_fixedmeta || {})</td>
                           
                         </tr>            <tr id="lib/api.js__272" class="hit">
                           <td class="line" data-tooltip>272</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      vfa[k] &#x3D; v</td>
+                          <td class="hits" data-tooltip>2131</td>
+                          <td class="source">    return self.delegate.call(this, args, meta)</td>
                           
                         </tr>            <tr id="lib/api.js__273" class="hit">
                           <td class="line" data-tooltip>273</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__274" class="hit">
                           <td class="line" data-tooltip>274</td>
@@ -14070,20 +14021,20 @@
                         </tr>            <tr id="lib/api.js__275" class="hit">
                           <td class="line" data-tooltip>275</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>82</td>
-                          <td class="source">    strdesc &#x3D;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // Somewhere to put contextual data for this delegate.</td>
                           
                         </tr>            <tr id="lib/api.js__276" class="hit">
                           <td class="line" data-tooltip>276</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      self.toString() +</td>
+                          <td class="source">  // For example, data for individual web requests.</td>
                           
                         </tr>            <tr id="lib/api.js__277" class="hit">
                           <td class="line" data-tooltip>277</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      (Object.keys(vfa).length ? &#x27;/&#x27; + Jsonic.stringify(vfa) : &#x27;&#x27;)</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var delegate_context &#x3D; Object.assign({}, self.context)</td>
                           
                         </tr>            <tr id="lib/api.js__278" class="hit">
                           <td class="line" data-tooltip>278</td>
@@ -14094,122 +14045,122 @@
                         </tr>            <tr id="lib/api.js__279" class="hit">
                           <td class="line" data-tooltip>279</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>82</td>
-                          <td class="source">    return strdesc</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // Prevents incorrect prototype properties in mocha test contexts</td>
                           
                         </tr>            <tr id="lib/api.js__280" class="hit">
                           <td class="line" data-tooltip>280</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  Object.defineProperties(delegate, {</td>
                           
                         </tr>            <tr id="lib/api.js__281" class="hit">
                           <td class="line" data-tooltip>281</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    log: { value: delegate_log, writable: true },</td>
                           
-                        </tr>            <tr id="lib/api.js__282" class="chunks">
+                        </tr>            <tr id="lib/api.js__282" class="hit">
                           <td class="line" data-tooltip>282</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  var delegate_fixedargs &#x3D; </div><div class="miss true" data-tooltip>opts.strict.fixedargs</div></td>
+                          <td class="source">    toString: { value: delegate_toString, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__283" class="hit">
                           <td class="line" data-tooltip>283</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    ? Object.assign({}, fixedargs, self.fixedargs)</td>
+                          <td class="source">    fixedargs: { value: delegate_fixedargs, writable: true },</td>
                           
-                        </tr>            <tr id="lib/api.js__284" class="chunks">
+                        </tr>            <tr id="lib/api.js__284" class="hit">
                           <td class="line" data-tooltip>284</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    : </div><div class="miss never" data-tooltip>Object.assign({}, self.fixedargs, fixedargs)</div></td>
+                          <td class="source">    fixedmeta: { value: delegate_fixedmeta, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__285" class="hit">
                           <td class="line" data-tooltip>285</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    delegate: { value: delegate_delegate, writable: true },</td>
                           
-                        </tr>            <tr id="lib/api.js__286" class="chunks">
+                        </tr>            <tr id="lib/api.js__286" class="hit">
                           <td class="line" data-tooltip>286</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  var delegate_fixedmeta &#x3D; </div><div class="miss false" data-tooltip>opts.strict.fixedmeta</div></td>
+                          <td class="source">    context: { value: delegate_context, writable: true },</td>
                           
-                        </tr>            <tr id="lib/api.js__287" class="chunks">
+                        </tr>            <tr id="lib/api.js__287" class="hit">
                           <td class="line" data-tooltip>287</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    ? </div><div class="miss never" data-tooltip>Object.assign({}, fixedmeta, self.fixedmeta)</div></td>
+                          <td class="source">  })</td>
                           
                         </tr>            <tr id="lib/api.js__288" class="hit">
                           <td class="line" data-tooltip>288</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    : Object.assign({}, self.fixedmeta, fixedmeta)</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__289" class="hit">
                           <td class="line" data-tooltip>289</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  return delegate</td>
                           
                         </tr>            <tr id="lib/api.js__290" class="hit">
                           <td class="line" data-tooltip>290</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  function delegate_delegate(further_fixedargs, further_fixedmeta) {</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__291" class="hit">
                           <td class="line" data-tooltip>291</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2131</td>
-                          <td class="source">    var args &#x3D; Object.assign({}, delegate.fixedargs, further_fixedargs || {})</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__292" class="hit">
                           <td class="line" data-tooltip>292</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2131</td>
-                          <td class="source">    var meta &#x3D; Object.assign({}, delegate.fixedmeta, further_fixedmeta || {})</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.depends &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__293" class="hit">
                           <td class="line" data-tooltip>293</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2131</td>
-                          <td class="source">    return self.delegate.call(this, args, meta)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__294" class="hit">
                           <td class="line" data-tooltip>294</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  var private$ &#x3D; this.private$</td>
                           
                         </tr>            <tr id="lib/api.js__295" class="hit">
                           <td class="line" data-tooltip>295</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  var error &#x3D; this.util.error</td>
                           
                         </tr>            <tr id="lib/api.js__296" class="hit">
                           <td class="line" data-tooltip>296</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // Somewhere to put contextual data for this delegate.</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  var args &#x3D; Norma(&#x27;{pluginname:s deps:a? moredeps:s*}&#x27;, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__297" class="hit">
                           <td class="line" data-tooltip>297</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // For example, data for individual web requests.</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__298" class="hit">
                           <td class="line" data-tooltip>298</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var delegate_context &#x3D; Object.assign({}, self.context)</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  var deps &#x3D; args.deps || args.moredeps || []</td>
                           
                         </tr>            <tr id="lib/api.js__299" class="hit">
                           <td class="line" data-tooltip>299</td>
@@ -14220,140 +14171,140 @@
                         </tr>            <tr id="lib/api.js__300" class="hit">
                           <td class="line" data-tooltip>300</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // Prevents incorrect prototype properties in mocha test contexts</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  for (var i &#x3D; 0; i &lt; deps.length; i++) {</td>
                           
                         </tr>            <tr id="lib/api.js__301" class="hit">
                           <td class="line" data-tooltip>301</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  Object.defineProperties(delegate, {</td>
+                          <td class="hits" data-tooltip>9</td>
+                          <td class="source">    var depname &#x3D; deps[i]</td>
                           
                         </tr>            <tr id="lib/api.js__302" class="hit">
                           <td class="line" data-tooltip>302</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    log: { value: delegate_log, writable: true },</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__303" class="hit">
                           <td class="line" data-tooltip>303</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    toString: { value: delegate_toString, writable: true },</td>
+                          <td class="hits" data-tooltip>9</td>
+                          <td class="source">    if (</td>
                           
                         </tr>            <tr id="lib/api.js__304" class="hit">
                           <td class="line" data-tooltip>304</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    fixedargs: { value: delegate_fixedargs, writable: true },</td>
+                          <td class="source">      !private$.plugin_order.byname.includes(depname) &amp;&amp;</td>
                           
-                        </tr>            <tr id="lib/api.js__305" class="hit">
+                        </tr>            <tr id="lib/api.js__305" class="chunks">
                           <td class="line" data-tooltip>305</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    fixedmeta: { value: delegate_fixedmeta, writable: true },</td>
+                          <td class="source"><div>      </div><div class="miss true" data-tooltip>!private$.plugin_order.byname.includes(&#x27;seneca-&#x27; + depname)</div></td>
                           
                         </tr>            <tr id="lib/api.js__306" class="hit">
                           <td class="line" data-tooltip>306</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    delegate: { value: delegate_delegate, writable: true },</td>
+                          <td class="source">    ) {</td>
                           
                         </tr>            <tr id="lib/api.js__307" class="hit">
                           <td class="line" data-tooltip>307</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    context: { value: delegate_context, writable: true },</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">      self.die(</td>
                           
                         </tr>            <tr id="lib/api.js__308" class="hit">
                           <td class="line" data-tooltip>308</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  })</td>
+                          <td class="source">        error(&#x27;plugin_required&#x27;, {</td>
                           
                         </tr>            <tr id="lib/api.js__309" class="hit">
                           <td class="line" data-tooltip>309</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">          name: args.pluginname,</td>
                           
                         </tr>            <tr id="lib/api.js__310" class="hit">
                           <td class="line" data-tooltip>310</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  return delegate</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">          dependency: depname,</td>
                           
                         </tr>            <tr id="lib/api.js__311" class="hit">
                           <td class="line" data-tooltip>311</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">        })</td>
                           
                         </tr>            <tr id="lib/api.js__312" class="hit">
                           <td class="line" data-tooltip>312</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      )</td>
                           
                         </tr>            <tr id="lib/api.js__313" class="hit">
                           <td class="line" data-tooltip>313</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.depends &#x3D; function () {</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">      break</td>
                           
                         </tr>            <tr id="lib/api.js__314" class="hit">
                           <td class="line" data-tooltip>314</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var self &#x3D; this</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__315" class="hit">
                           <td class="line" data-tooltip>315</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  var private$ &#x3D; this.private$</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__316" class="hit">
                           <td class="line" data-tooltip>316</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  var error &#x3D; this.util.error</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__317" class="hit">
                           <td class="line" data-tooltip>317</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  var args &#x3D; Norma(&#x27;{pluginname:s deps:a? moredeps:s*}&#x27;, arguments)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__318" class="hit">
                           <td class="line" data-tooltip>318</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.export &#x3D; function (key) {</td>
                           
                         </tr>            <tr id="lib/api.js__319" class="hit">
                           <td class="line" data-tooltip>319</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  var deps &#x3D; args.deps || args.moredeps || []</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__320" class="hit">
                           <td class="line" data-tooltip>320</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>76</td>
+                          <td class="source">  var private$ &#x3D; this.private$</td>
                           
                         </tr>            <tr id="lib/api.js__321" class="hit">
                           <td class="line" data-tooltip>321</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  for (var i &#x3D; 0; i &lt; deps.length; i++) {</td>
+                          <td class="hits" data-tooltip>76</td>
+                          <td class="source">  var error &#x3D; this.util.error</td>
                           
                         </tr>            <tr id="lib/api.js__322" class="hit">
                           <td class="line" data-tooltip>322</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
-                          <td class="source">    var depname &#x3D; deps[i]</td>
+                          <td class="hits" data-tooltip>76</td>
+                          <td class="source">  var opts &#x3D; this.options()</td>
                           
                         </tr>            <tr id="lib/api.js__323" class="hit">
                           <td class="line" data-tooltip>323</td>
@@ -14364,152 +14315,152 @@
                         </tr>            <tr id="lib/api.js__324" class="hit">
                           <td class="line" data-tooltip>324</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
-                          <td class="source">    if (</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // Legacy aliases</td>
                           
-                        </tr>            <tr id="lib/api.js__325" class="hit">
+                        </tr>            <tr id="lib/api.js__325" class="chunks">
                           <td class="line" data-tooltip>325</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      !private$.plugin_order.byname.includes(depname) &amp;&amp;</td>
+                          <td class="source"><div>  if (</div><div class="miss false" data-tooltip>key &#x3D;&#x3D;&#x3D; &#x27;util&#x27;</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__326" class="chunks">
+                        </tr>            <tr id="lib/api.js__326" class="miss">
                           <td class="line" data-tooltip>326</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      </div><div class="miss true" data-tooltip>!private$.plugin_order.byname.includes(&#x27;seneca-&#x27; + depname)</div></td>
+                          <td class="source" data-tooltip>    key &#x3D; &#x27;basic&#x27;</td>
                           
                         </tr>            <tr id="lib/api.js__327" class="hit">
                           <td class="line" data-tooltip>327</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    ) {</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__328" class="hit">
                           <td class="line" data-tooltip>328</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">      self.die(</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__329" class="hit">
                           <td class="line" data-tooltip>329</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        error(&#x27;plugin_required&#x27;, {</td>
+                          <td class="hits" data-tooltip>76</td>
+                          <td class="source">  var exportval &#x3D; private$.exports[key]</td>
                           
                         </tr>            <tr id="lib/api.js__330" class="hit">
                           <td class="line" data-tooltip>330</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          name: args.pluginname,</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__331" class="hit">
+                        </tr>            <tr id="lib/api.js__331" class="chunks">
                           <td class="line" data-tooltip>331</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          dependency: depname,</td>
+                          <td class="source"><div>  if (!exportval &amp;&amp; </div><div class="miss true" data-tooltip>opts.strict.exports</div><div>) {</div></td>
                           
                         </tr>            <tr id="lib/api.js__332" class="hit">
                           <td class="line" data-tooltip>332</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        })</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    return self.die(error(&#x27;export_not_found&#x27;, { key: key }))</td>
                           
                         </tr>            <tr id="lib/api.js__333" class="hit">
                           <td class="line" data-tooltip>333</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      )</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__334" class="hit">
                           <td class="line" data-tooltip>334</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">      break</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__335" class="hit">
                           <td class="line" data-tooltip>335</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>75</td>
+                          <td class="source">  return exportval</td>
                           
                         </tr>            <tr id="lib/api.js__336" class="hit">
                           <td class="line" data-tooltip>336</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__337" class="hit">
                           <td class="line" data-tooltip>337</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__338" class="hit">
                           <td class="line" data-tooltip>338</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.quiet &#x3D; function (flags) {</td>
                           
                         </tr>            <tr id="lib/api.js__339" class="hit">
                           <td class="line" data-tooltip>339</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.export &#x3D; function (key) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  flags &#x3D; flags || {}</td>
                           
                         </tr>            <tr id="lib/api.js__340" class="hit">
                           <td class="line" data-tooltip>340</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var self &#x3D; this</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__341" class="hit">
                           <td class="line" data-tooltip>341</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>76</td>
-                          <td class="source">  var private$ &#x3D; this.private$</td>
+                          <td class="hits" data-tooltip>39</td>
+                          <td class="source">  var quiet_opts &#x3D; {</td>
                           
                         </tr>            <tr id="lib/api.js__342" class="hit">
                           <td class="line" data-tooltip>342</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>76</td>
-                          <td class="source">  var error &#x3D; this.util.error</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    test: false,</td>
                           
                         </tr>            <tr id="lib/api.js__343" class="hit">
                           <td class="line" data-tooltip>343</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>76</td>
-                          <td class="source">  var opts &#x3D; this.options()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    quiet: true,</td>
                           
                         </tr>            <tr id="lib/api.js__344" class="hit">
                           <td class="line" data-tooltip>344</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    log: &#x27;none&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__345" class="hit">
                           <td class="line" data-tooltip>345</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // Legacy aliases</td>
+                          <td class="source">    reload$: true,</td>
                           
-                        </tr>            <tr id="lib/api.js__346" class="chunks">
+                        </tr>            <tr id="lib/api.js__346" class="hit">
                           <td class="line" data-tooltip>346</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  if (</div><div class="miss false" data-tooltip>key &#x3D;&#x3D;&#x3D; &#x27;util&#x27;</div><div>) {</div></td>
+                          <td class="source">  }</td>
                           
-                        </tr>            <tr id="lib/api.js__347" class="miss">
+                        </tr>            <tr id="lib/api.js__347" class="hit">
                           <td class="line" data-tooltip>347</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>    key &#x3D; &#x27;basic&#x27;</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__348" class="hit">
                           <td class="line" data-tooltip>348</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>39</td>
+                          <td class="source">  var opts &#x3D; this.options(quiet_opts)</td>
                           
                         </tr>            <tr id="lib/api.js__349" class="hit">
                           <td class="line" data-tooltip>349</td>
@@ -14520,122 +14471,122 @@
                         </tr>            <tr id="lib/api.js__350" class="hit">
                           <td class="line" data-tooltip>350</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>76</td>
-                          <td class="source">  var exportval &#x3D; private$.exports[key]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // An override from env or args is possible.</td>
                           
                         </tr>            <tr id="lib/api.js__351" class="hit">
                           <td class="line" data-tooltip>351</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  // Only flip to test mode if called from test() method</td>
                           
                         </tr>            <tr id="lib/api.js__352" class="chunks">
                           <td class="line" data-tooltip>352</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  if (!exportval &amp;&amp; </div><div class="miss true" data-tooltip>opts.strict.exports</div><div>) {</div></td>
+                          <td class="source"><div>  if (opts.test &amp;&amp; </div><div class="miss true" data-tooltip>&#x27;test&#x27; !&#x3D;&#x3D; flags.from</div><div>) {</div></td>
                           
                         </tr>            <tr id="lib/api.js__353" class="hit">
                           <td class="line" data-tooltip>353</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    return self.die(error(&#x27;export_not_found&#x27;, { key: key }))</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    return this.test()</td>
                           
                         </tr>            <tr id="lib/api.js__354" class="hit">
                           <td class="line" data-tooltip>354</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">  } else {</td>
                           
                         </tr>            <tr id="lib/api.js__355" class="hit">
                           <td class="line" data-tooltip>355</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>37</td>
+                          <td class="source">    this.private$.logging.build_log(this)</td>
                           
                         </tr>            <tr id="lib/api.js__356" class="hit">
                           <td class="line" data-tooltip>356</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>75</td>
-                          <td class="source">  return exportval</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__357" class="hit">
                           <td class="line" data-tooltip>357</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>37</td>
+                          <td class="source">    return this</td>
                           
                         </tr>            <tr id="lib/api.js__358" class="hit">
                           <td class="line" data-tooltip>358</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__359" class="hit">
                           <td class="line" data-tooltip>359</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.quiet &#x3D; function (flags) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__360" class="hit">
                           <td class="line" data-tooltip>360</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  flags &#x3D; flags || {}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__361" class="hit">
                           <td class="line" data-tooltip>361</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.test &#x3D; function (errhandler, logspec) {</td>
                           
                         </tr>            <tr id="lib/api.js__362" class="hit">
                           <td class="line" data-tooltip>362</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>39</td>
-                          <td class="source">  var quiet_opts &#x3D; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var opts &#x3D; this.options()</td>
                           
                         </tr>            <tr id="lib/api.js__363" class="hit">
                           <td class="line" data-tooltip>363</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    test: false,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__364" class="hit">
                           <td class="line" data-tooltip>364</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    quiet: true,</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  if (&#x27;-&#x27; !&#x3D; opts.tag) {</td>
                           
                         </tr>            <tr id="lib/api.js__365" class="hit">
                           <td class="line" data-tooltip>365</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    log: &#x27;none&#x27;,</td>
+                          <td class="hits" data-tooltip>21</td>
+                          <td class="source">    this.root.id &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__366" class="hit">
                           <td class="line" data-tooltip>366</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    reload$: true,</td>
+                          <td class="source">      null &#x3D;&#x3D; opts.id$</td>
                           
                         </tr>            <tr id="lib/api.js__367" class="hit">
                           <td class="line" data-tooltip>367</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">        ? this.private$.actnid().substring(0, 4) + &#x27;/&#x27; + opts.tag</td>
                           
                         </tr>            <tr id="lib/api.js__368" class="hit">
                           <td class="line" data-tooltip>368</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">        : &#x27;&#x27; + opts.id$</td>
                           
                         </tr>            <tr id="lib/api.js__369" class="hit">
                           <td class="line" data-tooltip>369</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>39</td>
-                          <td class="source">  var opts &#x3D; this.options(quiet_opts)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__370" class="hit">
                           <td class="line" data-tooltip>370</td>
@@ -14646,38 +14597,38 @@
                         </tr>            <tr id="lib/api.js__371" class="hit">
                           <td class="line" data-tooltip>371</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // An override from env or args is possible.</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  if (&#x27;function&#x27; !&#x3D;&#x3D; typeof errhandler &amp;&amp; null !&#x3D;&#x3D; errhandler) {</td>
                           
                         </tr>            <tr id="lib/api.js__372" class="hit">
                           <td class="line" data-tooltip>372</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // Only flip to test mode if called from test() method</td>
+                          <td class="hits" data-tooltip>55</td>
+                          <td class="source">    logspec &#x3D; errhandler</td>
                           
-                        </tr>            <tr id="lib/api.js__373" class="chunks">
+                        </tr>            <tr id="lib/api.js__373" class="hit">
                           <td class="line" data-tooltip>373</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  if (opts.test &amp;&amp; </div><div class="miss true" data-tooltip>&#x27;test&#x27; !&#x3D;&#x3D; flags.from</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>55</td>
+                          <td class="source">    errhandler &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__374" class="hit">
                           <td class="line" data-tooltip>374</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    return this.test()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__375" class="hit">
                           <td class="line" data-tooltip>375</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__376" class="hit">
+                        </tr>            <tr id="lib/api.js__376" class="chunks">
                           <td class="line" data-tooltip>376</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>37</td>
-                          <td class="source">    this.private$.logging.build_log(this)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>  logspec &#x3D; </div><div class="miss false" data-tooltip>true &#x3D;&#x3D;&#x3D; logspec</div><div> || &#x27;true&#x27; &#x3D;&#x3D;&#x3D; logspec ? &#x27;test&#x27; : logspec</div></td>
                           
                         </tr>            <tr id="lib/api.js__377" class="hit">
                           <td class="line" data-tooltip>377</td>
@@ -14688,278 +14639,278 @@
                         </tr>            <tr id="lib/api.js__378" class="hit">
                           <td class="line" data-tooltip>378</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>37</td>
-                          <td class="source">    return this</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  var test_opts &#x3D; {</td>
                           
                         </tr>            <tr id="lib/api.js__379" class="hit">
                           <td class="line" data-tooltip>379</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    errhandler: null &#x3D;&#x3D; errhandler ? null : errhandler,</td>
                           
                         </tr>            <tr id="lib/api.js__380" class="hit">
                           <td class="line" data-tooltip>380</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    test: true,</td>
                           
                         </tr>            <tr id="lib/api.js__381" class="hit">
                           <td class="line" data-tooltip>381</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    quiet: false,</td>
                           
                         </tr>            <tr id="lib/api.js__382" class="hit">
                           <td class="line" data-tooltip>382</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.test &#x3D; function (errhandler, logspec) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    reload$: true,</td>
                           
                         </tr>            <tr id="lib/api.js__383" class="hit">
                           <td class="line" data-tooltip>383</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var opts &#x3D; this.options()</td>
+                          <td class="source">    log: logspec || &#x27;test&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__384" class="hit">
                           <td class="line" data-tooltip>384</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__385" class="hit">
                           <td class="line" data-tooltip>385</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  if (&#x27;-&#x27; !&#x3D; opts.tag) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__386" class="hit">
                           <td class="line" data-tooltip>386</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
-                          <td class="source">    this.root.id &#x3D;</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  var set_opts &#x3D; this.options(test_opts)</td>
                           
                         </tr>            <tr id="lib/api.js__387" class="hit">
                           <td class="line" data-tooltip>387</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      null &#x3D;&#x3D; opts.id$</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__388" class="hit">
                           <td class="line" data-tooltip>388</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        ? this.private$.actnid().substring(0, 4) + &#x27;/&#x27; + opts.tag</td>
+                          <td class="source">  // An override from env or args is possible.</td>
                           
                         </tr>            <tr id="lib/api.js__389" class="hit">
                           <td class="line" data-tooltip>389</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        : &#x27;&#x27; + opts.id$</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  if (set_opts.quiet) {</td>
                           
                         </tr>            <tr id="lib/api.js__390" class="hit">
                           <td class="line" data-tooltip>390</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    return this.quiet({ from: &#x27;test&#x27; })</td>
                           
                         </tr>            <tr id="lib/api.js__391" class="hit">
                           <td class="line" data-tooltip>391</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  } else {</td>
                           
                         </tr>            <tr id="lib/api.js__392" class="hit">
                           <td class="line" data-tooltip>392</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  if (&#x27;function&#x27; !&#x3D;&#x3D; typeof errhandler &amp;&amp; null !&#x3D;&#x3D; errhandler) {</td>
+                          <td class="hits" data-tooltip>201</td>
+                          <td class="source">    this.private$.logging.build_log(this)</td>
                           
                         </tr>            <tr id="lib/api.js__393" class="hit">
                           <td class="line" data-tooltip>393</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>55</td>
-                          <td class="source">    logspec &#x3D; errhandler</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__394" class="hit">
                           <td class="line" data-tooltip>394</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>55</td>
-                          <td class="source">    errhandler &#x3D; null</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    // Manually set logger to test_logger (avoids infecting options structure),</td>
                           
                         </tr>            <tr id="lib/api.js__395" class="hit">
                           <td class="line" data-tooltip>395</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    // unless there was an external logger defined by the options</td>
                           
                         </tr>            <tr id="lib/api.js__396" class="hit">
                           <td class="line" data-tooltip>396</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>201</td>
+                          <td class="source">    if (!this.private$.logger.from_options$) {</td>
                           
-                        </tr>            <tr id="lib/api.js__397" class="chunks">
+                        </tr>            <tr id="lib/api.js__397" class="hit">
                           <td class="line" data-tooltip>397</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  logspec &#x3D; </div><div class="miss false" data-tooltip>true &#x3D;&#x3D;&#x3D; logspec</div><div> || &#x27;true&#x27; &#x3D;&#x3D;&#x3D; logspec ? &#x27;test&#x27; : logspec</div></td>
+                          <td class="hits" data-tooltip>188</td>
+                          <td class="source">      this.root.private$.logger &#x3D; this.private$.logging.test_logger</td>
                           
                         </tr>            <tr id="lib/api.js__398" class="hit">
                           <td class="line" data-tooltip>398</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__399" class="hit">
                           <td class="line" data-tooltip>399</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  var test_opts &#x3D; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__400" class="hit">
                           <td class="line" data-tooltip>400</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    errhandler: null &#x3D;&#x3D; errhandler ? null : errhandler,</td>
+                          <td class="hits" data-tooltip>201</td>
+                          <td class="source">    return this</td>
                           
                         </tr>            <tr id="lib/api.js__401" class="hit">
                           <td class="line" data-tooltip>401</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    test: true,</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__402" class="hit">
                           <td class="line" data-tooltip>402</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    quiet: false,</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__403" class="hit">
                           <td class="line" data-tooltip>403</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    reload$: true,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__404" class="hit">
                           <td class="line" data-tooltip>404</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    log: logspec || &#x27;test&#x27;,</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.ping &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__405" class="hit">
                           <td class="line" data-tooltip>405</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">  var now &#x3D; Date.now()</td>
                           
                         </tr>            <tr id="lib/api.js__406" class="hit">
                           <td class="line" data-tooltip>406</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">  return {</td>
                           
                         </tr>            <tr id="lib/api.js__407" class="hit">
                           <td class="line" data-tooltip>407</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  var set_opts &#x3D; this.options(test_opts)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    now: now,</td>
                           
                         </tr>            <tr id="lib/api.js__408" class="hit">
                           <td class="line" data-tooltip>408</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    uptime: now - this.private$.stats.start,</td>
                           
                         </tr>            <tr id="lib/api.js__409" class="hit">
                           <td class="line" data-tooltip>409</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // An override from env or args is possible.</td>
+                          <td class="source">    id: this.id,</td>
                           
                         </tr>            <tr id="lib/api.js__410" class="hit">
                           <td class="line" data-tooltip>410</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  if (set_opts.quiet) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    cpu: process.cpuUsage(),</td>
                           
                         </tr>            <tr id="lib/api.js__411" class="hit">
                           <td class="line" data-tooltip>411</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    return this.quiet({ from: &#x27;test&#x27; })</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    mem: process.memoryUsage(),</td>
                           
                         </tr>            <tr id="lib/api.js__412" class="hit">
                           <td class="line" data-tooltip>412</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="source">    act: this.private$.stats.act,</td>
                           
                         </tr>            <tr id="lib/api.js__413" class="hit">
                           <td class="line" data-tooltip>413</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>201</td>
-                          <td class="source">    this.private$.logging.build_log(this)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    tr: this.private$.transport.register.map(function (x) {</td>
                           
                         </tr>            <tr id="lib/api.js__414" class="hit">
                           <td class="line" data-tooltip>414</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      return Object.assign({ when: x.when, err: x.err }, x.config)</td>
                           
                         </tr>            <tr id="lib/api.js__415" class="hit">
                           <td class="line" data-tooltip>415</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // Manually set logger to test_logger (avoids infecting options structure),</td>
+                          <td class="source">    }),</td>
                           
                         </tr>            <tr id="lib/api.js__416" class="hit">
                           <td class="line" data-tooltip>416</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // unless there was an external logger defined by the options</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__417" class="hit">
                           <td class="line" data-tooltip>417</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>201</td>
-                          <td class="source">    if (!this.private$.logger.from_options$) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__418" class="hit">
                           <td class="line" data-tooltip>418</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>188</td>
-                          <td class="source">      this.root.private$.logger &#x3D; this.private$.logging.test_logger</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__419" class="hit">
                           <td class="line" data-tooltip>419</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.translate &#x3D; function (from_in, to_in, pick_in) {</td>
                           
                         </tr>            <tr id="lib/api.js__420" class="hit">
                           <td class="line" data-tooltip>420</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  var from &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof from_in ? Jsonic(from_in) : from_in</td>
                           
                         </tr>            <tr id="lib/api.js__421" class="hit">
                           <td class="line" data-tooltip>421</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>201</td>
-                          <td class="source">    return this</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  var to &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof to_in ? Jsonic(to_in) : to_in</td>
                           
                         </tr>            <tr id="lib/api.js__422" class="hit">
                           <td class="line" data-tooltip>422</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__423" class="hit">
                           <td class="line" data-tooltip>423</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  var pick &#x3D; {}</td>
                           
                         </tr>            <tr id="lib/api.js__424" class="hit">
                           <td class="line" data-tooltip>424</td>
@@ -14970,122 +14921,122 @@
                         </tr>            <tr id="lib/api.js__425" class="hit">
                           <td class="line" data-tooltip>425</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.ping &#x3D; function () {</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  if (&#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pick_in) {</td>
                           
                         </tr>            <tr id="lib/api.js__426" class="hit">
                           <td class="line" data-tooltip>426</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var now &#x3D; Date.now()</td>
+                          <td class="hits" data-tooltip>4</td>
+                          <td class="source">    pick_in &#x3D; pick_in.split(/\s*,\s*/)</td>
                           
                         </tr>            <tr id="lib/api.js__427" class="hit">
                           <td class="line" data-tooltip>427</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">  return {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__428" class="hit">
                           <td class="line" data-tooltip>428</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    now: now,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__429" class="hit">
                           <td class="line" data-tooltip>429</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    uptime: now - this.private$.stats.start,</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  if (Array.isArray(pick_in)) {</td>
                           
                         </tr>            <tr id="lib/api.js__430" class="hit">
                           <td class="line" data-tooltip>430</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    id: this.id,</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">    pick_in.forEach(function (prop) {</td>
                           
                         </tr>            <tr id="lib/api.js__431" class="hit">
                           <td class="line" data-tooltip>431</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    cpu: process.cpuUsage(),</td>
+                          <td class="source">      if (prop.startsWith(&#x27;-&#x27;)) {</td>
                           
                         </tr>            <tr id="lib/api.js__432" class="hit">
                           <td class="line" data-tooltip>432</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    mem: process.memoryUsage(),</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">        pick[prop.substring(1)] &#x3D; false</td>
                           
                         </tr>            <tr id="lib/api.js__433" class="hit">
                           <td class="line" data-tooltip>433</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    act: this.private$.stats.act,</td>
+                          <td class="source">      } else {</td>
                           
                         </tr>            <tr id="lib/api.js__434" class="hit">
                           <td class="line" data-tooltip>434</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    tr: this.private$.transport.register.map(function (x) {</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">        pick[prop] &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__435" class="hit">
                           <td class="line" data-tooltip>435</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      return Object.assign({ when: x.when, err: x.err }, x.config)</td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__436" class="hit">
                           <td class="line" data-tooltip>436</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }),</td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__437" class="hit">
                           <td class="line" data-tooltip>437</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">  } else if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof pick_in) {</td>
                           
                         </tr>            <tr id="lib/api.js__438" class="hit">
                           <td class="line" data-tooltip>438</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    pick &#x3D; Object.assign({}, pick_in)</td>
                           
                         </tr>            <tr id="lib/api.js__439" class="hit">
                           <td class="line" data-tooltip>439</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  } else {</td>
                           
                         </tr>            <tr id="lib/api.js__440" class="hit">
                           <td class="line" data-tooltip>440</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.translate &#x3D; function (from_in, to_in, pick_in) {</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    pick &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__441" class="hit">
                           <td class="line" data-tooltip>441</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var from &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof from_in ? Jsonic(from_in) : from_in</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__442" class="hit">
                           <td class="line" data-tooltip>442</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  var to &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof to_in ? Jsonic(to_in) : to_in</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__443" class="hit">
                           <td class="line" data-tooltip>443</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  this.add(from, function (msg, reply) {</td>
                           
                         </tr>            <tr id="lib/api.js__444" class="hit">
                           <td class="line" data-tooltip>444</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  var pick &#x3D; {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    var pick_msg</td>
                           
                         </tr>            <tr id="lib/api.js__445" class="hit">
                           <td class="line" data-tooltip>445</td>
@@ -15097,103 +15048,103 @@
                           <td class="line" data-tooltip>446</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>11</td>
-                          <td class="source">  if (&#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pick_in) {</td>
+                          <td class="source">    if (pick) {</td>
                           
                         </tr>            <tr id="lib/api.js__447" class="hit">
                           <td class="line" data-tooltip>447</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>4</td>
-                          <td class="source">    pick_in &#x3D; pick_in.split(/\s*,\s*/)</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">      pick_msg &#x3D; {}</td>
                           
                         </tr>            <tr id="lib/api.js__448" class="hit">
                           <td class="line" data-tooltip>448</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">      Object.keys(pick).forEach(function (prop) {</td>
                           
                         </tr>            <tr id="lib/api.js__449" class="hit">
                           <td class="line" data-tooltip>449</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">        if (pick[prop]) {</td>
                           
                         </tr>            <tr id="lib/api.js__450" class="hit">
                           <td class="line" data-tooltip>450</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  if (Array.isArray(pick_in)) {</td>
+                          <td class="hits" data-tooltip>9</td>
+                          <td class="source">          pick_msg[prop] &#x3D; msg[prop]</td>
                           
                         </tr>            <tr id="lib/api.js__451" class="hit">
                           <td class="line" data-tooltip>451</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">    pick_in.forEach(function (prop) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__452" class="hit">
                           <td class="line" data-tooltip>452</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      if (prop.startsWith(&#x27;-&#x27;)) {</td>
+                          <td class="source">      })</td>
                           
                         </tr>            <tr id="lib/api.js__453" class="hit">
                           <td class="line" data-tooltip>453</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">        pick[prop.substring(1)] &#x3D; false</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    } else {</td>
                           
                         </tr>            <tr id="lib/api.js__454" class="hit">
                           <td class="line" data-tooltip>454</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      } else {</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">      pick_msg &#x3D; this.util.clean(msg)</td>
                           
                         </tr>            <tr id="lib/api.js__455" class="hit">
                           <td class="line" data-tooltip>455</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">        pick[prop] &#x3D; true</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__456" class="hit">
                           <td class="line" data-tooltip>456</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__457" class="hit">
                           <td class="line" data-tooltip>457</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">    var transmsg &#x3D; Object.assign(pick_msg, to)</td>
                           
                         </tr>            <tr id="lib/api.js__458" class="hit">
                           <td class="line" data-tooltip>458</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">  } else if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof pick_in) {</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">    this.act(transmsg, reply)</td>
                           
                         </tr>            <tr id="lib/api.js__459" class="hit">
                           <td class="line" data-tooltip>459</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    pick &#x3D; Object.assign({}, pick_in)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  })</td>
                           
                         </tr>            <tr id="lib/api.js__460" class="hit">
                           <td class="line" data-tooltip>460</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__461" class="hit">
                           <td class="line" data-tooltip>461</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    pick &#x3D; null</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__462" class="hit">
                           <td class="line" data-tooltip>462</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__463" class="hit">
                           <td class="line" data-tooltip>463</td>
@@ -15204,80 +15155,80 @@
                         </tr>            <tr id="lib/api.js__464" class="hit">
                           <td class="line" data-tooltip>464</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  this.add(from, function (msg, reply) {</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.gate &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__465" class="hit">
                           <td class="line" data-tooltip>465</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    var pick_msg</td>
+                          <td class="source">  return this.delegate({ gate$: true })</td>
                           
                         </tr>            <tr id="lib/api.js__466" class="hit">
                           <td class="line" data-tooltip>466</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__467" class="hit">
                           <td class="line" data-tooltip>467</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">    if (pick) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__468" class="hit">
                           <td class="line" data-tooltip>468</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">      pick_msg &#x3D; {}</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.ungate &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__469" class="hit">
                           <td class="line" data-tooltip>469</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">      Object.keys(pick).forEach(function (prop) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  this.fixedargs.gate$ &#x3D; false</td>
                           
                         </tr>            <tr id="lib/api.js__470" class="hit">
                           <td class="line" data-tooltip>470</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        if (pick[prop]) {</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__471" class="hit">
                           <td class="line" data-tooltip>471</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
-                          <td class="source">          pick_msg[prop] &#x3D; msg[prop]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__472" class="hit">
                           <td class="line" data-tooltip>472</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__473" class="hit">
                           <td class="line" data-tooltip>473</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      })</td>
+                          <td class="source">// TODO this needs a better name</td>
                           
                         </tr>            <tr id="lib/api.js__474" class="hit">
                           <td class="line" data-tooltip>474</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    } else {</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.list_plugins &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__475" class="hit">
                           <td class="line" data-tooltip>475</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">      pick_msg &#x3D; this.util.clean(msg)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  return Object.assign({}, this.private$.plugins)</td>
                           
                         </tr>            <tr id="lib/api.js__476" class="hit">
                           <td class="line" data-tooltip>476</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__477" class="hit">
                           <td class="line" data-tooltip>477</td>
@@ -15288,152 +15239,152 @@
                         </tr>            <tr id="lib/api.js__478" class="hit">
                           <td class="line" data-tooltip>478</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">    var transmsg &#x3D; Object.assign(pick_msg, to)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.find_plugin &#x3D; function (plugindesc, tag) {</td>
                           
                         </tr>            <tr id="lib/api.js__479" class="hit">
                           <td class="line" data-tooltip>479</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">    this.act(transmsg, reply)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
                           
                         </tr>            <tr id="lib/api.js__480" class="hit">
                           <td class="line" data-tooltip>480</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  })</td>
+                          <td class="hits" data-tooltip>4</td>
+                          <td class="source">  return this.private$.plugins[plugin_key]</td>
                           
                         </tr>            <tr id="lib/api.js__481" class="hit">
                           <td class="line" data-tooltip>481</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__482" class="hit">
                           <td class="line" data-tooltip>482</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__483" class="hit">
                           <td class="line" data-tooltip>483</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.has_plugin &#x3D; function (plugindesc, tag) {</td>
                           
                         </tr>            <tr id="lib/api.js__484" class="hit">
                           <td class="line" data-tooltip>484</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
                           
                         </tr>            <tr id="lib/api.js__485" class="hit">
                           <td class="line" data-tooltip>485</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.gate &#x3D; function () {</td>
+                          <td class="hits" data-tooltip>13</td>
+                          <td class="source">  return !!this.private$.plugins[plugin_key]</td>
                           
                         </tr>            <tr id="lib/api.js__486" class="hit">
                           <td class="line" data-tooltip>486</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return this.delegate({ gate$: true })</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__487" class="hit">
                           <td class="line" data-tooltip>487</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__488" class="hit">
                           <td class="line" data-tooltip>488</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.ignore_plugin &#x3D; function (plugindesc, tag, ignore) {</td>
                           
                         </tr>            <tr id="lib/api.js__489" class="hit">
                           <td class="line" data-tooltip>489</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.ungate &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  if (&#x27;boolean&#x27; &#x3D;&#x3D;&#x3D; typeof tag) {</td>
                           
                         </tr>            <tr id="lib/api.js__490" class="hit">
                           <td class="line" data-tooltip>490</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  this.fixedargs.gate$ &#x3D; false</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">    ignore &#x3D; tag</td>
                           
                         </tr>            <tr id="lib/api.js__491" class="hit">
                           <td class="line" data-tooltip>491</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">    tag &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__492" class="hit">
                           <td class="line" data-tooltip>492</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__493" class="hit">
                           <td class="line" data-tooltip>493</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
                           
                         </tr>            <tr id="lib/api.js__494" class="hit">
                           <td class="line" data-tooltip>494</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// TODO this needs a better name</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">  var resolved_ignore &#x3D; (this.private$.ignore_plugins[plugin_key] &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__495" class="hit">
                           <td class="line" data-tooltip>495</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.list_plugins &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    null &#x3D;&#x3D; ignore ? true : !!ignore)</td>
                           
                         </tr>            <tr id="lib/api.js__496" class="hit">
                           <td class="line" data-tooltip>496</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return Object.assign({}, this.private$.plugins)</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__497" class="hit">
                           <td class="line" data-tooltip>497</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">  this.log.info({</td>
                           
                         </tr>            <tr id="lib/api.js__498" class="hit">
                           <td class="line" data-tooltip>498</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    kind: &#x27;plugin&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__499" class="hit">
                           <td class="line" data-tooltip>499</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.find_plugin &#x3D; function (plugindesc, tag) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    case: &#x27;ignore&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__500" class="hit">
                           <td class="line" data-tooltip>500</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
+                          <td class="source">    full: plugin_key,</td>
                           
                         </tr>            <tr id="lib/api.js__501" class="hit">
                           <td class="line" data-tooltip>501</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>4</td>
-                          <td class="source">  return this.private$.plugins[plugin_key]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    ignore: resolved_ignore,</td>
                           
                         </tr>            <tr id="lib/api.js__502" class="hit">
                           <td class="line" data-tooltip>502</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  })</td>
                           
                         </tr>            <tr id="lib/api.js__503" class="hit">
                           <td class="line" data-tooltip>503</td>
@@ -15444,272 +15395,272 @@
                         </tr>            <tr id="lib/api.js__504" class="hit">
                           <td class="line" data-tooltip>504</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.has_plugin &#x3D; function (plugindesc, tag) {</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__505" class="hit">
                           <td class="line" data-tooltip>505</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__506" class="hit">
                           <td class="line" data-tooltip>506</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>13</td>
-                          <td class="source">  return !!this.private$.plugins[plugin_key]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__507" class="hit">
                           <td class="line" data-tooltip>507</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">// Find the action metadata for a given pattern, if it exists.</td>
                           
                         </tr>            <tr id="lib/api.js__508" class="hit">
                           <td class="line" data-tooltip>508</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.find &#x3D; function (pattern, flags) {</td>
                           
                         </tr>            <tr id="lib/api.js__509" class="hit">
                           <td class="line" data-tooltip>509</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.ignore_plugin &#x3D; function (plugindesc, tag, ignore) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var seneca &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__510" class="hit">
                           <td class="line" data-tooltip>510</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  if (&#x27;boolean&#x27; &#x3D;&#x3D;&#x3D; typeof tag) {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__511" class="hit">
                           <td class="line" data-tooltip>511</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">    ignore &#x3D; tag</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  var pat &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pattern ? Jsonic(pattern) : pattern</td>
                           
                         </tr>            <tr id="lib/api.js__512" class="hit">
                           <td class="line" data-tooltip>512</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">    tag &#x3D; null</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  pat &#x3D; seneca.util.clean(pat)</td>
                           
                         </tr>            <tr id="lib/api.js__513" class="hit">
                           <td class="line" data-tooltip>513</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  pat &#x3D; pat || {}</td>
                           
                         </tr>            <tr id="lib/api.js__514" class="hit">
                           <td class="line" data-tooltip>514</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__515" class="hit">
                           <td class="line" data-tooltip>515</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">  var resolved_ignore &#x3D; (this.private$.ignore_plugins[plugin_key] &#x3D;</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  var actdef &#x3D; seneca.private$.actrouter.find(pat, flags &amp;&amp; flags.exact)</td>
                           
                         </tr>            <tr id="lib/api.js__516" class="hit">
                           <td class="line" data-tooltip>516</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    null &#x3D;&#x3D; ignore ? true : !!ignore)</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__517" class="hit">
                           <td class="line" data-tooltip>517</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  if (!actdef) {</td>
                           
                         </tr>            <tr id="lib/api.js__518" class="hit">
                           <td class="line" data-tooltip>518</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">  this.log.info({</td>
+                          <td class="hits" data-tooltip>7692</td>
+                          <td class="source">    actdef &#x3D; seneca.private$.actrouter.find({})</td>
                           
                         </tr>            <tr id="lib/api.js__519" class="hit">
                           <td class="line" data-tooltip>519</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    kind: &#x27;plugin&#x27;,</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__520" class="hit">
                           <td class="line" data-tooltip>520</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    case: &#x27;ignore&#x27;,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__521" class="hit">
                           <td class="line" data-tooltip>521</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    full: plugin_key,</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  return actdef</td>
                           
                         </tr>            <tr id="lib/api.js__522" class="hit">
                           <td class="line" data-tooltip>522</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    ignore: resolved_ignore,</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__523" class="hit">
                           <td class="line" data-tooltip>523</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  })</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__524" class="hit">
                           <td class="line" data-tooltip>524</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">// True if an action matching the pattern exists.</td>
                           
                         </tr>            <tr id="lib/api.js__525" class="hit">
                           <td class="line" data-tooltip>525</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.has &#x3D; function (pattern) {</td>
                           
                         </tr>            <tr id="lib/api.js__526" class="hit">
                           <td class="line" data-tooltip>526</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  return !!this.find(pattern, { exact: true })</td>
                           
                         </tr>            <tr id="lib/api.js__527" class="hit">
                           <td class="line" data-tooltip>527</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__528" class="hit">
                           <td class="line" data-tooltip>528</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Find the action metadata for a given pattern, if it exists.</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__529" class="hit">
                           <td class="line" data-tooltip>529</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.find &#x3D; function (pattern, flags) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">// List all actions that match the pattern.</td>
                           
                         </tr>            <tr id="lib/api.js__530" class="hit">
                           <td class="line" data-tooltip>530</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var seneca &#x3D; this</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.list &#x3D; function (pattern) {</td>
                           
                         </tr>            <tr id="lib/api.js__531" class="hit">
                           <td class="line" data-tooltip>531</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  return this.private$.actrouter</td>
                           
                         </tr>            <tr id="lib/api.js__532" class="hit">
                           <td class="line" data-tooltip>532</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  var pat &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pattern ? Jsonic(pattern) : pattern</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    .list(null &#x3D;&#x3D; pattern ? {} : Jsonic(pattern))</td>
                           
                         </tr>            <tr id="lib/api.js__533" class="hit">
                           <td class="line" data-tooltip>533</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  pat &#x3D; seneca.util.clean(pat)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    .map((x) &#x3D;&gt; x.match)</td>
                           
                         </tr>            <tr id="lib/api.js__534" class="hit">
                           <td class="line" data-tooltip>534</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  pat &#x3D; pat || {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__535" class="hit">
                           <td class="line" data-tooltip>535</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  /*</td>
                           
                         </tr>            <tr id="lib/api.js__536" class="hit">
                           <td class="line" data-tooltip>536</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  var actdef &#x3D; seneca.private$.actrouter.find(pat, flags &amp;&amp; flags.exact)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  return _.map(</td>
                           
                         </tr>            <tr id="lib/api.js__537" class="hit">
                           <td class="line" data-tooltip>537</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    this.private$.actrouter.list(null &#x3D;&#x3D; pattern ? {} : Jsonic(pattern)),</td>
                           
                         </tr>            <tr id="lib/api.js__538" class="hit">
                           <td class="line" data-tooltip>538</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  if (!actdef) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    &#x27;match&#x27;</td>
                           
                         </tr>            <tr id="lib/api.js__539" class="hit">
                           <td class="line" data-tooltip>539</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7692</td>
-                          <td class="source">    actdef &#x3D; seneca.private$.actrouter.find({})</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  )</td>
                           
                         </tr>            <tr id="lib/api.js__540" class="hit">
                           <td class="line" data-tooltip>540</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">  */</td>
                           
                         </tr>            <tr id="lib/api.js__541" class="hit">
                           <td class="line" data-tooltip>541</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__542" class="hit">
                           <td class="line" data-tooltip>542</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  return actdef</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__543" class="hit">
                           <td class="line" data-tooltip>543</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">// Get the current status of the instance.</td>
                           
                         </tr>            <tr id="lib/api.js__544" class="hit">
                           <td class="line" data-tooltip>544</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.status &#x3D; function (flags) {</td>
                           
                         </tr>            <tr id="lib/api.js__545" class="hit">
                           <td class="line" data-tooltip>545</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// True if an action matching the pattern exists.</td>
+                          <td class="source">  flags &#x3D; flags || {}</td>
                           
                         </tr>            <tr id="lib/api.js__546" class="hit">
                           <td class="line" data-tooltip>546</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.has &#x3D; function (pattern) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__547" class="hit">
                           <td class="line" data-tooltip>547</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  return !!this.find(pattern, { exact: true })</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  var hist &#x3D; this.private$.history.stats()</td>
                           
                         </tr>            <tr id="lib/api.js__548" class="hit">
                           <td class="line" data-tooltip>548</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  hist.log &#x3D; this.private$.history.list()</td>
                           
                         </tr>            <tr id="lib/api.js__549" class="hit">
                           <td class="line" data-tooltip>549</td>
@@ -15720,32 +15671,32 @@
                         </tr>            <tr id="lib/api.js__550" class="hit">
                           <td class="line" data-tooltip>550</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// List all actions that match the pattern.</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  var status &#x3D; {</td>
                           
                         </tr>            <tr id="lib/api.js__551" class="hit">
                           <td class="line" data-tooltip>551</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.list &#x3D; function (pattern) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    stats: this.stats(flags.stats),</td>
                           
                         </tr>            <tr id="lib/api.js__552" class="hit">
                           <td class="line" data-tooltip>552</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return this.private$.actrouter</td>
+                          <td class="source">    history: hist,</td>
                           
                         </tr>            <tr id="lib/api.js__553" class="hit">
                           <td class="line" data-tooltip>553</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    .list(null &#x3D;&#x3D; pattern ? {} : Jsonic(pattern))</td>
+                          <td class="source">    transport: this.private$.transport,</td>
                           
                         </tr>            <tr id="lib/api.js__554" class="hit">
                           <td class="line" data-tooltip>554</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    .map((x) &#x3D;&gt; x.match)</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__555" class="hit">
                           <td class="line" data-tooltip>555</td>
@@ -15756,452 +15707,452 @@
                         </tr>            <tr id="lib/api.js__556" class="hit">
                           <td class="line" data-tooltip>556</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  /*</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  return status</td>
                           
                         </tr>            <tr id="lib/api.js__557" class="hit">
                           <td class="line" data-tooltip>557</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return _.map(</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__558" class="hit">
                           <td class="line" data-tooltip>558</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    this.private$.actrouter.list(null &#x3D;&#x3D; pattern ? {} : Jsonic(pattern)),</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__559" class="hit">
                           <td class="line" data-tooltip>559</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;match&#x27;</td>
+                          <td class="source">// Reply to an action that is waiting for a result.</td>
                           
                         </tr>            <tr id="lib/api.js__560" class="hit">
                           <td class="line" data-tooltip>560</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  )</td>
+                          <td class="source">// Used by transports to decouple sending messages from receiving responses.</td>
                           
                         </tr>            <tr id="lib/api.js__561" class="hit">
                           <td class="line" data-tooltip>561</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  */</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.reply &#x3D; function (spec) {</td>
                           
                         </tr>            <tr id="lib/api.js__562" class="hit">
                           <td class="line" data-tooltip>562</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  var instance &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__563" class="hit">
                           <td class="line" data-tooltip>563</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>34</td>
+                          <td class="source">  var actctxt &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__564" class="hit">
                           <td class="line" data-tooltip>564</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Get the current status of the instance.</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__565" class="hit">
                           <td class="line" data-tooltip>565</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.status &#x3D; function (flags) {</td>
+                          <td class="hits" data-tooltip>34</td>
+                          <td class="source">  if (spec &amp;&amp; spec.meta) {</td>
                           
                         </tr>            <tr id="lib/api.js__566" class="hit">
                           <td class="line" data-tooltip>566</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  flags &#x3D; flags || {}</td>
+                          <td class="hits" data-tooltip>32</td>
+                          <td class="source">    actctxt &#x3D; instance.private$.history.get(spec.meta.id)</td>
                           
                         </tr>            <tr id="lib/api.js__567" class="hit">
                           <td class="line" data-tooltip>567</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>32</td>
+                          <td class="source">    if (actctxt) {</td>
                           
                         </tr>            <tr id="lib/api.js__568" class="hit">
                           <td class="line" data-tooltip>568</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  var hist &#x3D; this.private$.history.stats()</td>
+                          <td class="hits" data-tooltip>31</td>
+                          <td class="source">      actctxt.reply(spec.err, spec.out, spec.meta)</td>
                           
                         </tr>            <tr id="lib/api.js__569" class="hit">
                           <td class="line" data-tooltip>569</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  hist.log &#x3D; this.private$.history.list()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__570" class="hit">
                           <td class="line" data-tooltip>570</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__571" class="hit">
                           <td class="line" data-tooltip>571</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  var status &#x3D; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__572" class="hit">
                           <td class="line" data-tooltip>572</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    stats: this.stats(flags.stats),</td>
+                          <td class="hits" data-tooltip>34</td>
+                          <td class="source">  return !!actctxt</td>
                           
                         </tr>            <tr id="lib/api.js__573" class="hit">
                           <td class="line" data-tooltip>573</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    history: hist,</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__574" class="hit">
                           <td class="line" data-tooltip>574</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    transport: this.private$.transport,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__575" class="hit">
                           <td class="line" data-tooltip>575</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">// Listen for inbound messages.</td>
                           
                         </tr>            <tr id="lib/api.js__576" class="hit">
                           <td class="line" data-tooltip>576</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.listen &#x3D; function (callpoint) {</td>
                           
                         </tr>            <tr id="lib/api.js__577" class="hit">
                           <td class="line" data-tooltip>577</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  return status</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  return function api_listen(...argsarr) {</td>
                           
                         </tr>            <tr id="lib/api.js__578" class="hit">
                           <td class="line" data-tooltip>578</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    var private$ &#x3D; this.private$</td>
                           
                         </tr>            <tr id="lib/api.js__579" class="hit">
                           <td class="line" data-tooltip>579</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__580" class="hit">
                           <td class="line" data-tooltip>580</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Reply to an action that is waiting for a result.</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__581" class="hit">
                           <td class="line" data-tooltip>581</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// Used by transports to decouple sending messages from receiving responses.</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    var done &#x3D; argsarr[argsarr.length - 1]</td>
                           
                         </tr>            <tr id="lib/api.js__582" class="hit">
                           <td class="line" data-tooltip>582</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.reply &#x3D; function (spec) {</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    if (typeof done &#x3D;&#x3D;&#x3D; &#x27;function&#x27;) {</td>
                           
                         </tr>            <tr id="lib/api.js__583" class="hit">
                           <td class="line" data-tooltip>583</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var instance &#x3D; this</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      argsarr.pop()</td>
                           
                         </tr>            <tr id="lib/api.js__584" class="hit">
                           <td class="line" data-tooltip>584</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>34</td>
-                          <td class="source">  var actctxt &#x3D; null</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    } else {</td>
                           
                         </tr>            <tr id="lib/api.js__585" class="hit">
                           <td class="line" data-tooltip>585</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>46</td>
+                          <td class="source">      done &#x3D; () &#x3D;&gt; {}</td>
                           
                         </tr>            <tr id="lib/api.js__586" class="hit">
                           <td class="line" data-tooltip>586</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>34</td>
-                          <td class="source">  if (spec &amp;&amp; spec.meta) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__587" class="hit">
                           <td class="line" data-tooltip>587</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>32</td>
-                          <td class="source">    actctxt &#x3D; instance.private$.history.get(spec.meta.id)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__588" class="hit">
                           <td class="line" data-tooltip>588</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>32</td>
-                          <td class="source">    if (actctxt) {</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    self.log.info({</td>
                           
                         </tr>            <tr id="lib/api.js__589" class="hit">
                           <td class="line" data-tooltip>589</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>31</td>
-                          <td class="source">      actctxt.reply(spec.err, spec.out, spec.meta)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      kind: &#x27;listen&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__590" class="hit">
                           <td class="line" data-tooltip>590</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">      case: &#x27;INIT&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__591" class="hit">
                           <td class="line" data-tooltip>591</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">      data: argsarr,</td>
                           
                         </tr>            <tr id="lib/api.js__592" class="hit">
                           <td class="line" data-tooltip>592</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      callpoint: callpoint(true),</td>
                           
                         </tr>            <tr id="lib/api.js__593" class="hit">
                           <td class="line" data-tooltip>593</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>34</td>
-                          <td class="source">  return !!actctxt</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__594" class="hit">
                           <td class="line" data-tooltip>594</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__595" class="hit">
+                        </tr>            <tr id="lib/api.js__595" class="chunks">
                           <td class="line" data-tooltip>595</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>    var opts &#x3D; </div><div class="miss true" data-tooltip>self.options().transport</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
                           
                         </tr>            <tr id="lib/api.js__596" class="hit">
                           <td class="line" data-tooltip>596</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// Listen for inbound messages.</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    var config &#x3D; intern.resolve_config(intern.parse_config(argsarr), opts)</td>
                           
                         </tr>            <tr id="lib/api.js__597" class="hit">
                           <td class="line" data-tooltip>597</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.listen &#x3D; function (callpoint) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__598" class="hit">
                           <td class="line" data-tooltip>598</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  return function api_listen(...argsarr) {</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    self.act(</td>
                           
                         </tr>            <tr id="lib/api.js__599" class="hit">
                           <td class="line" data-tooltip>599</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    var private$ &#x3D; this.private$</td>
+                          <td class="source">      &#x27;role:transport,cmd:listen&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__600" class="hit">
                           <td class="line" data-tooltip>600</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    var self &#x3D; this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      { config: config, gate$: true },</td>
                           
                         </tr>            <tr id="lib/api.js__601" class="hit">
                           <td class="line" data-tooltip>601</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      function (err, result) {</td>
                           
-                        </tr>            <tr id="lib/api.js__602" class="hit">
+                        </tr>            <tr id="lib/api.js__602" class="chunks">
                           <td class="line" data-tooltip>602</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    var done &#x3D; argsarr[argsarr.length - 1]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>err</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__603" class="hit">
+                        </tr>            <tr id="lib/api.js__603" class="miss">
                           <td class="line" data-tooltip>603</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    if (typeof done &#x3D;&#x3D;&#x3D; &#x27;function&#x27;) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source" data-tooltip>          return self.die(private$.error(err, &#x27;transport_listen&#x27;, config))</td>
                           
                         </tr>            <tr id="lib/api.js__604" class="hit">
                           <td class="line" data-tooltip>604</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      argsarr.pop()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__605" class="hit">
                           <td class="line" data-tooltip>605</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    } else {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__606" class="hit">
                           <td class="line" data-tooltip>606</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>46</td>
-                          <td class="source">      done &#x3D; () &#x3D;&gt; {}</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">        done(null, result)</td>
                           
                         </tr>            <tr id="lib/api.js__607" class="hit">
                           <td class="line" data-tooltip>607</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">        done &#x3D; () &#x3D;&gt; {}</td>
                           
                         </tr>            <tr id="lib/api.js__608" class="hit">
                           <td class="line" data-tooltip>608</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__609" class="hit">
                           <td class="line" data-tooltip>609</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    self.log.info({</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    )</td>
                           
                         </tr>            <tr id="lib/api.js__610" class="hit">
                           <td class="line" data-tooltip>610</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      kind: &#x27;listen&#x27;,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__611" class="hit">
                           <td class="line" data-tooltip>611</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      case: &#x27;INIT&#x27;,</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    return self</td>
                           
                         </tr>            <tr id="lib/api.js__612" class="hit">
                           <td class="line" data-tooltip>612</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      data: argsarr,</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__613" class="hit">
                           <td class="line" data-tooltip>613</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      callpoint: callpoint(true),</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__614" class="hit">
                           <td class="line" data-tooltip>614</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__615" class="hit">
                           <td class="line" data-tooltip>615</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">// Send outbound messages.</td>
                           
-                        </tr>            <tr id="lib/api.js__616" class="chunks">
+                        </tr>            <tr id="lib/api.js__616" class="hit">
                           <td class="line" data-tooltip>616</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var opts &#x3D; </div><div class="miss true" data-tooltip>self.options().transport</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.client &#x3D; function (callpoint) {</td>
                           
                         </tr>            <tr id="lib/api.js__617" class="hit">
                           <td class="line" data-tooltip>617</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    var config &#x3D; intern.resolve_config(intern.parse_config(argsarr), opts)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  return function api_client() {</td>
                           
                         </tr>            <tr id="lib/api.js__618" class="hit">
                           <td class="line" data-tooltip>618</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    var private$ &#x3D; this.private$</td>
                           
                         </tr>            <tr id="lib/api.js__619" class="hit">
                           <td class="line" data-tooltip>619</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    self.act(</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var argsarr &#x3D; Array.prototype.slice.call(arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__620" class="hit">
                           <td class="line" data-tooltip>620</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      &#x27;role:transport,cmd:listen&#x27;,</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__621" class="hit">
                           <td class="line" data-tooltip>621</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      { config: config, gate$: true },</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__622" class="hit">
                           <td class="line" data-tooltip>622</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      function (err, result) {</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    self.log.info({</td>
                           
-                        </tr>            <tr id="lib/api.js__623" class="chunks">
+                        </tr>            <tr id="lib/api.js__623" class="hit">
                           <td class="line" data-tooltip>623</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>err</div><div>) {</div></td>
+                          <td class="source">      kind: &#x27;client&#x27;,</td>
                           
-                        </tr>            <tr id="lib/api.js__624" class="miss">
+                        </tr>            <tr id="lib/api.js__624" class="hit">
                           <td class="line" data-tooltip>624</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>          return self.die(private$.error(err, &#x27;transport_listen&#x27;, config))</td>
+                          <td class="source">      case: &#x27;INIT&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__625" class="hit">
                           <td class="line" data-tooltip>625</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="source">      data: argsarr,</td>
                           
                         </tr>            <tr id="lib/api.js__626" class="hit">
                           <td class="line" data-tooltip>626</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      callpoint: callpoint(true),</td>
                           
                         </tr>            <tr id="lib/api.js__627" class="hit">
                           <td class="line" data-tooltip>627</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">        done(null, result)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__628" class="hit">
                           <td class="line" data-tooltip>628</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">        done &#x3D; () &#x3D;&gt; {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__629" class="hit">
+                        </tr>            <tr id="lib/api.js__629" class="chunks">
                           <td class="line" data-tooltip>629</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source"><div>    var legacy &#x3D; </div><div class="miss true" data-tooltip>self.options().legacy</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
                           
-                        </tr>            <tr id="lib/api.js__630" class="hit">
+                        </tr>            <tr id="lib/api.js__630" class="chunks">
                           <td class="line" data-tooltip>630</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    )</td>
+                          <td class="source"><div>    var opts &#x3D; </div><div class="miss true" data-tooltip>self.options().transport</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
                           
                         </tr>            <tr id="lib/api.js__631" class="hit">
                           <td class="line" data-tooltip>631</td>
@@ -16212,200 +16163,200 @@
                         </tr>            <tr id="lib/api.js__632" class="hit">
                           <td class="line" data-tooltip>632</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    return self</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var raw_config &#x3D; intern.parse_config(argsarr)</td>
                           
                         </tr>            <tr id="lib/api.js__633" class="hit">
                           <td class="line" data-tooltip>633</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__634" class="hit">
                           <td class="line" data-tooltip>634</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    // pg: pin group</td>
                           
                         </tr>            <tr id="lib/api.js__635" class="hit">
                           <td class="line" data-tooltip>635</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    raw_config.pg &#x3D; Common.pincanon(raw_config.pin || raw_config.pins)</td>
                           
                         </tr>            <tr id="lib/api.js__636" class="hit">
                           <td class="line" data-tooltip>636</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Send outbound messages.</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__637" class="hit">
                           <td class="line" data-tooltip>637</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.client &#x3D; function (callpoint) {</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var config &#x3D; intern.resolve_config(raw_config, opts)</td>
                           
                         </tr>            <tr id="lib/api.js__638" class="hit">
                           <td class="line" data-tooltip>638</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return function api_client() {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__639" class="hit">
                           <td class="line" data-tooltip>639</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    var private$ &#x3D; this.private$</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    config.id &#x3D; config.id || Common.pattern(raw_config)</td>
                           
                         </tr>            <tr id="lib/api.js__640" class="hit">
                           <td class="line" data-tooltip>640</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var argsarr &#x3D; Array.prototype.slice.call(arguments)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__641" class="hit">
                           <td class="line" data-tooltip>641</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var self &#x3D; this</td>
+                          <td class="source">    var pins &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__642" class="hit">
                           <td class="line" data-tooltip>642</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      config.pins ||</td>
                           
-                        </tr>            <tr id="lib/api.js__643" class="hit">
+                        </tr>            <tr id="lib/api.js__643" class="chunks">
                           <td class="line" data-tooltip>643</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    self.log.info({</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>      (</div><div class="miss false" data-tooltip>Array.isArray(config.pin)</div><div> ? </div><div class="miss never" data-tooltip>config.pin</div><div> : [config.pin || &#x27;&#x27;])</div></td>
                           
                         </tr>            <tr id="lib/api.js__644" class="hit">
                           <td class="line" data-tooltip>644</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      kind: &#x27;client&#x27;,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__645" class="hit">
                           <td class="line" data-tooltip>645</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      case: &#x27;INIT&#x27;,</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    pins &#x3D; pins.map((pin) &#x3D;&gt; {</td>
                           
                         </tr>            <tr id="lib/api.js__646" class="hit">
                           <td class="line" data-tooltip>646</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      data: argsarr,</td>
+                          <td class="source">      return &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pin ? Jsonic(pin) : pin</td>
                           
                         </tr>            <tr id="lib/api.js__647" class="hit">
                           <td class="line" data-tooltip>647</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      callpoint: callpoint(true),</td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__648" class="hit">
                           <td class="line" data-tooltip>648</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__649" class="hit">
                           <td class="line" data-tooltip>649</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    //var sd &#x3D; Plugins.make_delegate(self, {</td>
                           
-                        </tr>            <tr id="lib/api.js__650" class="chunks">
+                        </tr>            <tr id="lib/api.js__650" class="hit">
                           <td class="line" data-tooltip>650</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var legacy &#x3D; </div><div class="miss true" data-tooltip>self.options().legacy</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
+                          <td class="source">    // TODO: review - this feels like a hack</td>
                           
-                        </tr>            <tr id="lib/api.js__651" class="chunks">
+                        </tr>            <tr id="lib/api.js__651" class="hit">
                           <td class="line" data-tooltip>651</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var opts &#x3D; </div><div class="miss true" data-tooltip>self.options().transport</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
+                          <td class="source">    // perhaps we should instantiate a virtual plugin to represent the client?</td>
                           
                         </tr>            <tr id="lib/api.js__652" class="hit">
                           <td class="line" data-tooltip>652</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    // ... but is this necessary at all?</td>
                           
                         </tr>            <tr id="lib/api.js__653" class="hit">
                           <td class="line" data-tooltip>653</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var raw_config &#x3D; intern.parse_config(argsarr)</td>
+                          <td class="source">    var task_res &#x3D; self.order.plugin.task.delegate.exec({</td>
                           
                         </tr>            <tr id="lib/api.js__654" class="hit">
                           <td class="line" data-tooltip>654</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      ctx: {</td>
                           
                         </tr>            <tr id="lib/api.js__655" class="hit">
                           <td class="line" data-tooltip>655</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // pg: pin group</td>
+                          <td class="source">        seneca: self,</td>
                           
                         </tr>            <tr id="lib/api.js__656" class="hit">
                           <td class="line" data-tooltip>656</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    raw_config.pg &#x3D; Common.pincanon(raw_config.pin || raw_config.pins)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      },</td>
                           
                         </tr>            <tr id="lib/api.js__657" class="hit">
                           <td class="line" data-tooltip>657</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      data: {</td>
                           
                         </tr>            <tr id="lib/api.js__658" class="hit">
                           <td class="line" data-tooltip>658</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var config &#x3D; intern.resolve_config(raw_config, opts)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        plugin: {</td>
                           
                         </tr>            <tr id="lib/api.js__659" class="hit">
                           <td class="line" data-tooltip>659</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">          // TODO: make this unique with a counter</td>
                           
                         </tr>            <tr id="lib/api.js__660" class="hit">
                           <td class="line" data-tooltip>660</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    config.id &#x3D; config.id || Common.pattern(raw_config)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">          name: &#x27;seneca_internal_client&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__661" class="hit">
                           <td class="line" data-tooltip>661</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">          tag: void 0,</td>
                           
                         </tr>            <tr id="lib/api.js__662" class="hit">
                           <td class="line" data-tooltip>662</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var pins &#x3D;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        },</td>
                           
                         </tr>            <tr id="lib/api.js__663" class="hit">
                           <td class="line" data-tooltip>663</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      config.pins ||</td>
+                          <td class="source">      },</td>
                           
-                        </tr>            <tr id="lib/api.js__664" class="chunks">
+                        </tr>            <tr id="lib/api.js__664" class="hit">
                           <td class="line" data-tooltip>664</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      (</div><div class="miss false" data-tooltip>Array.isArray(config.pin)</div><div> ? </div><div class="miss never" data-tooltip>config.pin</div><div> : [config.pin || &#x27;&#x27;])</div></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__665" class="hit">
                           <td class="line" data-tooltip>665</td>
@@ -16417,19 +16368,19 @@
                           <td class="line" data-tooltip>666</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>43</td>
-                          <td class="source">    pins &#x3D; pins.map((pin) &#x3D;&gt; {</td>
+                          <td class="source">    var sd &#x3D; task_res.out.delegate</td>
                           
                         </tr>            <tr id="lib/api.js__667" class="hit">
                           <td class="line" data-tooltip>667</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      return &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pin ? Jsonic(pin) : pin</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__668" class="hit">
                           <td class="line" data-tooltip>668</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var sendclient</td>
                           
                         </tr>            <tr id="lib/api.js__669" class="hit">
                           <td class="line" data-tooltip>669</td>
@@ -16440,152 +16391,152 @@
                         </tr>            <tr id="lib/api.js__670" class="hit">
                           <td class="line" data-tooltip>670</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    //var sd &#x3D; Plugins.make_delegate(self, {</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var transport_client &#x3D; function transport_client(msg, reply, meta) {</td>
                           
-                        </tr>            <tr id="lib/api.js__671" class="hit">
+                        </tr>            <tr id="lib/api.js__671" class="chunks">
                           <td class="line" data-tooltip>671</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // TODO: review - this feels like a hack</td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>legacy.meta</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__672" class="hit">
+                        </tr>            <tr id="lib/api.js__672" class="miss">
                           <td class="line" data-tooltip>672</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // perhaps we should instantiate a virtual plugin to represent the client?</td>
+                          <td class="source" data-tooltip>        meta &#x3D; meta || msg.meta$</td>
                           
                         </tr>            <tr id="lib/api.js__673" class="hit">
                           <td class="line" data-tooltip>673</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // ... but is this necessary at all?</td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__674" class="hit">
                           <td class="line" data-tooltip>674</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var task_res &#x3D; self.order.plugin.task.delegate.exec({</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__675" class="hit">
                           <td class="line" data-tooltip>675</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      ctx: {</td>
+                          <td class="source">      // Undefined plugin init actions pass through here when</td>
                           
                         </tr>            <tr id="lib/api.js__676" class="hit">
                           <td class="line" data-tooltip>676</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        seneca: self,</td>
+                          <td class="source">      // there&#x27;s a catchall client, as they have local$:true</td>
                           
                         </tr>            <tr id="lib/api.js__677" class="hit">
                           <td class="line" data-tooltip>677</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      },</td>
+                          <td class="hits" data-tooltip>69</td>
+                          <td class="source">      if (meta.local) {</td>
                           
                         </tr>            <tr id="lib/api.js__678" class="hit">
                           <td class="line" data-tooltip>678</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      data: {</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">        this.prior(msg, reply)</td>
                           
-                        </tr>            <tr id="lib/api.js__679" class="hit">
+                        </tr>            <tr id="lib/api.js__679" class="chunks">
                           <td class="line" data-tooltip>679</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        plugin: {</td>
+                          <td class="source"><div>      } else if (</div><div class="miss true" data-tooltip>sendclient</div><div> &amp;&amp; </div><div class="miss true" data-tooltip>sendclient.send</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__680" class="hit">
+                        </tr>            <tr id="lib/api.js__680" class="chunks">
                           <td class="line" data-tooltip>680</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          // TODO: make this unique with a counter</td>
+                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>legacy.meta</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__681" class="hit">
+                        </tr>            <tr id="lib/api.js__681" class="miss">
                           <td class="line" data-tooltip>681</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          name: &#x27;seneca_internal_client&#x27;,</td>
+                          <td class="source" data-tooltip>          msg.meta$ &#x3D; meta</td>
                           
                         </tr>            <tr id="lib/api.js__682" class="hit">
                           <td class="line" data-tooltip>682</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          tag: void 0,</td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__683" class="hit">
                           <td class="line" data-tooltip>683</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        },</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__684" class="hit">
                           <td class="line" data-tooltip>684</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      },</td>
+                          <td class="hits" data-tooltip>58</td>
+                          <td class="source">        sendclient.send.call(this, msg, reply, meta)</td>
                           
                         </tr>            <tr id="lib/api.js__685" class="hit">
                           <td class="line" data-tooltip>685</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source">      } else {</td>
                           
-                        </tr>            <tr id="lib/api.js__686" class="hit">
+                        </tr>            <tr id="lib/api.js__686" class="miss">
                           <td class="line" data-tooltip>686</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source" data-tooltip>        this.log.error(&#x27;no-transport-client&#x27;, { config: config, msg: msg })</td>
                           
                         </tr>            <tr id="lib/api.js__687" class="hit">
                           <td class="line" data-tooltip>687</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var sd &#x3D; task_res.out.delegate</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__688" class="hit">
                           <td class="line" data-tooltip>688</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__689" class="hit">
                           <td class="line" data-tooltip>689</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var sendclient</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__690" class="hit">
                           <td class="line" data-tooltip>690</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    transport_client.id &#x3D; config.id</td>
                           
                         </tr>            <tr id="lib/api.js__691" class="hit">
                           <td class="line" data-tooltip>691</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var transport_client &#x3D; function transport_client(msg, reply, meta) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__692" class="chunks">
+                        </tr>            <tr id="lib/api.js__692" class="hit">
                           <td class="line" data-tooltip>692</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>legacy.meta</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    if (config.makehandle) {</td>
                           
-                        </tr>            <tr id="lib/api.js__693" class="miss">
+                        </tr>            <tr id="lib/api.js__693" class="hit">
                           <td class="line" data-tooltip>693</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        meta &#x3D; meta || msg.meta$</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      transport_client.handle &#x3D; config.makehandle(config)</td>
                           
                         </tr>            <tr id="lib/api.js__694" class="hit">
                           <td class="line" data-tooltip>694</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__695" class="hit">
                           <td class="line" data-tooltip>695</td>
@@ -16596,200 +16547,200 @@
                         </tr>            <tr id="lib/api.js__696" class="hit">
                           <td class="line" data-tooltip>696</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      // Undefined plugin init actions pass through here when</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    pins.forEach((pin) &#x3D;&gt; {</td>
                           
                         </tr>            <tr id="lib/api.js__697" class="hit">
                           <td class="line" data-tooltip>697</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      // there&#x27;s a catchall client, as they have local$:true</td>
+                          <td class="source">      pin &#x3D; Object.assign({}, pin)</td>
                           
                         </tr>            <tr id="lib/api.js__698" class="hit">
                           <td class="line" data-tooltip>698</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>69</td>
-                          <td class="source">      if (meta.local) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__699" class="hit">
                           <td class="line" data-tooltip>699</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">        this.prior(msg, reply)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      // Override local actions, including those more specific than</td>
                           
-                        </tr>            <tr id="lib/api.js__700" class="chunks">
+                        </tr>            <tr id="lib/api.js__700" class="hit">
                           <td class="line" data-tooltip>700</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      } else if (</div><div class="miss true" data-tooltip>sendclient</div><div> &amp;&amp; </div><div class="miss true" data-tooltip>sendclient.send</div><div>) {</div></td>
+                          <td class="source">      // the client pattern</td>
                           
                         </tr>            <tr id="lib/api.js__701" class="chunks">
                           <td class="line" data-tooltip>701</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>legacy.meta</div><div>) {</div></td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>config.override</div><div>) {</div></td>
                           
                         </tr>            <tr id="lib/api.js__702" class="miss">
                           <td class="line" data-tooltip>702</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>          msg.meta$ &#x3D; meta</td>
+                          <td class="source" data-tooltip>        sd.wrap(</td>
                           
                         </tr>            <tr id="lib/api.js__703" class="hit">
                           <td class="line" data-tooltip>703</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="source">          sd.util.clean(pin),</td>
                           
                         </tr>            <tr id="lib/api.js__704" class="hit">
                           <td class="line" data-tooltip>704</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">          { client_pattern: sd.util.pattern(pin) },</td>
                           
                         </tr>            <tr id="lib/api.js__705" class="hit">
                           <td class="line" data-tooltip>705</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>58</td>
-                          <td class="source">        sendclient.send.call(this, msg, reply, meta)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">          transport_client</td>
                           
                         </tr>            <tr id="lib/api.js__706" class="hit">
                           <td class="line" data-tooltip>706</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      } else {</td>
+                          <td class="source">        )</td>
                           
-                        </tr>            <tr id="lib/api.js__707" class="miss">
+                        </tr>            <tr id="lib/api.js__707" class="hit">
                           <td class="line" data-tooltip>707</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        this.log.error(&#x27;no-transport-client&#x27;, { config: config, msg: msg })</td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__708" class="hit">
                           <td class="line" data-tooltip>708</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__709" class="hit">
                           <td class="line" data-tooltip>709</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>44</td>
+                          <td class="source">      pin.client$ &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__710" class="hit">
                           <td class="line" data-tooltip>710</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>44</td>
+                          <td class="source">      pin.strict$ &#x3D; { add: true }</td>
                           
                         </tr>            <tr id="lib/api.js__711" class="hit">
                           <td class="line" data-tooltip>711</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    transport_client.id &#x3D; config.id</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__712" class="hit">
                           <td class="line" data-tooltip>712</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>44</td>
+                          <td class="source">      sd.add(pin, transport_client)</td>
                           
                         </tr>            <tr id="lib/api.js__713" class="hit">
                           <td class="line" data-tooltip>713</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    if (config.makehandle) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__714" class="hit">
                           <td class="line" data-tooltip>714</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      transport_client.handle &#x3D; config.makehandle(config)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__715" class="hit">
                           <td class="line" data-tooltip>715</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">    // Create client.</td>
                           
                         </tr>            <tr id="lib/api.js__716" class="hit">
                           <td class="line" data-tooltip>716</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    sd.act(</td>
                           
                         </tr>            <tr id="lib/api.js__717" class="hit">
                           <td class="line" data-tooltip>717</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    pins.forEach((pin) &#x3D;&gt; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      &#x27;role:transport,cmd:client&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__718" class="hit">
                           <td class="line" data-tooltip>718</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      pin &#x3D; Object.assign({}, pin)</td>
+                          <td class="source">      { config: config, gate$: true },</td>
                           
                         </tr>            <tr id="lib/api.js__719" class="hit">
                           <td class="line" data-tooltip>719</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      function (err, liveclient) {</td>
                           
-                        </tr>            <tr id="lib/api.js__720" class="hit">
+                        </tr>            <tr id="lib/api.js__720" class="chunks">
                           <td class="line" data-tooltip>720</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      // Override local actions, including those more specific than</td>
+                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>err</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__721" class="hit">
+                        </tr>            <tr id="lib/api.js__721" class="miss">
                           <td class="line" data-tooltip>721</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      // the client pattern</td>
+                          <td class="source" data-tooltip>          return sd.die(private$.error(err, &#x27;transport_client&#x27;, config))</td>
                           
-                        </tr>            <tr id="lib/api.js__722" class="chunks">
+                        </tr>            <tr id="lib/api.js__722" class="hit">
                           <td class="line" data-tooltip>722</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>config.override</div><div>) {</div></td>
+                          <td class="source">        }</td>
                           
-                        </tr>            <tr id="lib/api.js__723" class="miss">
+                        </tr>            <tr id="lib/api.js__723" class="hit">
                           <td class="line" data-tooltip>723</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        sd.wrap(</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__724" class="hit">
+                        </tr>            <tr id="lib/api.js__724" class="chunks">
                           <td class="line" data-tooltip>724</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          sd.util.clean(pin),</td>
+                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>null &#x3D;&#x3D; liveclient</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__725" class="hit">
+                        </tr>            <tr id="lib/api.js__725" class="miss">
                           <td class="line" data-tooltip>725</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          { client_pattern: sd.util.pattern(pin) },</td>
+                          <td class="source" data-tooltip>          return sd.die(</td>
                           
                         </tr>            <tr id="lib/api.js__726" class="hit">
                           <td class="line" data-tooltip>726</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          transport_client</td>
+                          <td class="source">            private$.error(&#x27;transport_client_null&#x27;, Common.clean(config))</td>
                           
                         </tr>            <tr id="lib/api.js__727" class="hit">
                           <td class="line" data-tooltip>727</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        )</td>
+                          <td class="source">          )</td>
                           
                         </tr>            <tr id="lib/api.js__728" class="hit">
                           <td class="line" data-tooltip>728</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__729" class="hit">
                           <td class="line" data-tooltip>729</td>
@@ -16800,200 +16751,200 @@
                         </tr>            <tr id="lib/api.js__730" class="hit">
                           <td class="line" data-tooltip>730</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>44</td>
-                          <td class="source">      pin.client$ &#x3D; true</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">        sendclient &#x3D; liveclient</td>
                           
                         </tr>            <tr id="lib/api.js__731" class="hit">
                           <td class="line" data-tooltip>731</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>44</td>
-                          <td class="source">      pin.strict$ &#x3D; { add: true }</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__732" class="hit">
                           <td class="line" data-tooltip>732</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    )</td>
                           
                         </tr>            <tr id="lib/api.js__733" class="hit">
                           <td class="line" data-tooltip>733</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>44</td>
-                          <td class="source">      sd.add(pin, transport_client)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__734" class="hit">
                           <td class="line" data-tooltip>734</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    return self</td>
                           
                         </tr>            <tr id="lib/api.js__735" class="hit">
                           <td class="line" data-tooltip>735</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__736" class="hit">
                           <td class="line" data-tooltip>736</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // Create client.</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__737" class="hit">
                           <td class="line" data-tooltip>737</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    sd.act(</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__738" class="hit">
                           <td class="line" data-tooltip>738</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      &#x27;role:transport,cmd:client&#x27;,</td>
+                          <td class="source">// Inspired by https://github.com/hapijs/hapi/blob/master/lib/plugin.js decorate</td>
                           
                         </tr>            <tr id="lib/api.js__739" class="hit">
                           <td class="line" data-tooltip>739</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      { config: config, gate$: true },</td>
+                          <td class="source">// TODO: convert to plugin configuration, with standard errors</td>
                           
                         </tr>            <tr id="lib/api.js__740" class="hit">
                           <td class="line" data-tooltip>740</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      function (err, liveclient) {</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.decorate &#x3D; function () {</td>
                           
-                        </tr>            <tr id="lib/api.js__741" class="chunks">
+                        </tr>            <tr id="lib/api.js__741" class="hit">
                           <td class="line" data-tooltip>741</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>err</div><div>) {</div></td>
+                          <td class="source">  var args &#x3D; Norma(&#x27;property:s value:.&#x27;, arguments)</td>
                           
-                        </tr>            <tr id="lib/api.js__742" class="miss">
+                        </tr>            <tr id="lib/api.js__742" class="hit">
                           <td class="line" data-tooltip>742</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>          return sd.die(private$.error(err, &#x27;transport_client&#x27;, config))</td>
-                          
-                        </tr>            <tr id="lib/api.js__743" class="hit">
-                          <td class="line" data-tooltip>743</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
-                          
-                        </tr>            <tr id="lib/api.js__744" class="hit">
-                          <td class="line" data-tooltip>744</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__745" class="chunks">
+                        </tr>            <tr id="lib/api.js__743" class="hit">
+                          <td class="line" data-tooltip>743</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>32</td>
+                          <td class="source">  var property &#x3D; args.property</td>
+                          
+                        </tr>            <tr id="lib/api.js__744" class="hit">
+                          <td class="line" data-tooltip>744</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>32</td>
+                          <td class="source">  Assert(property[0] !&#x3D;&#x3D; &#x27;_&#x27;, &#x27;property cannot start with _&#x27;)</td>
+                          
+                        </tr>            <tr id="lib/api.js__745" class="hit">
                           <td class="line" data-tooltip>745</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>null &#x3D;&#x3D; liveclient</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>31</td>
+                          <td class="source">  Assert(</td>
                           
-                        </tr>            <tr id="lib/api.js__746" class="miss">
+                        </tr>            <tr id="lib/api.js__746" class="hit">
                           <td class="line" data-tooltip>746</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>          return sd.die(</td>
+                          <td class="source">    this.private$.decorations[property] &#x3D;&#x3D;&#x3D; undefined,</td>
                           
                         </tr>            <tr id="lib/api.js__747" class="hit">
                           <td class="line" data-tooltip>747</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">            private$.error(&#x27;transport_client_null&#x27;, Common.clean(config))</td>
+                          <td class="source">    &#x27;seneca is already decorated with the property: &#x27; + property</td>
                           
                         </tr>            <tr id="lib/api.js__748" class="hit">
                           <td class="line" data-tooltip>748</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          )</td>
+                          <td class="source">  )</td>
                           
                         </tr>            <tr id="lib/api.js__749" class="hit">
                           <td class="line" data-tooltip>749</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="hits" data-tooltip>30</td>
+                          <td class="source">  Assert(</td>
                           
                         </tr>            <tr id="lib/api.js__750" class="hit">
                           <td class="line" data-tooltip>750</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    this.root[property] &#x3D;&#x3D;&#x3D; undefined,</td>
                           
                         </tr>            <tr id="lib/api.js__751" class="hit">
                           <td class="line" data-tooltip>751</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">        sendclient &#x3D; liveclient</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    &#x27;cannot override a core seneca property: &#x27; + property</td>
                           
                         </tr>            <tr id="lib/api.js__752" class="hit">
                           <td class="line" data-tooltip>752</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">  )</td>
                           
                         </tr>            <tr id="lib/api.js__753" class="hit">
                           <td class="line" data-tooltip>753</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    )</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__754" class="hit">
                           <td class="line" data-tooltip>754</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>29</td>
+                          <td class="source">  this.root[property] &#x3D; this.private$.decorations[property] &#x3D; args.value</td>
                           
                         </tr>            <tr id="lib/api.js__755" class="hit">
                           <td class="line" data-tooltip>755</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    return self</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__756" class="hit">
                           <td class="line" data-tooltip>756</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__757" class="hit">
                           <td class="line" data-tooltip>757</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">intern.parse_config &#x3D; function (args) {</td>
                           
                         </tr>            <tr id="lib/api.js__758" class="hit">
                           <td class="line" data-tooltip>758</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  var out &#x3D; {}</td>
                           
                         </tr>            <tr id="lib/api.js__759" class="hit">
                           <td class="line" data-tooltip>759</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Inspired by https://github.com/hapijs/hapi/blob/master/lib/plugin.js decorate</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__760" class="hit">
                           <td class="line" data-tooltip>760</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// TODO: convert to plugin configuration, with standard errors</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  var config &#x3D; args.filter((x) &#x3D;&gt; null !&#x3D; x)</td>
                           
                         </tr>            <tr id="lib/api.js__761" class="hit">
                           <td class="line" data-tooltip>761</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.decorate &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__762" class="hit">
                           <td class="line" data-tooltip>762</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var args &#x3D; Norma(&#x27;property:s value:.&#x27;, arguments)</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  var arglen &#x3D; config.length</td>
                           
                         </tr>            <tr id="lib/api.js__763" class="hit">
                           <td class="line" data-tooltip>763</td>
@@ -17004,98 +16955,98 @@
                         </tr>            <tr id="lib/api.js__764" class="hit">
                           <td class="line" data-tooltip>764</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>32</td>
-                          <td class="source">  var property &#x3D; args.property</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // TODO: use Joi for better error msgs</td>
                           
                         </tr>            <tr id="lib/api.js__765" class="hit">
                           <td class="line" data-tooltip>765</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>32</td>
-                          <td class="source">  Assert(property[0] !&#x3D;&#x3D; &#x27;_&#x27;, &#x27;property cannot start with _&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__766" class="hit">
                           <td class="line" data-tooltip>766</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>31</td>
-                          <td class="source">  Assert(</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  if (arglen &#x3D;&#x3D;&#x3D; 1) {</td>
                           
-                        </tr>            <tr id="lib/api.js__767" class="hit">
+                        </tr>            <tr id="lib/api.js__767" class="chunks">
                           <td class="line" data-tooltip>767</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    this.private$.decorations[property] &#x3D;&#x3D;&#x3D; undefined,</td>
+                          <td class="source"><div>    if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof config[0] &amp;&amp; </div><div class="miss true" data-tooltip>null !&#x3D; config[0]</div><div>) {</div></td>
                           
                         </tr>            <tr id="lib/api.js__768" class="hit">
                           <td class="line" data-tooltip>768</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;seneca is already decorated with the property: &#x27; + property</td>
+                          <td class="hits" data-tooltip>63</td>
+                          <td class="source">      out &#x3D; Object.assign({}, config[0])</td>
                           
                         </tr>            <tr id="lib/api.js__769" class="hit">
                           <td class="line" data-tooltip>769</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  )</td>
+                          <td class="source">    } else {</td>
                           
                         </tr>            <tr id="lib/api.js__770" class="hit">
                           <td class="line" data-tooltip>770</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>30</td>
-                          <td class="source">  Assert(</td>
+                          <td class="hits" data-tooltip>17</td>
+                          <td class="source">      out.port &#x3D; parseInt(config[0], 10)</td>
                           
                         </tr>            <tr id="lib/api.js__771" class="hit">
                           <td class="line" data-tooltip>771</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    this.root[property] &#x3D;&#x3D;&#x3D; undefined,</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__772" class="hit">
                           <td class="line" data-tooltip>772</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;cannot override a core seneca property: &#x27; + property</td>
+                          <td class="hits" data-tooltip>10</td>
+                          <td class="source">  } else if (arglen &#x3D;&#x3D;&#x3D; 2) {</td>
                           
                         </tr>            <tr id="lib/api.js__773" class="hit">
                           <td class="line" data-tooltip>773</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  )</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    out.port &#x3D; parseInt(config[0], 10)</td>
                           
                         </tr>            <tr id="lib/api.js__774" class="hit">
                           <td class="line" data-tooltip>774</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    out.host &#x3D; config[1]</td>
                           
                         </tr>            <tr id="lib/api.js__775" class="hit">
                           <td class="line" data-tooltip>775</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>29</td>
-                          <td class="source">  this.root[property] &#x3D; this.private$.decorations[property] &#x3D; args.value</td>
+                          <td class="hits" data-tooltip>9</td>
+                          <td class="source">  } else if (arglen &#x3D;&#x3D;&#x3D; 3) {</td>
                           
                         </tr>            <tr id="lib/api.js__776" class="hit">
                           <td class="line" data-tooltip>776</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    out.port &#x3D; parseInt(config[0], 10)</td>
                           
                         </tr>            <tr id="lib/api.js__777" class="hit">
                           <td class="line" data-tooltip>777</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    out.host &#x3D; config[1]</td>
                           
                         </tr>            <tr id="lib/api.js__778" class="hit">
                           <td class="line" data-tooltip>778</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">intern.parse_config &#x3D; function (args) {</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    out.path &#x3D; config[2]</td>
                           
                         </tr>            <tr id="lib/api.js__779" class="hit">
                           <td class="line" data-tooltip>779</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var out &#x3D; {}</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__780" class="hit">
                           <td class="line" data-tooltip>780</td>
@@ -17107,31 +17058,31 @@
                           <td class="line" data-tooltip>781</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>90</td>
-                          <td class="source">  var config &#x3D; args.filter((x) &#x3D;&gt; null !&#x3D; x)</td>
+                          <td class="source">  return out</td>
                           
                         </tr>            <tr id="lib/api.js__782" class="hit">
                           <td class="line" data-tooltip>782</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__783" class="hit">
                           <td class="line" data-tooltip>783</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  var arglen &#x3D; config.length</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__784" class="hit">
                           <td class="line" data-tooltip>784</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">intern.resolve_config &#x3D; function (config, options) {</td>
                           
                         </tr>            <tr id="lib/api.js__785" class="hit">
                           <td class="line" data-tooltip>785</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // TODO: use Joi for better error msgs</td>
+                          <td class="source">  var out &#x3D; Object.assign({}, config)</td>
                           
                         </tr>            <tr id="lib/api.js__786" class="hit">
                           <td class="line" data-tooltip>786</td>
@@ -17143,103 +17094,103 @@
                           <td class="line" data-tooltip>787</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>90</td>
-                          <td class="source">  if (arglen &#x3D;&#x3D;&#x3D; 1) {</td>
+                          <td class="source">  Object.keys(options).forEach((key) &#x3D;&gt; {</td>
                           
-                        </tr>            <tr id="lib/api.js__788" class="chunks">
+                        </tr>            <tr id="lib/api.js__788" class="hit">
                           <td class="line" data-tooltip>788</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof config[0] &amp;&amp; </div><div class="miss true" data-tooltip>null !&#x3D; config[0]</div><div>) {</div></td>
+                          <td class="source">    var value &#x3D; options[key]</td>
                           
                         </tr>            <tr id="lib/api.js__789" class="hit">
                           <td class="line" data-tooltip>789</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>63</td>
-                          <td class="source">      out &#x3D; Object.assign({}, config[0])</td>
+                          <td class="hits" data-tooltip>241</td>
+                          <td class="source">    if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof value) {</td>
                           
                         </tr>            <tr id="lib/api.js__790" class="hit">
                           <td class="line" data-tooltip>790</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    } else {</td>
+                          <td class="hits" data-tooltip>13</td>
+                          <td class="source">      return</td>
                           
                         </tr>            <tr id="lib/api.js__791" class="hit">
                           <td class="line" data-tooltip>791</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
-                          <td class="source">      out.port &#x3D; parseInt(config[0], 10)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__792" class="hit">
                           <td class="line" data-tooltip>792</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>228</td>
+                          <td class="source">    out[key] &#x3D; out[key] &#x3D;&#x3D;&#x3D; void 0 ? value : out[key]</td>
                           
                         </tr>            <tr id="lib/api.js__793" class="hit">
                           <td class="line" data-tooltip>793</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10</td>
-                          <td class="source">  } else if (arglen &#x3D;&#x3D;&#x3D; 2) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  })</td>
                           
                         </tr>            <tr id="lib/api.js__794" class="hit">
                           <td class="line" data-tooltip>794</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    out.port &#x3D; parseInt(config[0], 10)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__795" class="hit">
                           <td class="line" data-tooltip>795</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    out.host &#x3D; config[1]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // Default transport is web</td>
                           
                         </tr>            <tr id="lib/api.js__796" class="hit">
                           <td class="line" data-tooltip>796</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
-                          <td class="source">  } else if (arglen &#x3D;&#x3D;&#x3D; 3) {</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  out.type &#x3D; out.type || &#x27;web&#x27;</td>
                           
                         </tr>            <tr id="lib/api.js__797" class="hit">
                           <td class="line" data-tooltip>797</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    out.port &#x3D; parseInt(config[0], 10)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__798" class="hit">
                           <td class="line" data-tooltip>798</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    out.host &#x3D; config[1]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // DEPRECATED: Remove in 4.0</td>
                           
                         </tr>            <tr id="lib/api.js__799" class="hit">
                           <td class="line" data-tooltip>799</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    out.path &#x3D; config[2]</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  if (out.type &#x3D;&#x3D;&#x3D; &#x27;direct&#x27; || out.type &#x3D;&#x3D;&#x3D; &#x27;http&#x27;) {</td>
                           
                         </tr>            <tr id="lib/api.js__800" class="hit">
                           <td class="line" data-tooltip>800</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    out.type &#x3D; &#x27;web&#x27;</td>
                           
                         </tr>            <tr id="lib/api.js__801" class="hit">
                           <td class="line" data-tooltip>801</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__802" class="hit">
                           <td class="line" data-tooltip>802</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  return out</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__803" class="hit">
                           <td class="line" data-tooltip>803</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  var base &#x3D; options[out.type] || {}</td>
                           
                         </tr>            <tr id="lib/api.js__804" class="hit">
                           <td class="line" data-tooltip>804</td>
@@ -17250,62 +17201,62 @@
                         </tr>            <tr id="lib/api.js__805" class="hit">
                           <td class="line" data-tooltip>805</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">intern.resolve_config &#x3D; function (config, options) {</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  out &#x3D; Object.assign({}, base, out)</td>
                           
                         </tr>            <tr id="lib/api.js__806" class="hit">
                           <td class="line" data-tooltip>806</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var out &#x3D; Object.assign({}, config)</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__807" class="hit">
                           <td class="line" data-tooltip>807</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  if (out.type &#x3D;&#x3D;&#x3D; &#x27;web&#x27; || out.type &#x3D;&#x3D;&#x3D; &#x27;tcp&#x27;) {</td>
                           
-                        </tr>            <tr id="lib/api.js__808" class="hit">
+                        </tr>            <tr id="lib/api.js__808" class="chunks">
                           <td class="line" data-tooltip>808</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  Object.keys(options).forEach((key) &#x3D;&gt; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>    out.port &#x3D; </div><div class="miss false" data-tooltip>out.port &#x3D;&#x3D; null</div><div> ? </div><div class="miss never" data-tooltip>base.port</div><div> : out.port</div></td>
                           
                         </tr>            <tr id="lib/api.js__809" class="hit">
                           <td class="line" data-tooltip>809</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    var value &#x3D; options[key]</td>
+                          <td class="hits" data-tooltip>53</td>
+                          <td class="source">    out.host &#x3D; out.host &#x3D;&#x3D; null ? base.host : out.host</td>
                           
                         </tr>            <tr id="lib/api.js__810" class="hit">
                           <td class="line" data-tooltip>810</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>241</td>
-                          <td class="source">    if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof value) {</td>
+                          <td class="hits" data-tooltip>53</td>
+                          <td class="source">    out.path &#x3D; out.path &#x3D;&#x3D; null ? base.path : out.path</td>
                           
                         </tr>            <tr id="lib/api.js__811" class="hit">
                           <td class="line" data-tooltip>811</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>13</td>
-                          <td class="source">      return</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__812" class="hit">
                           <td class="line" data-tooltip>812</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__813" class="hit">
                           <td class="line" data-tooltip>813</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>228</td>
-                          <td class="source">    out[key] &#x3D; out[key] &#x3D;&#x3D;&#x3D; void 0 ? value : out[key]</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  return out</td>
                           
                         </tr>            <tr id="lib/api.js__814" class="hit">
                           <td class="line" data-tooltip>814</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  })</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__815" class="hit">
                           <td class="line" data-tooltip>815</td>
@@ -17316,68 +17267,68 @@
                         </tr>            <tr id="lib/api.js__816" class="hit">
                           <td class="line" data-tooltip>816</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // Default transport is web</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">intern.close &#x3D; function (callpoint, done) {</td>
                           
                         </tr>            <tr id="lib/api.js__817" class="hit">
                           <td class="line" data-tooltip>817</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  out.type &#x3D; out.type || &#x27;web&#x27;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var seneca &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__818" class="hit">
                           <td class="line" data-tooltip>818</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">  var options &#x3D; seneca.options()</td>
                           
                         </tr>            <tr id="lib/api.js__819" class="hit">
                           <td class="line" data-tooltip>819</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // DEPRECATED: Remove in 4.0</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__820" class="hit">
                           <td class="line" data-tooltip>820</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  if (out.type &#x3D;&#x3D;&#x3D; &#x27;direct&#x27; || out.type &#x3D;&#x3D;&#x3D; &#x27;http&#x27;) {</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">  var done_called &#x3D; false</td>
                           
                         </tr>            <tr id="lib/api.js__821" class="hit">
                           <td class="line" data-tooltip>821</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    out.type &#x3D; &#x27;web&#x27;</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">  var safe_done &#x3D; function safe_done(err) {</td>
                           
                         </tr>            <tr id="lib/api.js__822" class="hit">
                           <td class="line" data-tooltip>822</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    if (!done_called &amp;&amp; &#x27;function&#x27; &#x3D;&#x3D;&#x3D; typeof done) {</td>
                           
                         </tr>            <tr id="lib/api.js__823" class="hit">
                           <td class="line" data-tooltip>823</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      done_called &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__824" class="hit">
                           <td class="line" data-tooltip>824</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  var base &#x3D; options[out.type] || {}</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      return done.call(seneca, err)</td>
                           
                         </tr>            <tr id="lib/api.js__825" class="hit">
                           <td class="line" data-tooltip>825</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__826" class="hit">
                           <td class="line" data-tooltip>826</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  out &#x3D; Object.assign({}, base, out)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__827" class="hit">
                           <td class="line" data-tooltip>827</td>
@@ -17388,212 +17339,212 @@
                         </tr>            <tr id="lib/api.js__828" class="hit">
                           <td class="line" data-tooltip>828</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  if (out.type &#x3D;&#x3D;&#x3D; &#x27;web&#x27; || out.type &#x3D;&#x3D;&#x3D; &#x27;tcp&#x27;) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // don&#x27;t try to close twice</td>
                           
-                        </tr>            <tr id="lib/api.js__829" class="chunks">
+                        </tr>            <tr id="lib/api.js__829" class="hit">
                           <td class="line" data-tooltip>829</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    out.port &#x3D; </div><div class="miss false" data-tooltip>out.port &#x3D;&#x3D; null</div><div> ? </div><div class="miss never" data-tooltip>base.port</div><div> : out.port</div></td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">  if (seneca.flags.closed) {</td>
                           
                         </tr>            <tr id="lib/api.js__830" class="hit">
                           <td class="line" data-tooltip>830</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>53</td>
-                          <td class="source">    out.host &#x3D; out.host &#x3D;&#x3D; null ? base.host : out.host</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    return safe_done()</td>
                           
                         </tr>            <tr id="lib/api.js__831" class="hit">
                           <td class="line" data-tooltip>831</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>53</td>
-                          <td class="source">    out.path &#x3D; out.path &#x3D;&#x3D; null ? base.path : out.path</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__832" class="hit">
                           <td class="line" data-tooltip>832</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__833" class="hit">
                           <td class="line" data-tooltip>833</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">  seneca.ready(do_close)</td>
                           
                         </tr>            <tr id="lib/api.js__834" class="hit">
                           <td class="line" data-tooltip>834</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  return out</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">  var close_timeout &#x3D; setTimeout(do_close, options.close_delay)</td>
                           
                         </tr>            <tr id="lib/api.js__835" class="hit">
                           <td class="line" data-tooltip>835</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__836" class="hit">
                           <td class="line" data-tooltip>836</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  function do_close() {</td>
                           
                         </tr>            <tr id="lib/api.js__837" class="hit">
                           <td class="line" data-tooltip>837</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">intern.close &#x3D; function (callpoint, done) {</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">    clearTimeout(close_timeout)</td>
                           
                         </tr>            <tr id="lib/api.js__838" class="hit">
                           <td class="line" data-tooltip>838</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var seneca &#x3D; this</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__839" class="hit">
                           <td class="line" data-tooltip>839</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>78</td>
-                          <td class="source">  var options &#x3D; seneca.options()</td>
+                          <td class="source">    if (seneca.flags.closed) {</td>
                           
                         </tr>            <tr id="lib/api.js__840" class="hit">
                           <td class="line" data-tooltip>840</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      return safe_done()</td>
                           
                         </tr>            <tr id="lib/api.js__841" class="hit">
                           <td class="line" data-tooltip>841</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">  var done_called &#x3D; false</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__842" class="hit">
                           <td class="line" data-tooltip>842</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">  var safe_done &#x3D; function safe_done(err) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__843" class="hit">
                           <td class="line" data-tooltip>843</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    if (!done_called &amp;&amp; &#x27;function&#x27; &#x3D;&#x3D;&#x3D; typeof done) {</td>
+                          <td class="source">    // TODO: remove in 4.x</td>
                           
                         </tr>            <tr id="lib/api.js__844" class="hit">
                           <td class="line" data-tooltip>844</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">      done_called &#x3D; true</td>
+                          <td class="source">    seneca.closed &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__845" class="hit">
                           <td class="line" data-tooltip>845</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      return done.call(seneca, err)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__846" class="hit">
                           <td class="line" data-tooltip>846</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">    seneca.flags.closed &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__847" class="hit">
                           <td class="line" data-tooltip>847</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__848" class="hit">
                           <td class="line" data-tooltip>848</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    // cleanup process event listeners</td>
                           
                         </tr>            <tr id="lib/api.js__849" class="hit">
                           <td class="line" data-tooltip>849</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // don&#x27;t try to close twice</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">    Common.each(options.system.close_signals, function (active, signal) {</td>
                           
-                        </tr>            <tr id="lib/api.js__850" class="hit">
+                        </tr>            <tr id="lib/api.js__850" class="chunks">
                           <td class="line" data-tooltip>850</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">  if (seneca.flags.closed) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>active</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__851" class="hit">
+                        </tr>            <tr id="lib/api.js__851" class="miss">
                           <td class="line" data-tooltip>851</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    return safe_done()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source" data-tooltip>        process.removeListener(signal, seneca.private$.exit_close)</td>
                           
                         </tr>            <tr id="lib/api.js__852" class="hit">
                           <td class="line" data-tooltip>852</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__853" class="hit">
                           <td class="line" data-tooltip>853</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__854" class="hit">
                           <td class="line" data-tooltip>854</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">  seneca.ready(do_close)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__855" class="hit">
                           <td class="line" data-tooltip>855</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">  var close_timeout &#x3D; setTimeout(do_close, options.close_delay)</td>
+                          <td class="source">    seneca.log.debug({</td>
                           
                         </tr>            <tr id="lib/api.js__856" class="hit">
                           <td class="line" data-tooltip>856</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      kind: &#x27;close&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__857" class="hit">
                           <td class="line" data-tooltip>857</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  function do_close() {</td>
+                          <td class="source">      notice: &#x27;start&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__858" class="hit">
                           <td class="line" data-tooltip>858</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">    clearTimeout(close_timeout)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      callpoint: callpoint(true),</td>
                           
                         </tr>            <tr id="lib/api.js__859" class="hit">
                           <td class="line" data-tooltip>859</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__860" class="hit">
                           <td class="line" data-tooltip>860</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">    if (seneca.flags.closed) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__861" class="hit">
                           <td class="line" data-tooltip>861</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      return safe_done()</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">    seneca.act(&#x27;role:seneca,cmd:close,closing$:true&#x27;, function (err) {</td>
                           
                         </tr>            <tr id="lib/api.js__862" class="hit">
                           <td class="line" data-tooltip>862</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">      seneca.log.debug(errlog(err, { kind: &#x27;close&#x27;, notice: &#x27;end&#x27; }))</td>
                           
                         </tr>            <tr id="lib/api.js__863" class="hit">
                           <td class="line" data-tooltip>863</td>
@@ -17604,311 +17555,185 @@
                         </tr>            <tr id="lib/api.js__864" class="hit">
                           <td class="line" data-tooltip>864</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    // TODO: remove in 4.x</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;act-in&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__865" class="hit">
                           <td class="line" data-tooltip>865</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">    seneca.closed &#x3D; true</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;act-out&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__866" class="hit">
                           <td class="line" data-tooltip>866</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;act-err&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__867" class="hit">
                           <td class="line" data-tooltip>867</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">    seneca.flags.closed &#x3D; true</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;pin&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__868" class="hit">
                           <td class="line" data-tooltip>868</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;after-pin&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__869" class="hit">
                           <td class="line" data-tooltip>869</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    // cleanup process event listeners</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;ready&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__870" class="hit">
                           <td class="line" data-tooltip>870</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">    Common.each(options.system.close_signals, function (active, signal) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__871" class="chunks">
+                        </tr>            <tr id="lib/api.js__871" class="hit">
                           <td class="line" data-tooltip>871</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>active</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.private$.history.close()</td>
                           
-                        </tr>            <tr id="lib/api.js__872" class="miss">
+                        </tr>            <tr id="lib/api.js__872" class="hit">
                           <td class="line" data-tooltip>872</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        process.removeListener(signal, seneca.private$.exit_close)</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__873" class="hit">
+                        </tr>            <tr id="lib/api.js__873" class="chunks">
                           <td class="line" data-tooltip>873</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>seneca.private$.status_interval</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__874" class="hit">
+                        </tr>            <tr id="lib/api.js__874" class="miss">
                           <td class="line" data-tooltip>874</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source" data-tooltip>        clearInterval(seneca.private$.status_interval)</td>
                           
                         </tr>            <tr id="lib/api.js__875" class="hit">
                           <td class="line" data-tooltip>875</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__876" class="hit">
                           <td class="line" data-tooltip>876</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">    seneca.log.debug({</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__877" class="hit">
                           <td class="line" data-tooltip>877</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      kind: &#x27;close&#x27;,</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      return safe_done(err)</td>
                           
                         </tr>            <tr id="lib/api.js__878" class="hit">
                           <td class="line" data-tooltip>878</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      notice: &#x27;start&#x27;,</td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__879" class="hit">
                           <td class="line" data-tooltip>879</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      callpoint: callpoint(true),</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__880" class="hit">
                           <td class="line" data-tooltip>880</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__881" class="hit">
                           <td class="line" data-tooltip>881</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">  return seneca</td>
                           
                         </tr>            <tr id="lib/api.js__882" class="hit">
                           <td class="line" data-tooltip>882</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">    seneca.act(&#x27;role:seneca,cmd:close,closing$:true&#x27;, function (err) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__883" class="hit">
                           <td class="line" data-tooltip>883</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      seneca.log.debug(errlog(err, { kind: &#x27;close&#x27;, notice: &#x27;end&#x27; }))</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__884" class="hit">
                           <td class="line" data-tooltip>884</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">intern.fix_args &#x3D; function (origargs, patargs, msgargs, custom) {</td>
                           
                         </tr>            <tr id="lib/api.js__885" class="hit">
                           <td class="line" data-tooltip>885</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;act-in&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var args &#x3D; Common.parsePattern(this, origargs, &#x27;rest:.*&#x27;, patargs)</td>
                           
                         </tr>            <tr id="lib/api.js__886" class="hit">
                           <td class="line" data-tooltip>886</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;act-out&#x27;)</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  var fixargs &#x3D; [args.pattern]</td>
                           
                         </tr>            <tr id="lib/api.js__887" class="hit">
                           <td class="line" data-tooltip>887</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;act-err&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    .concat({</td>
                           
                         </tr>            <tr id="lib/api.js__888" class="hit">
                           <td class="line" data-tooltip>888</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;pin&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      fixed$: Object.assign({}, msgargs, args.pattern.fixed$),</td>
                           
                         </tr>            <tr id="lib/api.js__889" class="hit">
                           <td class="line" data-tooltip>889</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;after-pin&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      custom$: Object.assign({}, custom, args.pattern.custom$),</td>
                           
                         </tr>            <tr id="lib/api.js__890" class="hit">
                           <td class="line" data-tooltip>890</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;ready&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__891" class="hit">
                           <td class="line" data-tooltip>891</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    .concat(args.rest)</td>
                           
                         </tr>            <tr id="lib/api.js__892" class="hit">
                           <td class="line" data-tooltip>892</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.private$.history.close()</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  return fixargs</td>
                           
                         </tr>            <tr id="lib/api.js__893" class="hit">
                           <td class="line" data-tooltip>893</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
-                        </tr>            <tr id="lib/api.js__894" class="chunks">
+                        </tr>            <tr id="lib/api.js__894" class="hit">
                           <td class="line" data-tooltip>894</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>seneca.private$.status_interval</div><div>) {</div></td>
-                          
-                        </tr>            <tr id="lib/api.js__895" class="miss">
-                          <td class="line" data-tooltip>895</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        clearInterval(seneca.private$.status_interval)</td>
-                          
-                        </tr>            <tr id="lib/api.js__896" class="hit">
-                          <td class="line" data-tooltip>896</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
-                          
-                        </tr>            <tr id="lib/api.js__897" class="hit">
-                          <td class="line" data-tooltip>897</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
-                          
-                        </tr>            <tr id="lib/api.js__898" class="hit">
-                          <td class="line" data-tooltip>898</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      return safe_done(err)</td>
-                          
-                        </tr>            <tr id="lib/api.js__899" class="hit">
-                          <td class="line" data-tooltip>899</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
-                          
-                        </tr>            <tr id="lib/api.js__900" class="hit">
-                          <td class="line" data-tooltip>900</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
-                          
-                        </tr>            <tr id="lib/api.js__901" class="hit">
-                          <td class="line" data-tooltip>901</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
-                          
-                        </tr>            <tr id="lib/api.js__902" class="hit">
-                          <td class="line" data-tooltip>902</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">  return seneca</td>
-                          
-                        </tr>            <tr id="lib/api.js__903" class="hit">
-                          <td class="line" data-tooltip>903</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
-                          
-                        </tr>            <tr id="lib/api.js__904" class="hit">
-                          <td class="line" data-tooltip>904</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
-                          
-                        </tr>            <tr id="lib/api.js__905" class="hit">
-                          <td class="line" data-tooltip>905</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">intern.fix_args &#x3D; function (origargs, patargs, msgargs, custom) {</td>
-                          
-                        </tr>            <tr id="lib/api.js__906" class="hit">
-                          <td class="line" data-tooltip>906</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var args &#x3D; Common.parsePattern(this, origargs, &#x27;rest:.*&#x27;, patargs)</td>
-                          
-                        </tr>            <tr id="lib/api.js__907" class="hit">
-                          <td class="line" data-tooltip>907</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  var fixargs &#x3D; [args.pattern]</td>
-                          
-                        </tr>            <tr id="lib/api.js__908" class="hit">
-                          <td class="line" data-tooltip>908</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    .concat({</td>
-                          
-                        </tr>            <tr id="lib/api.js__909" class="hit">
-                          <td class="line" data-tooltip>909</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      fixed$: Object.assign({}, msgargs, args.pattern.fixed$),</td>
-                          
-                        </tr>            <tr id="lib/api.js__910" class="hit">
-                          <td class="line" data-tooltip>910</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      custom$: Object.assign({}, custom, args.pattern.custom$),</td>
-                          
-                        </tr>            <tr id="lib/api.js__911" class="hit">
-                          <td class="line" data-tooltip>911</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
-                          
-                        </tr>            <tr id="lib/api.js__912" class="hit">
-                          <td class="line" data-tooltip>912</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    .concat(args.rest)</td>
-                          
-                        </tr>            <tr id="lib/api.js__913" class="hit">
-                          <td class="line" data-tooltip>913</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  return fixargs</td>
-                          
-                        </tr>            <tr id="lib/api.js__914" class="hit">
-                          <td class="line" data-tooltip>914</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
-                          
-                        </tr>            <tr id="lib/api.js__915" class="hit">
-                          <td class="line" data-tooltip>915</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
@@ -17919,10 +17744,10 @@
             <div class="file ">
                 <h2 id="lib/common.js">lib/common.js </h2>
                 <div class="stats high">
-                    <div class="percentage">87.86%</div>
+                    <div class="percentage">87.69%</div>
                     <div class="sloc">585</div>
-                    <div class="hits">514</div>
-                    <div class="misses">71</div>
+                    <div class="hits">513</div>
+                    <div class="misses">72</div>
                 </div>
                 <table>
                     <thead>
@@ -19444,7 +19269,7 @@
                         </tr>            <tr id="lib/common.js__252" class="hit">
                           <td class="line" data-tooltip>252</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>23647</td>
+                          <td class="hits" data-tooltip>23639</td>
                           <td class="source">  if (null &#x3D;&#x3D; obj) return obj</td>
                           
                         </tr>            <tr id="lib/common.js__253" class="hit">
@@ -19456,7 +19281,7 @@
                         </tr>            <tr id="lib/common.js__254" class="hit">
                           <td class="line" data-tooltip>254</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>23641</td>
+                          <td class="hits" data-tooltip>23633</td>
                           <td class="source">  var out &#x3D; Array.isArray(obj) ? [] : {}</td>
                           
                         </tr>            <tr id="lib/common.js__255" class="hit">
@@ -19468,19 +19293,19 @@
                         </tr>            <tr id="lib/common.js__256" class="hit">
                           <td class="line" data-tooltip>256</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>23641</td>
+                          <td class="hits" data-tooltip>23633</td>
                           <td class="source">  var pn &#x3D; Object.getOwnPropertyNames(obj)</td>
                           
                         </tr>            <tr id="lib/common.js__257" class="hit">
                           <td class="line" data-tooltip>257</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>23641</td>
+                          <td class="hits" data-tooltip>23633</td>
                           <td class="source">  for (var i &#x3D; 0; i &lt; pn.length; i++) {</td>
                           
                         </tr>            <tr id="lib/common.js__258" class="hit">
                           <td class="line" data-tooltip>258</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77752</td>
+                          <td class="hits" data-tooltip>77689</td>
                           <td class="source">    var p &#x3D; pn[i]</td>
                           
                         </tr>            <tr id="lib/common.js__259" class="hit">
@@ -19492,13 +19317,13 @@
                         </tr>            <tr id="lib/common.js__260" class="hit">
                           <td class="line" data-tooltip>260</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77752</td>
+                          <td class="hits" data-tooltip>77689</td>
                           <td class="source">    if (&#x27;$&#x27; !&#x3D; p[p.length - 1]) {</td>
                           
                         </tr>            <tr id="lib/common.js__261" class="hit">
                           <td class="line" data-tooltip>261</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>63829</td>
+                          <td class="hits" data-tooltip>63782</td>
                           <td class="source">      out[p] &#x3D; obj[p]</td>
                           
                         </tr>            <tr id="lib/common.js__262" class="hit">
@@ -19546,7 +19371,7 @@
                         </tr>            <tr id="lib/common.js__269" class="hit">
                           <td class="line" data-tooltip>269</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>23641</td>
+                          <td class="hits" data-tooltip>23633</td>
                           <td class="source">  return out</td>
                           
                         </tr>            <tr id="lib/common.js__270" class="hit">
@@ -19954,7 +19779,7 @@
                         </tr>            <tr id="lib/common.js__337" class="hit">
                           <td class="line" data-tooltip>337</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>25</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">    var test &#x3D; so.test</td>
                           
                         </tr>            <tr id="lib/common.js__338" class="hit">
@@ -19978,7 +19803,7 @@
                         </tr>            <tr id="lib/common.js__341" class="hit">
                           <td class="line" data-tooltip>341</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>25</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">    var full &#x3D;</td>
                           
                         </tr>            <tr id="lib/common.js__342" class="chunks">
@@ -20002,7 +19827,7 @@
                         </tr>            <tr id="lib/common.js__345" class="hit">
                           <td class="line" data-tooltip>345</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>25</td>
+                          <td class="hits" data-tooltip>21</td>
                           <td class="source">    if (0 &lt; diecount) {</td>
                           
                         </tr>            <tr id="lib/common.js__346" class="chunks">
@@ -20038,7 +19863,7 @@
                         </tr>            <tr id="lib/common.js__351" class="hit">
                           <td class="line" data-tooltip>351</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>17</td>
                           <td class="source">      diecount++</td>
                           
                         </tr>            <tr id="lib/common.js__352" class="hit">
@@ -20056,7 +19881,7 @@
                         </tr>            <tr id="lib/common.js__354" class="hit">
                           <td class="line" data-tooltip>354</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>17</td>
                           <td class="source">    try {</td>
                           
                         </tr>            <tr id="lib/common.js__355" class="chunks">
@@ -20098,7 +19923,7 @@
                         </tr>            <tr id="lib/common.js__361" class="hit">
                           <td class="line" data-tooltip>361</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>17</td>
                           <td class="source">      err.fatal$ &#x3D; true</td>
                           
                         </tr>            <tr id="lib/common.js__362" class="hit">
@@ -20110,7 +19935,7 @@
                         </tr>            <tr id="lib/common.js__363" class="hit">
                           <td class="line" data-tooltip>363</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>17</td>
                           <td class="source">      var logdesc &#x3D; {</td>
                           
                         </tr>            <tr id="lib/common.js__364" class="chunks">
@@ -20182,7 +20007,7 @@
                         </tr>            <tr id="lib/common.js__375" class="hit">
                           <td class="line" data-tooltip>375</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>17</td>
                           <td class="source">      instance.log.fatal(logdesc)</td>
                           
                         </tr>            <tr id="lib/common.js__376" class="hit">
@@ -20200,7 +20025,7 @@
                         </tr>            <tr id="lib/common.js__378" class="hit">
                           <td class="line" data-tooltip>378</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>17</td>
                           <td class="source">      stack &#x3D; stack</td>
                           
                         </tr>            <tr id="lib/common.js__379" class="hit">
@@ -20224,7 +20049,7 @@
                         </tr>            <tr id="lib/common.js__382" class="hit">
                           <td class="line" data-tooltip>382</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>17</td>
                           <td class="source">      var procdesc &#x3D;</td>
                           
                         </tr>            <tr id="lib/common.js__383" class="hit">
@@ -20320,7 +20145,7 @@
                         </tr>            <tr id="lib/common.js__398" class="hit">
                           <td class="line" data-tooltip>398</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>17</td>
                           <td class="source">      var when &#x3D; new Date()</td>
                           
                         </tr>            <tr id="lib/common.js__399" class="hit">
@@ -20332,7 +20157,7 @@
                         </tr>            <tr id="lib/common.js__400" class="hit">
                           <td class="line" data-tooltip>400</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>17</td>
                           <td class="source">      var clean_details &#x3D; null</td>
                           
                         </tr>            <tr id="lib/common.js__401" class="hit">
@@ -20344,7 +20169,7 @@
                         </tr>            <tr id="lib/common.js__402" class="hit">
                           <td class="line" data-tooltip>402</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>17</td>
                           <td class="source">      var stderrmsg &#x3D;</td>
                           
                         </tr>            <tr id="lib/common.js__403" class="hit">
@@ -20602,13 +20427,13 @@
                         </tr>            <tr id="lib/common.js__445" class="hit">
                           <td class="line" data-tooltip>445</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
+                          <td class="hits" data-tooltip>17</td>
                           <td class="source">      if (so.errhandler) {</td>
                           
                         </tr>            <tr id="lib/common.js__446" class="hit">
                           <td class="line" data-tooltip>446</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>18</td>
+                          <td class="hits" data-tooltip>14</td>
                           <td class="source">        so.errhandler.call(instance, err)</td>
                           
                         </tr>            <tr id="lib/common.js__447" class="hit">
@@ -20989,11 +20814,11 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source">    } catch (panic) {</td>
                           
-                        </tr>            <tr id="lib/common.js__510" class="hit">
+                        </tr>            <tr id="lib/common.js__510" class="miss">
                           <td class="line" data-tooltip>510</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>4</td>
-                          <td class="source">      this.log.fatal({</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source" data-tooltip>      this.log.fatal({</td>
                           
                         </tr>            <tr id="lib/common.js__511" class="hit">
                           <td class="line" data-tooltip>511</td>
@@ -21025,11 +20850,11 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/common.js__516" class="chunks">
+                        </tr>            <tr id="lib/common.js__516" class="miss">
                           <td class="line" data-tooltip>516</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>so.test</div><div>) {</div></td>
+                          <td class="source" data-tooltip>      if (so.test) {</td>
                           
                         </tr>            <tr id="lib/common.js__517" class="miss">
                           <td class="line" data-tooltip>517</td>
@@ -21202,13 +21027,13 @@
                         </tr>            <tr id="lib/common.js__545" class="hit">
                           <td class="line" data-tooltip>545</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5644</td>
+                          <td class="hits" data-tooltip>5640</td>
                           <td class="source">  var prior &#x3D; callmeta.prior || {}</td>
                           
                         </tr>            <tr id="lib/common.js__546" class="hit">
                           <td class="line" data-tooltip>546</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5644</td>
+                          <td class="hits" data-tooltip>5640</td>
                           <td class="source">  actdef &#x3D; actdef || {}</td>
                           
                         </tr>            <tr id="lib/common.js__547" class="hit">
@@ -21220,7 +21045,7 @@
                         </tr>            <tr id="lib/common.js__548" class="hit">
                           <td class="line" data-tooltip>548</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5644</td>
+                          <td class="hits" data-tooltip>5640</td>
                           <td class="source">  return Object.assign(</td>
                           
                         </tr>            <tr id="lib/common.js__549" class="hit">
@@ -21364,7 +21189,7 @@
                         </tr>            <tr id="lib/common.js__572" class="hit">
                           <td class="line" data-tooltip>572</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>117</td>
+                          <td class="hits" data-tooltip>113</td>
                           <td class="source">  if (err.details &amp;&amp; ctxt &amp;&amp; ctxt.caller) {</td>
                           
                         </tr>            <tr id="lib/common.js__573" class="hit">
@@ -21388,7 +21213,7 @@
                         </tr>            <tr id="lib/common.js__576" class="hit">
                           <td class="line" data-tooltip>576</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>117</td>
+                          <td class="hits" data-tooltip>113</td>
                           <td class="source">  return Object.assign(</td>
                           
                         </tr>            <tr id="lib/common.js__577" class="hit">
@@ -21982,13 +21807,13 @@
                         </tr>            <tr id="lib/common.js__675" class="hit">
                           <td class="line" data-tooltip>675</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>67697</td>
+                          <td class="hits" data-tooltip>58658</td>
                           <td class="source">  var s &#x3D; 0</td>
                           
                         </tr>            <tr id="lib/common.js__676" class="hit">
                           <td class="line" data-tooltip>676</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>67697</td>
+                          <td class="hits" data-tooltip>58658</td>
                           <td class="source">  var e &#x3D; i</td>
                           
                         </tr>            <tr id="lib/common.js__677" class="hit">
@@ -22000,13 +21825,13 @@
                         </tr>            <tr id="lib/common.js__678" class="hit">
                           <td class="line" data-tooltip>678</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>67697</td>
+                          <td class="hits" data-tooltip>58658</td>
                           <td class="source">  if (0 &#x3D;&#x3D;&#x3D; this._list.length) {</td>
                           
                         </tr>            <tr id="lib/common.js__679" class="hit">
                           <td class="line" data-tooltip>679</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>16806</td>
+                          <td class="hits" data-tooltip>9783</td>
                           <td class="source">    return 0</td>
                           
                         </tr>            <tr id="lib/common.js__680" class="hit">
@@ -22024,13 +21849,13 @@
                         </tr>            <tr id="lib/common.js__682" class="hit">
                           <td class="line" data-tooltip>682</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>50891</td>
+                          <td class="hits" data-tooltip>48875</td>
                           <td class="source">  do {</td>
                           
                         </tr>            <tr id="lib/common.js__683" class="hit">
                           <td class="line" data-tooltip>683</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>105433</td>
+                          <td class="hits" data-tooltip>101507</td>
                           <td class="source">    i &#x3D; Math.floor((s + e) / 2)</td>
                           
                         </tr>            <tr id="lib/common.js__684" class="hit">
@@ -22042,31 +21867,31 @@
                         </tr>            <tr id="lib/common.js__685" class="hit">
                           <td class="line" data-tooltip>685</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>105433</td>
+                          <td class="hits" data-tooltip>101507</td>
                           <td class="source">    if (timelimit &gt; this._list[i].timelimit) {</td>
                           
                         </tr>            <tr id="lib/common.js__686" class="hit">
                           <td class="line" data-tooltip>686</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>270</td>
+                          <td class="hits" data-tooltip>216</td>
                           <td class="source">      s &#x3D; i + 1</td>
                           
                         </tr>            <tr id="lib/common.js__687" class="hit">
                           <td class="line" data-tooltip>687</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>270</td>
+                          <td class="hits" data-tooltip>216</td>
                           <td class="source">      i &#x3D; s</td>
                           
                         </tr>            <tr id="lib/common.js__688" class="hit">
                           <td class="line" data-tooltip>688</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>105163</td>
+                          <td class="hits" data-tooltip>101291</td>
                           <td class="source">    } else if (timelimit &lt; this._list[i].timelimit) {</td>
                           
                         </tr>            <tr id="lib/common.js__689" class="hit">
                           <td class="line" data-tooltip>689</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>105153</td>
+                          <td class="hits" data-tooltip>101279</td>
                           <td class="source">      e &#x3D; i</td>
                           
                         </tr>            <tr id="lib/common.js__690" class="hit">
@@ -22078,13 +21903,13 @@
                         </tr>            <tr id="lib/common.js__691" class="hit">
                           <td class="line" data-tooltip>691</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10</td>
+                          <td class="hits" data-tooltip>12</td>
                           <td class="source">      i++</td>
                           
                         </tr>            <tr id="lib/common.js__692" class="hit">
                           <td class="line" data-tooltip>692</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10</td>
+                          <td class="hits" data-tooltip>12</td>
                           <td class="source">      break</td>
                           
                         </tr>            <tr id="lib/common.js__693" class="hit">
@@ -22108,7 +21933,7 @@
                         </tr>            <tr id="lib/common.js__696" class="hit">
                           <td class="line" data-tooltip>696</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>50891</td>
+                          <td class="hits" data-tooltip>48875</td>
                           <td class="source">  return i</td>
                           
                         </tr>            <tr id="lib/common.js__697" class="hit">
@@ -22144,13 +21969,13 @@
                         </tr>            <tr id="lib/common.js__702" class="hit">
                           <td class="line" data-tooltip>702</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>67687</td>
+                          <td class="hits" data-tooltip>58648</td>
                           <td class="source">    for (var j &#x3D; 0; j &lt; i; j++) {</td>
                           
                         </tr>            <tr id="lib/common.js__703" class="hit">
                           <td class="line" data-tooltip>703</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>499</td>
+                          <td class="hits" data-tooltip>427</td>
                           <td class="source">      delete this._map[this._list[j].id]</td>
                           
                         </tr>            <tr id="lib/common.js__704" class="hit">
@@ -22162,7 +21987,7 @@
                         </tr>            <tr id="lib/common.js__705" class="hit">
                           <td class="line" data-tooltip>705</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>67687</td>
+                          <td class="hits" data-tooltip>58648</td>
                           <td class="source">    this._list &#x3D; this._list.slice(i)</td>
                           
                         </tr>            <tr id="lib/common.js__706" class="hit">
@@ -22334,8 +22159,8 @@
                 <h2 id="lib/errors.js">lib/errors.js </h2>
                 <div class="stats high">
                     <div class="percentage">100%</div>
-                    <div class="sloc">114</div>
-                    <div class="hits">114</div>
+                    <div class="sloc">112</div>
+                    <div class="hits">112</div>
                     <div class="misses">0</div>
                 </div>
                 <table>
@@ -23217,13 +23042,13 @@
                           <td class="line" data-tooltip>145</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  fail_wrong_number_of_args:</td>
+                          <td class="source">  action_timeout:</td>
                           
                         </tr>            <tr id="lib/errors.js__146" class="hit">
                           <td class="line" data-tooltip>146</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;The Seneca.fail method was called with the wrong number of arguments: &lt;%&#x3D;num_args%&gt;&#x27;,</td>
+                          <td class="source">    &#x27;&lt;%&#x3D;legacy_string%&gt;Action &lt;%&#x3D;pattern%&gt; timed out. Timeout was: &lt;%&#x3D;timeout%&gt; (start: &lt;%&#x3D;start%&gt;, end: &lt;%&#x3D;end%&gt;. Message was: &lt;%&#x3D;message%&gt;.&#x27;,</td>
                           
                         </tr>            <tr id="lib/errors.js__147" class="hit">
                           <td class="line" data-tooltip>147</td>
@@ -23235,13 +23060,13 @@
                           <td class="line" data-tooltip>148</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  action_timeout:</td>
+                          <td class="source">  use_no_args:</td>
                           
                         </tr>            <tr id="lib/errors.js__149" class="hit">
                           <td class="line" data-tooltip>149</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;&lt;%&#x3D;legacy_string%&gt;Action &lt;%&#x3D;pattern%&gt; timed out. Timeout was: &lt;%&#x3D;timeout%&gt; (start: &lt;%&#x3D;start%&gt;, end: &lt;%&#x3D;end%&gt;. Message was: &lt;%&#x3D;message%&gt;.&#x27;,</td>
+                          <td class="source">    &#x27;The seneca.use method needs at least one argument to define a plugin.&#x27;,</td>
                           
                         </tr>            <tr id="lib/errors.js__150" class="hit">
                           <td class="line" data-tooltip>150</td>
@@ -23253,100 +23078,82 @@
                           <td class="line" data-tooltip>151</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  use_no_args:</td>
+                          <td class="source">  // Legacy error message codes</td>
                           
                         </tr>            <tr id="lib/errors.js__152" class="hit">
                           <td class="line" data-tooltip>152</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;The seneca.use method needs at least one argument to define a plugin.&#x27;,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/errors.js__153" class="hit">
                           <td class="line" data-tooltip>153</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  act_invalid_args:</td>
                           
                         </tr>            <tr id="lib/errors.js__154" class="hit">
                           <td class="line" data-tooltip>154</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // Legacy error message codes</td>
+                          <td class="source">    &#x27;Action &lt;%&#x3D;pattern%&gt; has invalid arguments; &lt;%&#x3D;message%&gt;; &#x27; +</td>
                           
                         </tr>            <tr id="lib/errors.js__155" class="hit">
                           <td class="line" data-tooltip>155</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    &#x27;arguments were: &lt;%&#x3D;msg%&gt;.&#x27;,</td>
                           
                         </tr>            <tr id="lib/errors.js__156" class="hit">
                           <td class="line" data-tooltip>156</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  act_invalid_args:</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/errors.js__157" class="hit">
                           <td class="line" data-tooltip>157</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;Action &lt;%&#x3D;pattern%&gt; has invalid arguments; &lt;%&#x3D;message%&gt;; &#x27; +</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/errors.js__158" class="hit">
                           <td class="line" data-tooltip>158</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;arguments were: &lt;%&#x3D;msg%&gt;.&#x27;,</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">module.exports.deprecation &#x3D; {</td>
                           
                         </tr>            <tr id="lib/errors.js__159" class="hit">
                           <td class="line" data-tooltip>159</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  seneca_parent:</td>
                           
                         </tr>            <tr id="lib/errors.js__160" class="hit">
                           <td class="line" data-tooltip>160</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    &#x27;Seneca.parent has been renamed to Seneca.prior. Seneca.parent will be removed in Seneca 4.x.&#x27;,</td>
                           
                         </tr>            <tr id="lib/errors.js__161" class="hit">
                           <td class="line" data-tooltip>161</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">module.exports.deprecation &#x3D; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/errors.js__162" class="hit">
                           <td class="line" data-tooltip>162</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  seneca_parent:</td>
+                          <td class="source">  seneca_next_act: &#x27;Seneca.next_act will be removed in Seneca 3.x&#x27;,</td>
                           
                         </tr>            <tr id="lib/errors.js__163" class="hit">
                           <td class="line" data-tooltip>163</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;Seneca.parent has been renamed to Seneca.prior. Seneca.parent will be removed in Seneca 4.x.&#x27;,</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/errors.js__164" class="hit">
                           <td class="line" data-tooltip>164</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
-                          
-                        </tr>            <tr id="lib/errors.js__165" class="hit">
-                          <td class="line" data-tooltip>165</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  seneca_next_act: &#x27;Seneca.next_act will be removed in Seneca 3.x&#x27;,</td>
-                          
-                        </tr>            <tr id="lib/errors.js__166" class="hit">
-                          <td class="line" data-tooltip>166</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
-                          
-                        </tr>            <tr id="lib/errors.js__167" class="hit">
-                          <td class="line" data-tooltip>167</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
@@ -28310,7 +28117,7 @@
                         </tr>            <tr id="lib/logging.js__255" class="hit">
                           <td class="line" data-tooltip>255</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    } else if (&#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof entry) {</td>
                           
                         </tr>            <tr id="lib/logging.js__256" class="hit">
@@ -28334,13 +28141,13 @@
                         </tr>            <tr id="lib/logging.js__259" class="hit">
                           <td class="line" data-tooltip>259</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    var logspec &#x3D; instance.private$.logspec</td>
                           
                         </tr>            <tr id="lib/logging.js__260" class="hit">
                           <td class="line" data-tooltip>260</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    entry.level &#x3D; entry.level || logspec.default_level</td>
                           
                         </tr>            <tr id="lib/logging.js__261" class="hit">
@@ -28352,7 +28159,7 @@
                         </tr>            <tr id="lib/logging.js__262" class="hit">
                           <td class="line" data-tooltip>262</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    if (&#x27;number&#x27; !&#x3D;&#x3D; typeof entry.level) {</td>
                           
                         </tr>            <tr id="lib/logging.js__263" class="hit">
@@ -28388,7 +28195,7 @@
                         </tr>            <tr id="lib/logging.js__268" class="hit">
                           <td class="line" data-tooltip>268</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    var now &#x3D; new Date()</td>
                           
                         </tr>            <tr id="lib/logging.js__269" class="hit">
@@ -28412,25 +28219,25 @@
                         </tr>            <tr id="lib/logging.js__272" class="hit">
                           <td class="line" data-tooltip>272</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    entry.isot &#x3D; entry.isot || now.toISOString()</td>
                           
                         </tr>            <tr id="lib/logging.js__273" class="hit">
                           <td class="line" data-tooltip>273</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    entry.when &#x3D; entry.when || now.getTime()</td>
                           
                         </tr>            <tr id="lib/logging.js__274" class="hit">
                           <td class="line" data-tooltip>274</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    entry.level_name &#x3D; entry.level_name || logspec.level_text[entry.level]</td>
                           
                         </tr>            <tr id="lib/logging.js__275" class="hit">
                           <td class="line" data-tooltip>275</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    entry.seneca_id &#x3D; entry.seneca_id || instance.id</td>
                           
                         </tr>            <tr id="lib/logging.js__276" class="hit">
@@ -28442,13 +28249,13 @@
                         </tr>            <tr id="lib/logging.js__277" class="hit">
                           <td class="line" data-tooltip>277</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    if (instance.did) {</td>
                           
                         </tr>            <tr id="lib/logging.js__278" class="hit">
                           <td class="line" data-tooltip>278</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11974</td>
+                          <td class="hits" data-tooltip>11962</td>
                           <td class="source">      entry.seneca_did &#x3D; entry.seneca_did || instance.did</td>
                           
                         </tr>            <tr id="lib/logging.js__279" class="hit">
@@ -28466,13 +28273,13 @@
                         </tr>            <tr id="lib/logging.js__281" class="hit">
                           <td class="line" data-tooltip>281</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    if (instance.fixedargs.plugin$) {</td>
                           
                         </tr>            <tr id="lib/logging.js__282" class="hit">
                           <td class="line" data-tooltip>282</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11835</td>
+                          <td class="hits" data-tooltip>11823</td>
                           <td class="source">      entry.plugin_name &#x3D; entry.plugin_name || instance.fixedargs.plugin$.name</td>
                           
                         </tr>            <tr id="lib/logging.js__283" class="chunks">
@@ -28496,13 +28303,13 @@
                         </tr>            <tr id="lib/logging.js__286" class="hit">
                           <td class="line" data-tooltip>286</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    if (instance.private$.act) {</td>
                           
                         </tr>            <tr id="lib/logging.js__287" class="hit">
                           <td class="line" data-tooltip>287</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5382</td>
+                          <td class="hits" data-tooltip>5374</td>
                           <td class="source">      intern.build_act_entry(instance.private$.act, entry)</td>
                           
                         </tr>            <tr id="lib/logging.js__288" class="hit">
@@ -28526,7 +28333,7 @@
                         </tr>            <tr id="lib/logging.js__291" class="hit">
                           <td class="line" data-tooltip>291</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    instance.emit(&#x27;log&#x27;, entry)</td>
                           
                         </tr>            <tr id="lib/logging.js__292" class="hit">
@@ -28538,7 +28345,7 @@
                         </tr>            <tr id="lib/logging.js__293" class="hit">
                           <td class="line" data-tooltip>293</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    var level_match &#x3D; logspec.live_level &lt;&#x3D; entry.level</td>
                           
                         </tr>            <tr id="lib/logging.js__294" class="hit">
@@ -28550,13 +28357,13 @@
                         </tr>            <tr id="lib/logging.js__295" class="hit">
                           <td class="line" data-tooltip>295</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    if (level_match) {</td>
                           
                         </tr>            <tr id="lib/logging.js__296" class="hit">
                           <td class="line" data-tooltip>296</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>627</td>
+                          <td class="hits" data-tooltip>610</td>
                           <td class="source">      instance.private$.logger.call(this, entry)</td>
                           
                         </tr>            <tr id="lib/logging.js__297" class="hit">
@@ -28574,7 +28381,7 @@
                         </tr>            <tr id="lib/logging.js__299" class="hit">
                           <td class="line" data-tooltip>299</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17850</td>
+                          <td class="hits" data-tooltip>17813</td>
                           <td class="source">    return this</td>
                           
                         </tr>            <tr id="lib/logging.js__300" class="hit">
@@ -28676,7 +28483,7 @@
                         </tr>            <tr id="lib/logging.js__316" class="hit">
                           <td class="line" data-tooltip>316</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17807</td>
+                          <td class="hits" data-tooltip>17770</td>
                           <td class="source">    if (&#x27;object&#x27; !&#x3D;&#x3D; typeof entry) {</td>
                           
                         </tr>            <tr id="lib/logging.js__317" class="hit">
@@ -28712,13 +28519,13 @@
                         </tr>            <tr id="lib/logging.js__322" class="hit">
                           <td class="line" data-tooltip>322</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17807</td>
+                          <td class="hits" data-tooltip>17770</td>
                           <td class="source">    entry.level &#x3D; level</td>
                           
                         </tr>            <tr id="lib/logging.js__323" class="hit">
                           <td class="line" data-tooltip>323</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17807</td>
+                          <td class="hits" data-tooltip>17770</td>
                           <td class="source">    return self.log(entry)</td>
                           
                         </tr>            <tr id="lib/logging.js__324" class="hit">
@@ -29378,19 +29185,19 @@
                         </tr>            <tr id="lib/logging.js__433" class="hit">
                           <td class="line" data-tooltip>433</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5384</td>
+                          <td class="hits" data-tooltip>5376</td>
                           <td class="source">    entry.actid &#x3D; entry.actid || act.meta.id</td>
                           
                         </tr>            <tr id="lib/logging.js__434" class="hit">
                           <td class="line" data-tooltip>434</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5384</td>
+                          <td class="hits" data-tooltip>5376</td>
                           <td class="source">    entry.pattern &#x3D; entry.pattern || act.meta.pattern</td>
                           
                         </tr>            <tr id="lib/logging.js__435" class="hit">
                           <td class="line" data-tooltip>435</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5384</td>
+                          <td class="hits" data-tooltip>5376</td>
                           <td class="source">    entry.action &#x3D; entry.action || act.def.id</td>
                           
                         </tr>            <tr id="lib/logging.js__436" class="hit">
@@ -29402,19 +29209,19 @@
                         </tr>            <tr id="lib/logging.js__437" class="hit">
                           <td class="line" data-tooltip>437</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5384</td>
+                          <td class="hits" data-tooltip>5376</td>
                           <td class="source">    entry.idpath &#x3D; (&#x27;&#x27; + act.meta.tx).substring(0, 5)</td>
                           
                         </tr>            <tr id="lib/logging.js__438" class="hit">
                           <td class="line" data-tooltip>438</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5384</td>
+                          <td class="hits" data-tooltip>5376</td>
                           <td class="source">    if (act.meta.parents) {</td>
                           
                         </tr>            <tr id="lib/logging.js__439" class="hit">
                           <td class="line" data-tooltip>439</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>4944</td>
+                          <td class="hits" data-tooltip>4936</td>
                           <td class="source">      for (var i &#x3D; 0; i &lt; act.meta.parents.length; i++) {</td>
                           
                         </tr>            <tr id="lib/logging.js__440" class="hit">
@@ -29450,7 +29257,7 @@
                         </tr>            <tr id="lib/logging.js__445" class="hit">
                           <td class="line" data-tooltip>445</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5384</td>
+                          <td class="hits" data-tooltip>5376</td>
                           <td class="source">    entry.idpath +&#x3D; (&#x27;.&#x27; + act.meta.mi).substring(0, 6)</td>
                           
                         </tr>            <tr id="lib/logging.js__446" class="hit">
@@ -30822,7 +30629,7 @@
                         </tr>            <tr id="lib/options.js__222" class="hit">
                           <td class="line" data-tooltip>222</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21218</td>
+                          <td class="hits" data-tooltip>21205</td>
                           <td class="source">    return options</td>
                           
                         </tr>            <tr id="lib/options.js__223" class="hit">
@@ -31402,7 +31209,7 @@
                         </tr>            <tr id="lib/outward.js__29" class="hit">
                           <td class="line" data-tooltip>29</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2826</td>
+                          <td class="hits" data-tooltip>2822</td>
                           <td class="source">  if (!ctxt.options.legacy.error) {</td>
                           
                         </tr>            <tr id="lib/outward.js__30" class="chunks">
@@ -31486,7 +31293,7 @@
                         </tr>            <tr id="lib/outward.js__43" class="hit">
                           <td class="line" data-tooltip>43</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  Assert(ctxt.options)</td>
                           
                         </tr>            <tr id="lib/outward.js__44" class="hit">
@@ -31498,19 +31305,19 @@
                         </tr>            <tr id="lib/outward.js__45" class="hit">
                           <td class="line" data-tooltip>45</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var so &#x3D; ctxt.options</td>
                           
                         </tr>            <tr id="lib/outward.js__46" class="hit">
                           <td class="line" data-tooltip>46</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var res &#x3D; data.res</td>
                           
                         </tr>            <tr id="lib/outward.js__47" class="hit">
                           <td class="line" data-tooltip>47</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__48" class="hit">
@@ -31522,13 +31329,13 @@
                         </tr>            <tr id="lib/outward.js__49" class="hit">
                           <td class="line" data-tooltip>49</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var actid &#x3D; meta.id</td>
                           
                         </tr>            <tr id="lib/outward.js__50" class="hit">
                           <td class="line" data-tooltip>50</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var private$ &#x3D; ctxt.seneca.private$</td>
                           
                         </tr>            <tr id="lib/outward.js__51" class="hit">
@@ -31546,7 +31353,7 @@
                         </tr>            <tr id="lib/outward.js__53" class="hit">
                           <td class="line" data-tooltip>53</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    var actdetails &#x3D; private$.history.get(actid)</td>
                           
                         </tr>            <tr id="lib/outward.js__54" class="hit">
@@ -31558,13 +31365,13 @@
                         </tr>            <tr id="lib/outward.js__55" class="hit">
                           <td class="line" data-tooltip>55</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">    if (actdetails) {</td>
                           
                         </tr>            <tr id="lib/outward.js__56" class="hit">
                           <td class="line" data-tooltip>56</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2379</td>
+                          <td class="hits" data-tooltip>2380</td>
                           <td class="source">      actdetails.result.push({ when: Date.now(), res: res })</td>
                           
                         </tr>            <tr id="lib/outward.js__57" class="hit">
@@ -31600,7 +31407,7 @@
                         </tr>            <tr id="lib/outward.js__62" class="hit">
                           <td class="line" data-tooltip>62</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2825</td>
+                          <td class="hits" data-tooltip>2821</td>
                           <td class="source">  if (!ctxt.actdef || ctxt.cached$) {</td>
                           
                         </tr>            <tr id="lib/outward.js__63" class="hit">
@@ -31624,19 +31431,19 @@
                         </tr>            <tr id="lib/outward.js__66" class="hit">
                           <td class="line" data-tooltip>66</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2389</td>
+                          <td class="hits" data-tooltip>2385</td>
                           <td class="source">  var private$ &#x3D; ctxt.seneca.private$</td>
                           
                         </tr>            <tr id="lib/outward.js__67" class="hit">
                           <td class="line" data-tooltip>67</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2389</td>
+                          <td class="hits" data-tooltip>2385</td>
                           <td class="source">  var stats &#x3D; private$.stats.act</td>
                           
                         </tr>            <tr id="lib/outward.js__68" class="hit">
                           <td class="line" data-tooltip>68</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2389</td>
+                          <td class="hits" data-tooltip>2385</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__69" class="hit">
@@ -31648,7 +31455,7 @@
                         </tr>            <tr id="lib/outward.js__70" class="hit">
                           <td class="line" data-tooltip>70</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2389</td>
+                          <td class="hits" data-tooltip>2385</td>
                           <td class="source">  ++stats.done</td>
                           
                         </tr>            <tr id="lib/outward.js__71" class="hit">
@@ -31672,7 +31479,7 @@
                         </tr>            <tr id="lib/outward.js__74" class="hit">
                           <td class="line" data-tooltip>74</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2286</td>
+                          <td class="hits" data-tooltip>2282</td>
                           <td class="source">    private$.timestats.point(ctxt.duration, ctxt.actdef.pattern)</td>
                           
                         </tr>            <tr id="lib/outward.js__75" class="hit">
@@ -31690,7 +31497,7 @@
                         </tr>            <tr id="lib/outward.js__77" class="hit">
                           <td class="line" data-tooltip>77</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2389</td>
+                          <td class="hits" data-tooltip>2385</td>
                           <td class="source">  var pattern &#x3D; ctxt.actdef.pattern</td>
                           
                         </tr>            <tr id="lib/outward.js__78" class="hit">
@@ -31702,7 +31509,7 @@
                         </tr>            <tr id="lib/outward.js__79" class="hit">
                           <td class="line" data-tooltip>79</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2389</td>
+                          <td class="hits" data-tooltip>2385</td>
                           <td class="source">  var actstats &#x3D; (private$.stats.actmap[pattern] &#x3D;</td>
                           
                         </tr>            <tr id="lib/outward.js__80" class="hit">
@@ -31726,13 +31533,13 @@
                         </tr>            <tr id="lib/outward.js__83" class="hit">
                           <td class="line" data-tooltip>83</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>66</td>
+                          <td class="hits" data-tooltip>62</td>
                           <td class="source">    ++stats.fails</td>
                           
                         </tr>            <tr id="lib/outward.js__84" class="hit">
                           <td class="line" data-tooltip>84</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>66</td>
+                          <td class="hits" data-tooltip>62</td>
                           <td class="source">    ++actstats.fails</td>
                           
                         </tr>            <tr id="lib/outward.js__85" class="hit">
@@ -31774,7 +31581,7 @@
                         </tr>            <tr id="lib/outward.js__91" class="hit">
                           <td class="line" data-tooltip>91</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  Assert(ctxt.options)</td>
                           
                         </tr>            <tr id="lib/outward.js__92" class="hit">
@@ -31786,19 +31593,19 @@
                         </tr>            <tr id="lib/outward.js__93" class="hit">
                           <td class="line" data-tooltip>93</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var so &#x3D; ctxt.options</td>
                           
                         </tr>            <tr id="lib/outward.js__94" class="hit">
                           <td class="line" data-tooltip>94</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var msg &#x3D; data.msg</td>
                           
                         </tr>            <tr id="lib/outward.js__95" class="hit">
                           <td class="line" data-tooltip>95</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var res &#x3D; data.res</td>
                           
                         </tr>            <tr id="lib/outward.js__96" class="hit">
@@ -31810,7 +31617,7 @@
                         </tr>            <tr id="lib/outward.js__97" class="hit">
                           <td class="line" data-tooltip>97</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  if (void 0 &#x3D;&#x3D;&#x3D; data.res) {</td>
                           
                         </tr>            <tr id="lib/outward.js__98" class="hit">
@@ -31834,7 +31641,7 @@
                         </tr>            <tr id="lib/outward.js__101" class="hit">
                           <td class="line" data-tooltip>101</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var not_object &#x3D;</td>
                           
                         </tr>            <tr id="lib/outward.js__102" class="hit">
@@ -31906,7 +31713,7 @@
                         </tr>            <tr id="lib/outward.js__113" class="hit">
                           <td class="line" data-tooltip>113</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  if (data.out instanceof Error) {</td>
                           
                         </tr>            <tr id="lib/outward.js__114" class="hit">
@@ -31930,7 +31737,7 @@
                         </tr>            <tr id="lib/outward.js__117" class="hit">
                           <td class="line" data-tooltip>117</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var not_legacy &#x3D; !(</td>
                           
                         </tr>            <tr id="lib/outward.js__118" class="chunks">
@@ -32056,7 +31863,7 @@
                         </tr>            <tr id="lib/outward.js__138" class="hit">
                           <td class="line" data-tooltip>138</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__139" class="hit">
@@ -32068,13 +31875,13 @@
                         </tr>            <tr id="lib/outward.js__140" class="hit">
                           <td class="line" data-tooltip>140</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  if (meta.error) {</td>
                           
                         </tr>            <tr id="lib/outward.js__141" class="hit">
                           <td class="line" data-tooltip>141</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">    return</td>
                           
                         </tr>            <tr id="lib/outward.js__142" class="hit">
@@ -32200,7 +32007,7 @@
                         </tr>            <tr id="lib/outward.js__162" class="hit">
                           <td class="line" data-tooltip>162</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var private$ &#x3D; ctxt.seneca.private$</td>
                           
                         </tr>            <tr id="lib/outward.js__163" class="hit">
@@ -32212,13 +32019,13 @@
                         </tr>            <tr id="lib/outward.js__164" class="hit">
                           <td class="line" data-tooltip>164</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__165" class="hit">
                           <td class="line" data-tooltip>165</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var reply_meta &#x3D; data.reply_meta</td>
                           
                         </tr>            <tr id="lib/outward.js__166" class="hit">
@@ -32284,7 +32091,7 @@
                         </tr>            <tr id="lib/outward.js__176" class="hit">
                           <td class="line" data-tooltip>176</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  if (parent_meta) {</td>
                           
                         </tr>            <tr id="lib/outward.js__177" class="hit">
@@ -32344,13 +32151,13 @@
                         </tr>            <tr id="lib/outward.js__186" class="hit">
                           <td class="line" data-tooltip>186</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__187" class="hit">
                           <td class="line" data-tooltip>187</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var reply_meta &#x3D; data.reply_meta</td>
                           
                         </tr>            <tr id="lib/outward.js__188" class="hit">
@@ -32398,19 +32205,19 @@
                         </tr>            <tr id="lib/outward.js__195" class="hit">
                           <td class="line" data-tooltip>195</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var delegate &#x3D; ctxt.seneca</td>
                           
                         </tr>            <tr id="lib/outward.js__196" class="hit">
                           <td class="line" data-tooltip>196</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var actdef &#x3D; ctxt.actdef</td>
                           
                         </tr>            <tr id="lib/outward.js__197" class="hit">
                           <td class="line" data-tooltip>197</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__198" class="hit">
@@ -32422,13 +32229,13 @@
                         </tr>            <tr id="lib/outward.js__199" class="hit">
                           <td class="line" data-tooltip>199</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  if (meta.error) {</td>
                           
                         </tr>            <tr id="lib/outward.js__200" class="hit">
                           <td class="line" data-tooltip>200</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">    data.error_desc &#x3D; intern.act_error(delegate, ctxt, data)</td>
                           
                         </tr>            <tr id="lib/outward.js__201" class="hit">
@@ -32440,7 +32247,7 @@
                         </tr>            <tr id="lib/outward.js__202" class="hit">
                           <td class="line" data-tooltip>202</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">    if (meta.fatal) {</td>
                           
                         </tr>            <tr id="lib/outward.js__203" class="hit">
@@ -32452,7 +32259,7 @@
                         </tr>            <tr id="lib/outward.js__204" class="hit">
                           <td class="line" data-tooltip>204</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
+                          <td class="hits" data-tooltip>5</td>
                           <td class="source">      return delegate.die(data.error_desc.err)</td>
                           
                         </tr>            <tr id="lib/outward.js__205" class="hit">
@@ -32584,7 +32391,7 @@
                         </tr>            <tr id="lib/outward.js__226" class="hit">
                           <td class="line" data-tooltip>226</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var delegate &#x3D; ctxt.seneca</td>
                           
                         </tr>            <tr id="lib/outward.js__227" class="chunks">
@@ -32626,13 +32433,13 @@
                         </tr>            <tr id="lib/outward.js__233" class="hit">
                           <td class="line" data-tooltip>233</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__234" class="hit">
                           <td class="line" data-tooltip>234</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  var private$ &#x3D; ctxt.seneca.private$</td>
                           
                         </tr>            <tr id="lib/outward.js__235" class="hit">
@@ -32650,7 +32457,7 @@
                         </tr>            <tr id="lib/outward.js__237" class="hit">
                           <td class="line" data-tooltip>237</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2824</td>
+                          <td class="hits" data-tooltip>2820</td>
                           <td class="source">  if (meta.prior) {</td>
                           
                         </tr>            <tr id="lib/outward.js__238" class="hit">
@@ -32674,7 +32481,7 @@
                         </tr>            <tr id="lib/outward.js__241" class="hit">
                           <td class="line" data-tooltip>241</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2721</td>
+                          <td class="hits" data-tooltip>2717</td>
                           <td class="source">  var submsg &#x3D; ctxt.seneca.util.clean(data.msg)</td>
                           
                         </tr>            <tr id="lib/outward.js__242" class="hit">
@@ -32698,7 +32505,7 @@
                         </tr>            <tr id="lib/outward.js__245" class="hit">
                           <td class="line" data-tooltip>245</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2721</td>
+                          <td class="hits" data-tooltip>2717</td>
                           <td class="source">  var sub_actions_list &#x3D; private$.subrouter.outward.find(submsg, false, true)</td>
                           
                         </tr>            <tr id="lib/outward.js__246" class="hit">
@@ -32710,7 +32517,7 @@
                         </tr>            <tr id="lib/outward.js__247" class="hit">
                           <td class="line" data-tooltip>247</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2721</td>
+                          <td class="hits" data-tooltip>2717</td>
                           <td class="source">  submsg.out$ &#x3D; true</td>
                           
                         </tr>            <tr id="lib/outward.js__248" class="hit">
@@ -32740,7 +32547,7 @@
                         </tr>            <tr id="lib/outward.js__252" class="hit">
                           <td class="line" data-tooltip>252</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2721</td>
+                          <td class="hits" data-tooltip>2717</td>
                           <td class="source">  for (var alI &#x3D; 0; alI &lt; sub_actions_list.length; alI++) {</td>
                           
                         </tr>            <tr id="lib/outward.js__253" class="hit">
@@ -32866,25 +32673,25 @@
                         </tr>            <tr id="lib/outward.js__273" class="hit">
                           <td class="line" data-tooltip>273</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  var act_callpoint &#x3D; ctxt.callpoint</td>
                           
                         </tr>            <tr id="lib/outward.js__274" class="hit">
                           <td class="line" data-tooltip>274</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  var actdef &#x3D; ctxt.actdef || {}</td>
                           
                         </tr>            <tr id="lib/outward.js__275" class="hit">
                           <td class="line" data-tooltip>275</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  var origmsg &#x3D; ctxt.origmsg</td>
                           
                         </tr>            <tr id="lib/outward.js__276" class="hit">
                           <td class="line" data-tooltip>276</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  var reply &#x3D; ctxt.reply</td>
                           
                         </tr>            <tr id="lib/outward.js__277" class="hit">
@@ -32896,13 +32703,13 @@
                         </tr>            <tr id="lib/outward.js__278" class="hit">
                           <td class="line" data-tooltip>278</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  var meta &#x3D; data.meta</td>
                           
                         </tr>            <tr id="lib/outward.js__279" class="hit">
                           <td class="line" data-tooltip>279</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  var msg &#x3D; data.msg</td>
                           
                         </tr>            <tr id="lib/outward.js__280" class="hit">
@@ -32914,7 +32721,7 @@
                         </tr>            <tr id="lib/outward.js__281" class="hit">
                           <td class="line" data-tooltip>281</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  var opts &#x3D; instance.options()</td>
                           
                         </tr>            <tr id="lib/outward.js__282" class="hit">
@@ -32926,7 +32733,7 @@
                         </tr>            <tr id="lib/outward.js__283" class="hit">
                           <td class="line" data-tooltip>283</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  var call_cb &#x3D; true</td>
                           
                         </tr>            <tr id="lib/outward.js__284" class="hit">
@@ -32950,7 +32757,7 @@
                         </tr>            <tr id="lib/outward.js__287" class="hit">
                           <td class="line" data-tooltip>287</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  if (!err.seneca) {</td>
                           
                         </tr>            <tr id="lib/outward.js__288" class="hit">
@@ -33142,7 +32949,7 @@
                         </tr>            <tr id="lib/outward.js__319" class="hit">
                           <td class="line" data-tooltip>319</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
+                          <td class="hits" data-tooltip>43</td>
                           <td class="source">  } else if (</td>
                           
                         </tr>            <tr id="lib/outward.js__320" class="hit">
@@ -33196,7 +33003,7 @@
                         </tr>            <tr id="lib/outward.js__328" class="hit">
                           <td class="line" data-tooltip>328</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  if (opts.legacy.error) {</td>
                           
                         </tr>            <tr id="lib/outward.js__329" class="chunks">
@@ -33208,7 +33015,7 @@
                         </tr>            <tr id="lib/outward.js__330" class="hit">
                           <td class="line" data-tooltip>330</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>61</td>
+                          <td class="hits" data-tooltip>58</td>
                           <td class="source">    err.details.plugin &#x3D; err.details.plugin || {}</td>
                           
                         </tr>            <tr id="lib/outward.js__331" class="hit">
@@ -33226,7 +33033,7 @@
                         </tr>            <tr id="lib/outward.js__333" class="hit">
                           <td class="line" data-tooltip>333</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  var entry &#x3D; ctxt.actlog(actdef, msg, meta, origmsg, {</td>
                           
                         </tr>            <tr id="lib/outward.js__334" class="hit">
@@ -33262,7 +33069,7 @@
                         </tr>            <tr id="lib/outward.js__339" class="hit">
                           <td class="line" data-tooltip>339</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  entry &#x3D; ctxt.errlog(err, entry)</td>
                           
                         </tr>            <tr id="lib/outward.js__340" class="hit">
@@ -33274,13 +33081,13 @@
                         </tr>            <tr id="lib/outward.js__341" class="hit">
                           <td class="line" data-tooltip>341</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  instance.log.error(entry)</td>
                           
                         </tr>            <tr id="lib/outward.js__342" class="hit">
                           <td class="line" data-tooltip>342</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  instance.emit(&#x27;act-err&#x27;, msg, err)</td>
                           
                         </tr>            <tr id="lib/outward.js__343" class="hit">
@@ -33322,7 +33129,7 @@
                         </tr>            <tr id="lib/outward.js__349" class="hit">
                           <td class="line" data-tooltip>349</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
+                          <td class="hits" data-tooltip>86</td>
                           <td class="source">  return {</td>
                           
                         </tr>            <tr id="lib/outward.js__350" class="hit">
@@ -38278,7 +38085,7 @@
                         </tr>            <tr id="lib/ready.js__48" class="hit">
                           <td class="line" data-tooltip>48</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>604</td>
+                          <td class="hits" data-tooltip>609</td>
                           <td class="source">        execute_ready(self, ready_call)</td>
                           
                         </tr>            <tr id="lib/ready.js__49" class="hit">
@@ -38290,7 +38097,7 @@
                         </tr>            <tr id="lib/ready.js__50" class="hit">
                           <td class="line" data-tooltip>50</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>29</td>
+                          <td class="hits" data-tooltip>24</td>
                           <td class="source">        private$.ready_list.push(ready_call)</td>
                           
                         </tr>            <tr id="lib/ready.js__51" class="hit">
@@ -38344,13 +38151,13 @@
                         </tr>            <tr id="lib/ready.js__59" class="hit">
                           <td class="line" data-tooltip>59</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>546</td>
+                          <td class="hits" data-tooltip>543</td>
                           <td class="source">  const root &#x3D; this</td>
                           
                         </tr>            <tr id="lib/ready.js__60" class="hit">
                           <td class="line" data-tooltip>60</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>546</td>
+                          <td class="hits" data-tooltip>543</td>
                           <td class="source">  var private$ &#x3D; root.private$</td>
                           
                         </tr>            <tr id="lib/ready.js__61" class="hit">
@@ -38362,13 +38169,13 @@
                         </tr>            <tr id="lib/ready.js__62" class="hit">
                           <td class="line" data-tooltip>62</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>546</td>
+                          <td class="hits" data-tooltip>543</td>
                           <td class="source">  root.emit(&#x27;ready&#x27;)</td>
                           
                         </tr>            <tr id="lib/ready.js__63" class="hit">
                           <td class="line" data-tooltip>63</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>546</td>
+                          <td class="hits" data-tooltip>543</td>
                           <td class="source">  execute_ready(root, private$.ready_list.shift())</td>
                           
                         </tr>            <tr id="lib/ready.js__64" class="hit">
@@ -38380,13 +38187,13 @@
                         </tr>            <tr id="lib/ready.js__65" class="hit">
                           <td class="line" data-tooltip>65</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>546</td>
+                          <td class="hits" data-tooltip>543</td>
                           <td class="source">  if (private$.ge.isclear()) {</td>
                           
                         </tr>            <tr id="lib/ready.js__66" class="hit">
                           <td class="line" data-tooltip>66</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>545</td>
+                          <td class="hits" data-tooltip>542</td>
                           <td class="source">    while (0 &lt; private$.ready_list.length) {</td>
                           
                         </tr>            <tr id="lib/ready.js__67" class="hit">
@@ -38428,13 +38235,13 @@
                         </tr>            <tr id="lib/ready.js__73" class="hit">
                           <td class="line" data-tooltip>73</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1675</td>
+                          <td class="hits" data-tooltip>1683</td>
                           <td class="source">  if (null &#x3D;&#x3D; ready_func) return</td>
                           
                         </tr>            <tr id="lib/ready.js__74" class="hit">
                           <td class="line" data-tooltip>74</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>629</td>
+                          <td class="hits" data-tooltip>625</td>
                           <td class="source">  var opts &#x3D; instance.options()</td>
                           
                         </tr>            <tr id="lib/ready.js__75" class="hit">
@@ -38446,19 +38253,19 @@
                         </tr>            <tr id="lib/ready.js__76" class="hit">
                           <td class="line" data-tooltip>76</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>629</td>
+                          <td class="hits" data-tooltip>625</td>
                           <td class="source">  try {</td>
                           
                         </tr>            <tr id="lib/ready.js__77" class="hit">
                           <td class="line" data-tooltip>77</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>629</td>
+                          <td class="hits" data-tooltip>625</td>
                           <td class="source">    instance.log.debug({ kind: &#x27;ready&#x27;, case: &#x27;call&#x27;, name: ready_func.name })</td>
                           
                         </tr>            <tr id="lib/ready.js__78" class="hit">
                           <td class="line" data-tooltip>78</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>629</td>
+                          <td class="hits" data-tooltip>625</td>
                           <td class="source">    ready_func()</td>
                           
                         </tr>            <tr id="lib/ready.js__79" class="hit">

--- a/test/coverage.html
+++ b/test/coverage.html
@@ -552,7 +552,7 @@
             <a href="#lib/add.js"><span class="dirname">lib/</span><span class="basename">add.js</span></a>
         </li>
         <li class="">
-            <span class="cov high">92.42</span>
+            <span class="cov high">92.63</span>
             <a href="#lib/api.js"><span class="dirname">lib/</span><span class="basename">api.js</span></a>
         </li>
         <li class="">
@@ -611,7 +611,7 @@
           <div class="failures">0</div>
           <div class="skipped">0</div>
           <div class="test-count">351</div>
-          <div class="duration">42849</div>
+          <div class="duration">44338</div>
       </div>
       <div id="filters">
           <input type="checkbox" checked="" onchange="filter(this)" value="success" id="show-success">
@@ -728,56 +728,56 @@
               <td class="test-title">act make_actmsg
                   
               </td>
-              <td class="test-duration">8</td>
+              <td class="test-duration">12</td>
           </tr>
           <tr class="show act success">
               <td class="test-id">2</td>
               <td class="test-title">act process_outward
                   
               </td>
-              <td class="test-duration">60</td>
+              <td class="test-duration">78</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">3</td>
               <td class="test-title">actions cmd_ping
                   
               </td>
-              <td class="test-duration">256</td>
+              <td class="test-duration">259</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">4</td>
               <td class="test-title">actions cmd_stats
                   
               </td>
-              <td class="test-duration">43</td>
+              <td class="test-duration">48</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">5</td>
               <td class="test-title">actions cmd_close
                   
               </td>
-              <td class="test-duration">133</td>
+              <td class="test-duration">148</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">6</td>
               <td class="test-title">actions info_fatal
                   
               </td>
-              <td class="test-duration">134</td>
+              <td class="test-duration">142</td>
           </tr>
           <tr class="show actions success">
               <td class="test-id">7</td>
               <td class="test-title">actions get_options
                   
               </td>
-              <td class="test-duration">47</td>
+              <td class="test-duration">52</td>
           </tr>
           <tr class="show add success">
               <td class="test-id">8</td>
               <td class="test-title">add name
                   
               </td>
-              <td class="test-duration">40</td>
+              <td class="test-duration">26</td>
           </tr>
           <tr class="show add success">
               <td class="test-id">9</td>
@@ -798,84 +798,84 @@
               <td class="test-title">api list
                   
               </td>
-              <td class="test-duration">18</td>
+              <td class="test-duration">21</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">12</td>
               <td class="test-title">api translate
                   
               </td>
-              <td class="test-duration">137</td>
+              <td class="test-duration">150</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">13</td>
               <td class="test-title">api test-mode
                   
               </td>
-              <td class="test-duration">45</td>
+              <td class="test-duration">71</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">14</td>
               <td class="test-title">api find_plugin
                   
               </td>
-              <td class="test-duration">134</td>
+              <td class="test-duration">167</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">15</td>
               <td class="test-title">api has_plugin
                   
               </td>
-              <td class="test-duration">259</td>
+              <td class="test-duration">271</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">16</td>
               <td class="test-title">api ignore_plugin
                   
               </td>
-              <td class="test-duration">430</td>
+              <td class="test-duration">416</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">17</td>
               <td class="test-title">api has
                   
               </td>
-              <td class="test-duration">19</td>
+              <td class="test-duration">12</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">18</td>
               <td class="test-title">api find
                   
               </td>
-              <td class="test-duration">35</td>
+              <td class="test-duration">58</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">19</td>
               <td class="test-title">api status
                   
               </td>
-              <td class="test-duration">130</td>
+              <td class="test-duration">141</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">20</td>
               <td class="test-title">api reply
                   
               </td>
-              <td class="test-duration">39</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show api success">
               <td class="test-id">21</td>
               <td class="test-title">api delegate
                   
               </td>
-              <td class="test-duration">17</td>
+              <td class="test-duration">23</td>
           </tr>
           <tr class="show api fail success">
               <td class="test-id">22</td>
               <td class="test-title">api fail invoked with a code and details
                   
               </td>
-              <td class="test-duration">1</td>
+              <td class="test-duration">3</td>
           </tr>
           <tr class="show api fail invoked_with_a_condition,_code_and_details when_the_condition_is_true success">
               <td class="test-id">23</td>
@@ -903,14 +903,14 @@
               <td class="test-title">api fail when given no arguments throws a seneca error
                   
               </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">1</td>
           </tr>
           <tr class="show api fail when_given_too_many_arguments success">
               <td class="test-id">27</td>
               <td class="test-title">api fail when given too many arguments throws a seneca error
                   
               </td>
-              <td class="test-duration">1</td>
+              <td class="test-duration">2</td>
           </tr>
           <tr class="show close success">
               <td class="test-id">28</td>
@@ -924,84 +924,84 @@
               <td class="test-title">close add
                   
               </td>
-              <td class="test-duration">156</td>
+              <td class="test-duration">134</td>
           </tr>
           <tr class="show close success">
               <td class="test-id">30</td>
               <td class="test-title">close graceful
                   
               </td>
-              <td class="test-duration">263</td>
+              <td class="test-duration">252</td>
           </tr>
           <tr class="show close success">
               <td class="test-id">31</td>
               <td class="test-title">close timeout
                   
               </td>
-              <td class="test-duration">149</td>
+              <td class="test-duration">152</td>
           </tr>
           <tr class="show close success">
               <td class="test-id">32</td>
               <td class="test-title">close handle-signal
                   
               </td>
-              <td class="test-duration">154</td>
+              <td class="test-duration">145</td>
           </tr>
           <tr class="show close success">
               <td class="test-id">33</td>
               <td class="test-title">close error
                   
               </td>
-              <td class="test-duration">153</td>
+              <td class="test-duration">123</td>
           </tr>
           <tr class="show close success">
               <td class="test-id">34</td>
               <td class="test-title">close no-promise
                   
               </td>
-              <td class="test-duration">149</td>
+              <td class="test-duration">131</td>
           </tr>
           <tr class="show close success">
               <td class="test-id">35</td>
               <td class="test-title">close with-promise
                   
               </td>
-              <td class="test-duration">155</td>
+              <td class="test-duration">172</td>
           </tr>
           <tr class="show close success">
               <td class="test-id">36</td>
               <td class="test-title">close with-async-await
                   
               </td>
-              <td class="test-duration">149</td>
+              <td class="test-duration">132</td>
           </tr>
           <tr class="show common success">
               <td class="test-id">37</td>
               <td class="test-title">common misc
                   
               </td>
-              <td class="test-duration">27</td>
+              <td class="test-duration">12</td>
           </tr>
           <tr class="show common success">
               <td class="test-id">38</td>
               <td class="test-title">common deepextend-empty
                   
               </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">1</td>
           </tr>
           <tr class="show common success">
               <td class="test-id">39</td>
               <td class="test-title">common deepextend-dups
                   
               </td>
-              <td class="test-duration">0</td>
+              <td class="test-duration">1</td>
           </tr>
           <tr class="show common success">
               <td class="test-id">40</td>
               <td class="test-title">common deepextend-objs
                   
               </td>
-              <td class="test-duration">5</td>
+              <td class="test-duration">6</td>
           </tr>
           <tr class="show common success">
               <td class="test-id">41</td>
@@ -1043,609 +1043,609 @@
               <td class="test-title">common history
                   
               </td>
-              <td class="test-duration">6</td>
+              <td class="test-duration">9</td>
           </tr>
           <tr class="show common success">
               <td class="test-id">47</td>
               <td class="test-title">common clean
                   
               </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">4</td>
           </tr>
           <tr class="show common success">
               <td class="test-id">48</td>
               <td class="test-title">common parse_jsonic
                   
               </td>
-              <td class="test-duration">3</td>
+              <td class="test-duration">5</td>
           </tr>
           <tr class="show common success">
               <td class="test-id">49</td>
               <td class="test-title">common make_plugin_key
                   
               </td>
-              <td class="test-duration">6</td>
+              <td class="test-duration">8</td>
           </tr>
           <tr class="show custom success">
               <td class="test-id">50</td>
               <td class="test-title">custom custom-basic
                   
               </td>
-              <td class="test-duration">29</td>
+              <td class="test-duration">45</td>
           </tr>
           <tr class="show custom success">
               <td class="test-id">51</td>
               <td class="test-title">custom custom-deep
                   
               </td>
-              <td class="test-duration">167</td>
+              <td class="test-duration">151</td>
           </tr>
           <tr class="show custom success">
               <td class="test-id">52</td>
               <td class="test-title">custom custom-reply
                   
               </td>
-              <td class="test-duration">129</td>
+              <td class="test-duration">135</td>
           </tr>
           <tr class="show custom success">
               <td class="test-id">53</td>
               <td class="test-title">custom custom-entity
                   
               </td>
-              <td class="test-duration">171</td>
+              <td class="test-duration">220</td>
           </tr>
           <tr class="show custom success">
               <td class="test-id">54</td>
               <td class="test-title">custom custom-prior
                   
               </td>
-              <td class="test-duration">48</td>
+              <td class="test-duration">37</td>
           </tr>
           <tr class="show custom success">
               <td class="test-id">55</td>
               <td class="test-title">custom custom-simple-transport
                   
               </td>
-              <td class="test-duration">206</td>
+              <td class="test-duration">196</td>
           </tr>
           <tr class="show custom success">
               <td class="test-id">56</td>
               <td class="test-title">custom custom-bells-transport
                   
               </td>
-              <td class="test-duration">402</td>
+              <td class="test-duration">413</td>
           </tr>
           <tr class="show custom success">
               <td class="test-id">57</td>
               <td class="test-title">custom custom-add-basic
                   
               </td>
-              <td class="test-duration">160</td>
+              <td class="test-duration">182</td>
           </tr>
           <tr class="show custom success">
               <td class="test-id">58</td>
               <td class="test-title">custom custom-add-fix
                   
               </td>
-              <td class="test-duration">49</td>
+              <td class="test-duration">67</td>
           </tr>
           <tr class="show debug success">
               <td class="test-id">59</td>
               <td class="test-title">debug logroute
                   
               </td>
-              <td class="test-duration">12</td>
+              <td class="test-duration">13</td>
           </tr>
           <tr class="show delegation success">
               <td class="test-id">60</td>
               <td class="test-title">delegation happy
                   
               </td>
-              <td class="test-duration">169</td>
+              <td class="test-duration">155</td>
           </tr>
           <tr class="show delegation success">
               <td class="test-id">61</td>
               <td class="test-title">delegation dynamic
                   
               </td>
-              <td class="test-duration">182</td>
+              <td class="test-duration">244</td>
           </tr>
           <tr class="show delegation success">
               <td class="test-id">62</td>
               <td class="test-title">delegation prior.basic
                   
               </td>
-              <td class="test-duration">212</td>
+              <td class="test-duration">229</td>
           </tr>
           <tr class="show delegation success">
               <td class="test-id">63</td>
               <td class="test-title">delegation parent.plugin
                   
               </td>
-              <td class="test-duration">209</td>
+              <td class="test-duration">242</td>
           </tr>
           <tr class="show entity success">
               <td class="test-id">64</td>
               <td class="test-title">entity happy
                   
               </td>
-              <td class="test-duration">140</td>
+              <td class="test-duration">173</td>
           </tr>
           <tr class="show entity success">
               <td class="test-id">65</td>
               <td class="test-title">entity entity-msg
                   
               </td>
-              <td class="test-duration">143</td>
+              <td class="test-duration">139</td>
           </tr>
           <tr class="show entity success">
               <td class="test-id">66</td>
               <td class="test-title">entity mem-ops
                   
               </td>
-              <td class="test-duration">234</td>
+              <td class="test-duration">278</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">67</td>
               <td class="test-title">error fail
                   
               </td>
-              <td class="test-duration">66</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">68</td>
               <td class="test-title">error response_is_error
                   
               </td>
-              <td class="test-duration">41</td>
+              <td class="test-duration">34</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">69</td>
               <td class="test-title">error action_callback
                   
               </td>
-              <td class="test-duration">31</td>
+              <td class="test-duration">33</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">70</td>
               <td class="test-title">error plugin_load
                   
               </td>
-              <td class="test-duration">26</td>
+              <td class="test-duration">29</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">71</td>
               <td class="test-title">error act_not_found
                   
               </td>
-              <td class="test-duration">71</td>
+              <td class="test-duration">64</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">72</td>
               <td class="test-title">error exec_action_throw_basic
                   
               </td>
-              <td class="test-duration">31</td>
+              <td class="test-duration">30</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">73</td>
               <td class="test-title">error exec_action_throw_basic_legacy
                   
               </td>
-              <td class="test-duration">52</td>
+              <td class="test-duration">51</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">74</td>
               <td class="test-title">error exec_action_throw_nolog
                   
               </td>
-              <td class="test-duration">29</td>
+              <td class="test-duration">20</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">75</td>
               <td class="test-title">error exec_action_errhandler_throw
                   
               </td>
-              <td class="test-duration">89</td>
+              <td class="test-duration">60</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">76</td>
               <td class="test-title">error exec_action_result
                   
               </td>
-              <td class="test-duration">25</td>
+              <td class="test-duration">28</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">77</td>
               <td class="test-title">error exec_deep_action_result
                   
               </td>
-              <td class="test-duration">32</td>
+              <td class="test-duration">31</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">78</td>
               <td class="test-title">error exec_remote_action_result
                   
               </td>
-              <td class="test-duration">195</td>
+              <td class="test-duration">209</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">79</td>
               <td class="test-title">error exec_action_result_legacy
                   
               </td>
-              <td class="test-duration">71</td>
+              <td class="test-duration">52</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">80</td>
               <td class="test-title">error exec_action_result_nolog
                   
               </td>
-              <td class="test-duration">38</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">81</td>
               <td class="test-title">error exec_action_errhandler_result
                   
               </td>
-              <td class="test-duration">95</td>
+              <td class="test-duration">56</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">82</td>
               <td class="test-title">error action_callback
                   
               </td>
-              <td class="test-duration">214</td>
+              <td class="test-duration">186</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">83</td>
               <td class="test-title">error legacy_fail
                   
               </td>
-              <td class="test-duration">16</td>
+              <td class="test-duration">76</td>
           </tr>
           <tr class="show error success">
               <td class="test-id">84</td>
               <td class="test-title">error types
                   
               </td>
-              <td class="test-duration">40</td>
+              <td class="test-duration">47</td>
           </tr>
           <tr class="show explain success">
               <td class="test-id">85</td>
               <td class="test-title">explain explain-basic
                   
               </td>
-              <td class="test-duration">74</td>
+              <td class="test-duration">50</td>
           </tr>
           <tr class="show explain success">
               <td class="test-id">86</td>
               <td class="test-title">explain explain-data
                   
               </td>
-              <td class="test-duration">75</td>
+              <td class="test-duration">71</td>
           </tr>
           <tr class="show explain success">
               <td class="test-id">87</td>
               <td class="test-title">explain explain-deep
                   
               </td>
-              <td class="test-duration">81</td>
+              <td class="test-duration">48</td>
           </tr>
           <tr class="show explain success">
               <td class="test-id">88</td>
               <td class="test-title">explain explain-toplevel
                   
               </td>
-              <td class="test-duration">148</td>
+              <td class="test-duration">168</td>
           </tr>
           <tr class="show explain success">
               <td class="test-id">89</td>
               <td class="test-title">explain explain-transport
                   
               </td>
-              <td class="test-duration">330</td>
+              <td class="test-duration">378</td>
           </tr>
           <tr class="show exports success">
               <td class="test-id">90</td>
               <td class="test-title">exports happy
                   
               </td>
-              <td class="test-duration">135</td>
+              <td class="test-duration">201</td>
           </tr>
           <tr class="show exports success">
               <td class="test-id">91</td>
               <td class="test-title">exports with-init
                   
               </td>
-              <td class="test-duration">134</td>
+              <td class="test-duration">176</td>
           </tr>
           <tr class="show exports success">
               <td class="test-id">92</td>
               <td class="test-title">exports with-preload
                   
               </td>
-              <td class="test-duration">144</td>
+              <td class="test-duration">133</td>
           </tr>
           <tr class="show exports success">
               <td class="test-id">93</td>
               <td class="test-title">exports with-preload-and-init
                   
               </td>
-              <td class="test-duration">147</td>
+              <td class="test-duration">138</td>
           </tr>
           <tr class="show outward success">
               <td class="test-id">94</td>
               <td class="test-title">outward act_error
                   
               </td>
-              <td class="test-duration">1</td>
+              <td class="test-duration">0</td>
           </tr>
           <tr class="show inward success">
               <td class="test-id">95</td>
               <td class="test-title">inward announce
                   
               </td>
-              <td class="test-duration">135</td>
+              <td class="test-duration">126</td>
           </tr>
           <tr class="show inward success">
               <td class="test-id">96</td>
               <td class="test-title">inward arg-check
                   
               </td>
-              <td class="test-duration">3</td>
+              <td class="test-duration">2</td>
           </tr>
           <tr class="show legacy success">
               <td class="test-id">97</td>
               <td class="test-title">legacy fail
                   
               </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">3</td>
           </tr>
           <tr class="show legacy success">
               <td class="test-id">98</td>
               <td class="test-title">legacy argprops
                   
               </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">3</td>
           </tr>
           <tr class="show legacy success">
               <td class="test-id">99</td>
               <td class="test-title">legacy router
                   
               </td>
-              <td class="test-duration">0</td>
+              <td class="test-duration">1</td>
           </tr>
           <tr class="show legacy success">
               <td class="test-id">100</td>
               <td class="test-title">legacy no-default-transport
                   
               </td>
-              <td class="test-duration">123</td>
+              <td class="test-duration">122</td>
           </tr>
           <tr class="show legacy success">
               <td class="test-id">101</td>
               <td class="test-title">legacy actdef
                   
               </td>
-              <td class="test-duration">21</td>
+              <td class="test-duration">29</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">102</td>
               <td class="test-title">logging happy
                   
               </td>
-              <td class="test-duration">127</td>
+              <td class="test-duration">138</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">103</td>
               <td class="test-title">logging happy-ng
                   
               </td>
-              <td class="test-duration">128</td>
+              <td class="test-duration">159</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">104</td>
               <td class="test-title">logging level-text-values
                   
               </td>
-              <td class="test-duration">14</td>
+              <td class="test-duration">58</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">105</td>
               <td class="test-title">logging build_log_spec
                   
               </td>
-              <td class="test-duration">3</td>
+              <td class="test-duration">11</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">106</td>
               <td class="test-title">logging event
                   
               </td>
-              <td class="test-duration">127</td>
+              <td class="test-duration">160</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">107</td>
               <td class="test-title">logging quiet
                   
               </td>
-              <td class="test-duration">121</td>
+              <td class="test-duration">199</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">108</td>
               <td class="test-title">logging bad_logspec
                   
               </td>
-              <td class="test-duration">18</td>
+              <td class="test-duration">6</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">109</td>
               <td class="test-title">logging basic
                   
               </td>
-              <td class="test-duration">147</td>
+              <td class="test-duration">123</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">110</td>
               <td class="test-title">logging logger-output
                   
               </td>
-              <td class="test-duration">807</td>
+              <td class="test-duration">895</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">111</td>
               <td class="test-title">logging shortcuts
                   
               </td>
-              <td class="test-duration">1441</td>
+              <td class="test-duration">1788</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">112</td>
               <td class="test-title">logging test-mode-basic
                   
               </td>
-              <td class="test-duration">123</td>
+              <td class="test-duration">194</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">113</td>
               <td class="test-title">logging test-mode-option
                   
               </td>
-              <td class="test-duration">124</td>
+              <td class="test-duration">157</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">114</td>
               <td class="test-title">logging test-mode-argv
                   
               </td>
-              <td class="test-duration">131</td>
+              <td class="test-duration">197</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">115</td>
               <td class="test-title">logging test-mode-argv-opts
                   
               </td>
-              <td class="test-duration">181</td>
+              <td class="test-duration">184</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">116</td>
               <td class="test-title">logging test-mode-env
                   
               </td>
-              <td class="test-duration">134</td>
+              <td class="test-duration">156</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">117</td>
               <td class="test-title">logging quiet-mode-basic
                   
               </td>
-              <td class="test-duration">128</td>
+              <td class="test-duration">189</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">118</td>
               <td class="test-title">logging quiet-mode-option
                   
               </td>
-              <td class="test-duration">184</td>
+              <td class="test-duration">165</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">119</td>
               <td class="test-title">logging quiet-mode-argv
                   
               </td>
-              <td class="test-duration">140</td>
+              <td class="test-duration">183</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">120</td>
               <td class="test-title">logging quiet-mode-argv-opts
                   
               </td>
-              <td class="test-duration">140</td>
+              <td class="test-duration">153</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">121</td>
               <td class="test-title">logging quiet-mode-env
                   
               </td>
-              <td class="test-duration">183</td>
+              <td class="test-duration">197</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">122</td>
               <td class="test-title">logging test-quiet-mode-basic
                   
               </td>
-              <td class="test-duration">122</td>
+              <td class="test-duration">198</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">123</td>
               <td class="test-title">logging quiet-test-mode-basic
                   
               </td>
-              <td class="test-duration">131</td>
+              <td class="test-duration">155</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">124</td>
               <td class="test-title">logging test-ready-quiet-mode-basic
                   
               </td>
-              <td class="test-duration">241</td>
+              <td class="test-duration">309</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">125</td>
               <td class="test-title">logging quiet-ready-test-mode-basic
                   
               </td>
-              <td class="test-duration">251</td>
+              <td class="test-duration">288</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">126</td>
               <td class="test-title">logging quiet-argv-override
                   
               </td>
-              <td class="test-duration">143</td>
+              <td class="test-duration">135</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">127</td>
               <td class="test-title">logging test-argv-override
                   
               </td>
-              <td class="test-duration">131</td>
+              <td class="test-duration">132</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">128</td>
               <td class="test-title">logging quiet-env-override
                   
               </td>
-              <td class="test-duration">135</td>
+              <td class="test-duration">140</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">129</td>
               <td class="test-title">logging test-env-override
                   
               </td>
-              <td class="test-duration">134</td>
+              <td class="test-duration">136</td>
           </tr>
           <tr class="show logging success">
               <td class="test-id">130</td>
               <td class="test-title">logging intern.build_act_entry
                   
               </td>
-              <td class="test-duration">1</td>
+              <td class="test-duration">2</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">131</td>
               <td class="test-title">message happy-vanilla
                   
               </td>
-              <td class="test-duration">34</td>
+              <td class="test-duration">87</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">132</td>
               <td class="test-title">message happy-msg
                   
               </td>
-              <td class="test-duration">32</td>
+              <td class="test-duration">48</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">133</td>
@@ -1659,77 +1659,77 @@
               <td class="test-title">message branch
                   
               </td>
-              <td class="test-duration">45</td>
+              <td class="test-duration">70</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">135</td>
               <td class="test-title">message empty-response
                   
               </td>
-              <td class="test-duration">127</td>
+              <td class="test-duration">132</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">136</td>
               <td class="test-title">message reply
                   
               </td>
-              <td class="test-duration">175</td>
+              <td class="test-duration">184</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">137</td>
               <td class="test-title">message prior
                   
               </td>
-              <td class="test-duration">168</td>
+              <td class="test-duration">129</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">138</td>
               <td class="test-title">message entity
                   
               </td>
-              <td class="test-duration">49</td>
+              <td class="test-duration">62</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">139</td>
               <td class="test-title">message single-simple-transport
                   
               </td>
-              <td class="test-duration">157</td>
+              <td class="test-duration">170</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">140</td>
               <td class="test-title">message simple-transport
                   
               </td>
-              <td class="test-duration">684</td>
+              <td class="test-duration">688</td>
           </tr>
           <tr class="show message success">
               <td class="test-id">141</td>
               <td class="test-title">message partial-patterns
                   
               </td>
-              <td class="test-duration">165</td>
+              <td class="test-duration">178</td>
           </tr>
           <tr class="show meta success">
               <td class="test-id">142</td>
               <td class="test-title">meta custom-parents
                   
               </td>
-              <td class="test-duration">87</td>
+              <td class="test-duration">186</td>
           </tr>
           <tr class="show meta success">
               <td class="test-id">143</td>
               <td class="test-title">meta custom-priors
                   
               </td>
-              <td class="test-duration">42</td>
+              <td class="test-duration">99</td>
           </tr>
           <tr class="show meta success">
               <td class="test-id">144</td>
               <td class="test-title">meta custom-fixed
                   
               </td>
-              <td class="test-duration">23</td>
+              <td class="test-duration">26</td>
           </tr>
           <tr class="show options success">
               <td class="test-id">145</td>
@@ -1743,168 +1743,168 @@
               <td class="test-title">options internal.routers
                   
               </td>
-              <td class="test-duration">13</td>
+              <td class="test-duration">14</td>
           </tr>
           <tr class="show order success">
               <td class="test-id">147</td>
               <td class="test-title">order happy
                   
               </td>
-              <td class="test-duration">267</td>
+              <td class="test-duration">252</td>
           </tr>
           <tr class="show outward success">
               <td class="test-id">148</td>
               <td class="test-title">outward make_error
                   
               </td>
-              <td class="test-duration">6</td>
+              <td class="test-duration">5</td>
           </tr>
           <tr class="show outward success">
               <td class="test-id">149</td>
               <td class="test-title">outward act_stats
                   
               </td>
-              <td class="test-duration">3</td>
+              <td class="test-duration">2</td>
           </tr>
           <tr class="show outward success">
               <td class="test-id">150</td>
               <td class="test-title">outward arg-check
                   
               </td>
-              <td class="test-duration">6</td>
+              <td class="test-duration">8</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">151</td>
               <td class="test-title">plugin use.intern
                   
               </td>
-              <td class="test-duration">73</td>
+              <td class="test-duration">87</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">152</td>
               <td class="test-title">plugin plugin-edges
                   
               </td>
-              <td class="test-duration">26</td>
+              <td class="test-duration">35</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">153</td>
               <td class="test-title">plugin plugin-internal-ordu
                   
               </td>
-              <td class="test-duration">22</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">154</td>
               <td class="test-title">plugin standard-test-plugin
                   
               </td>
-              <td class="test-duration">214</td>
+              <td class="test-duration">152</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">155</td>
               <td class="test-title">plugin standard-test-plugin-full-ignore
                   
               </td>
-              <td class="test-duration">306</td>
+              <td class="test-duration">299</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">156</td>
               <td class="test-title">plugin plugin-ignore-via-options
                   
               </td>
-              <td class="test-duration">133</td>
+              <td class="test-duration">193</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">157</td>
               <td class="test-title">plugin plugin-ignore-null
                   
               </td>
-              <td class="test-duration">143</td>
+              <td class="test-duration">194</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">158</td>
               <td class="test-title">plugin plugin-delegate-init
                   
               </td>
-              <td class="test-duration">136</td>
+              <td class="test-duration">130</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">159</td>
               <td class="test-title">plugin load-defaults
                   
               </td>
-              <td class="test-duration">184</td>
+              <td class="test-duration">187</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">160</td>
               <td class="test-title">plugin load-relative-to-root
                   
               </td>
-              <td class="test-duration">144</td>
+              <td class="test-duration">140</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">161</td>
               <td class="test-title">plugin good-default-options
                   
               </td>
-              <td class="test-duration">180</td>
+              <td class="test-duration">164</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">162</td>
               <td class="test-title">plugin bad-default-options
                   
               </td>
-              <td class="test-duration">77</td>
+              <td class="test-duration">20</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">163</td>
               <td class="test-title">plugin legacy-options
                   
               </td>
-              <td class="test-duration">16</td>
+              <td class="test-duration">13</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">164</td>
               <td class="test-title">plugin should return &quot;no errors created.&quot; when passing test false
                   
               </td>
-              <td class="test-duration">442</td>
+              <td class="test-duration">421</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">165</td>
               <td class="test-title">plugin should return &quot;error caught!&quot; when passing test true
                   
               </td>
-              <td class="test-duration">442</td>
+              <td class="test-duration">398</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">166</td>
               <td class="test-title">plugin works with exportmap
                   
               </td>
-              <td class="test-duration">131</td>
+              <td class="test-duration">153</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">167</td>
               <td class="test-title">plugin bad
                   
               </td>
-              <td class="test-duration">141</td>
+              <td class="test-duration">217</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">168</td>
               <td class="test-title">plugin plugin-error-def
                   
               </td>
-              <td class="test-duration">52</td>
+              <td class="test-duration">76</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">169</td>
               <td class="test-title">plugin plugin-error-deprecated
                   
               </td>
-              <td class="test-duration">18</td>
+              <td class="test-duration">21</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">170</td>
@@ -1918,21 +1918,21 @@
               <td class="test-title">plugin plugin-error-act
                   
               </td>
-              <td class="test-duration">21</td>
+              <td class="test-duration">29</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">172</td>
               <td class="test-title">plugin depends
                   
               </td>
-              <td class="test-duration">150</td>
+              <td class="test-duration">143</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">173</td>
               <td class="test-title">plugin plugin-fix
                   
               </td>
-              <td class="test-duration">192</td>
+              <td class="test-duration">197</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">174</td>
@@ -1946,168 +1946,168 @@
               <td class="test-title">plugin handles plugin with action that timesout
                   
               </td>
-              <td class="test-duration">246</td>
+              <td class="test-duration">247</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">176</td>
               <td class="test-title">plugin handles plugin action that throws an error
                   
               </td>
-              <td class="test-duration">176</td>
+              <td class="test-duration">178</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">177</td>
               <td class="test-title">plugin calling act from init actor is deprecated
                   
               </td>
-              <td class="test-duration">117</td>
+              <td class="test-duration">42</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">178</td>
               <td class="test-title">plugin plugin actions receive errors in callback function
                   
               </td>
-              <td class="test-duration">178</td>
+              <td class="test-duration">148</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">179</td>
               <td class="test-title">plugin dynamic-load-sequence
                   
               </td>
-              <td class="test-duration">379</td>
+              <td class="test-duration">401</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">180</td>
               <td class="test-title">plugin serial-load-sequence
                   
               </td>
-              <td class="test-duration">139</td>
+              <td class="test-duration">144</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">181</td>
               <td class="test-title">plugin plugin options can be modified by plugins during load sequence
                   
               </td>
-              <td class="test-duration">128</td>
+              <td class="test-duration">148</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">182</td>
               <td class="test-title">plugin plugin options can be modified by plugins during init sequence
                   
               </td>
-              <td class="test-duration">140</td>
+              <td class="test-duration">151</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">183</td>
               <td class="test-title">plugin plugin init can add actions for future init actions to call
                   
               </td>
-              <td class="test-duration">149</td>
+              <td class="test-duration">152</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">184</td>
               <td class="test-title">plugin plugin-init-error
                   
               </td>
-              <td class="test-duration">39</td>
+              <td class="test-duration">60</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">185</td>
               <td class="test-title">plugin plugin-extend-action-modifier
                   
               </td>
-              <td class="test-duration">148</td>
+              <td class="test-duration">170</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">186</td>
               <td class="test-title">plugin plugin-extend-logger
                   
               </td>
-              <td class="test-duration">125</td>
+              <td class="test-duration">138</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">187</td>
               <td class="test-title">plugin plugins-from-options
                   
               </td>
-              <td class="test-duration">136</td>
+              <td class="test-duration">158</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">188</td>
               <td class="test-title">plugin plugins-from-bad-options
                   
               </td>
-              <td class="test-duration">25</td>
+              <td class="test-duration">71</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">189</td>
               <td class="test-title">plugin plugins-options-precedence
                   
               </td>
-              <td class="test-duration">139</td>
+              <td class="test-duration">158</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">190</td>
               <td class="test-title">plugin error-plugin-define
                   
               </td>
-              <td class="test-duration">43</td>
+              <td class="test-duration">82</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">191</td>
               <td class="test-title">plugin error-plugin-init
                   
               </td>
-              <td class="test-duration">41</td>
+              <td class="test-duration">34</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">192</td>
               <td class="test-title">plugin error-plugin-action
                   
               </td>
-              <td class="test-duration">42</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">193</td>
               <td class="test-title">plugin no-name
                   
               </td>
-              <td class="test-duration">134</td>
+              <td class="test-duration">140</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">194</td>
               <td class="test-title">plugin seneca-prefix-wins
                   
               </td>
-              <td class="test-duration">134</td>
+              <td class="test-duration">194</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">195</td>
               <td class="test-title">plugin plugin-defaults-top-level-joi
                   
               </td>
-              <td class="test-duration">186</td>
+              <td class="test-duration">199</td>
           </tr>
           <tr class="show plugin success">
               <td class="test-id">196</td>
               <td class="test-title">plugin plugin-order-task-args
                   
               </td>
-              <td class="test-duration">15</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show print success">
               <td class="test-id">197</td>
               <td class="test-title">print init
                   
               </td>
-              <td class="test-duration">13</td>
+              <td class="test-duration">29</td>
           </tr>
           <tr class="show print success">
               <td class="test-id">198</td>
               <td class="test-title">print options
                   
               </td>
-              <td class="test-duration">15</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show print success">
               <td class="test-id">199</td>
@@ -2121,21 +2121,21 @@
               <td class="test-title">print custom-print
                   
               </td>
-              <td class="test-duration">18</td>
+              <td class="test-duration">23</td>
           </tr>
           <tr class="show prior success">
               <td class="test-id">201</td>
               <td class="test-title">prior happy
                   
               </td>
-              <td class="test-duration">24</td>
+              <td class="test-duration">39</td>
           </tr>
           <tr class="show prior success">
               <td class="test-id">202</td>
               <td class="test-title">prior top-level
                   
               </td>
-              <td class="test-duration">9</td>
+              <td class="test-duration">15</td>
           </tr>
           <tr class="show prior success">
               <td class="test-id">203</td>
@@ -2156,161 +2156,161 @@
               <td class="test-title">prior add-specific-to-general
                   
               </td>
-              <td class="test-duration">16</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show prior success">
               <td class="test-id">206</td>
               <td class="test-title">prior add-strict-specific-to-general
                   
               </td>
-              <td class="test-duration">15</td>
+              <td class="test-duration">23</td>
           </tr>
           <tr class="show prior success">
               <td class="test-id">207</td>
               <td class="test-title">prior add-general-to-specific-alpha
                   
               </td>
-              <td class="test-duration">21</td>
+              <td class="test-duration">22</td>
           </tr>
           <tr class="show prior success">
               <td class="test-id">208</td>
               <td class="test-title">prior add-general-to-specific-reverse-alpha
                   
               </td>
-              <td class="test-duration">23</td>
+              <td class="test-duration">27</td>
           </tr>
           <tr class="show prior success">
               <td class="test-id">209</td>
               <td class="test-title">prior add-strict-default
                   
               </td>
-              <td class="test-duration">21</td>
+              <td class="test-duration">32</td>
           </tr>
           <tr class="show prior success">
               <td class="test-id">210</td>
               <td class="test-title">prior add-strict-true
                   
               </td>
-              <td class="test-duration">18</td>
+              <td class="test-duration">23</td>
           </tr>
           <tr class="show private success">
               <td class="test-id">211</td>
               <td class="test-title">private exit_close
                   
               </td>
-              <td class="test-duration">399</td>
+              <td class="test-duration">452</td>
           </tr>
           <tr class="show ready success">
               <td class="test-id">212</td>
               <td class="test-title">ready ready_die
                   
               </td>
-              <td class="test-duration">122</td>
+              <td class="test-duration">123</td>
           </tr>
           <tr class="show ready success">
               <td class="test-id">213</td>
               <td class="test-title">ready ready_die_no_errhandler
                   
               </td>
-              <td class="test-duration">152</td>
+              <td class="test-duration">164</td>
           </tr>
           <tr class="show ready success">
               <td class="test-id">214</td>
               <td class="test-title">ready ready_null_name
                   
               </td>
-              <td class="test-duration">153</td>
+              <td class="test-duration">131</td>
           </tr>
           <tr class="show ready success">
               <td class="test-id">215</td>
               <td class="test-title">ready ready-complex
                   
               </td>
-              <td class="test-duration">369</td>
+              <td class="test-duration">291</td>
           </tr>
           <tr class="show ready success">
               <td class="test-id">216</td>
               <td class="test-title">ready ready-always-called
                   
               </td>
-              <td class="test-duration">235</td>
+              <td class="test-duration">238</td>
           </tr>
           <tr class="show ready success">
               <td class="test-id">217</td>
               <td class="test-title">ready ready-error-test
                   
               </td>
-              <td class="test-duration">159</td>
+              <td class="test-duration">140</td>
           </tr>
           <tr class="show ready success">
               <td class="test-id">218</td>
               <td class="test-title">ready ready-event
                   
               </td>
-              <td class="test-duration">77</td>
+              <td class="test-duration">74</td>
           </tr>
           <tr class="show ready success">
               <td class="test-id">219</td>
               <td class="test-title">ready ready-both
                   
               </td>
-              <td class="test-duration">142</td>
+              <td class="test-duration">126</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
               <td class="test-id">220</td>
               <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log&#x3D;level:warn
                   
               </td>
-              <td class="test-duration">36</td>
+              <td class="test-duration">35</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
               <td class="test-id">221</td>
               <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log&#x3D;level:warn+
                   
               </td>
-              <td class="test-duration">15</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
               <td class="test-id">222</td>
               <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log.level.warn
                   
               </td>
-              <td class="test-duration">36</td>
+              <td class="test-duration">23</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
               <td class="test-id">223</td>
               <td class="test-title">seneca --seneca.log arguments tests:  --seneca.log.level.warn+
                   
               </td>
-              <td class="test-duration">29</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
               <td class="test-id">224</td>
               <td class="test-title">seneca --seneca.log arguments tests:  duplicate param --seneca.log
                   
               </td>
-              <td class="test-duration">26</td>
+              <td class="test-duration">20</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
               <td class="test-id">225</td>
               <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log&#x3D;level:
                   
               </td>
-              <td class="test-duration">16</td>
+              <td class="test-duration">15</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
               <td class="test-id">226</td>
               <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log.level.abc
                   
               </td>
-              <td class="test-duration">17</td>
+              <td class="test-duration">14</td>
           </tr>
           <tr class="show seneca_--seneca.log_arguments_tests:_ success">
               <td class="test-id">227</td>
               <td class="test-title">seneca --seneca.log arguments tests:  incorrect arg --seneca.log.abc
                   
               </td>
-              <td class="test-duration">12</td>
+              <td class="test-duration">9</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">228</td>
@@ -2324,553 +2324,553 @@
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.silent
                   
               </td>
-              <td class="test-duration">15</td>
+              <td class="test-duration">17</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">230</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.all
                   
               </td>
-              <td class="test-duration">19</td>
+              <td class="test-duration">21</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">231</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.any
                   
               </td>
-              <td class="test-duration">17</td>
+              <td class="test-duration">14</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">232</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.print
                   
               </td>
-              <td class="test-duration">22</td>
+              <td class="test-duration">20</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">233</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.test
                   
               </td>
-              <td class="test-duration">22</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">234</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.standard
                   
               </td>
-              <td class="test-duration">24</td>
+              <td class="test-duration">30</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">235</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.quiet
                   
               </td>
-              <td class="test-duration">22</td>
+              <td class="test-duration">14</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">236</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.silent
                   
               </td>
-              <td class="test-duration">29</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">237</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.all
                   
               </td>
-              <td class="test-duration">26</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">238</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.any
                   
               </td>
-              <td class="test-duration">20</td>
+              <td class="test-duration">21</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">239</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.print
                   
               </td>
-              <td class="test-duration">22</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">240</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.test
                   
               </td>
-              <td class="test-duration">28</td>
+              <td class="test-duration">17</td>
           </tr>
           <tr class="show seneca_--seneca.log_aliases_tests:_ success">
               <td class="test-id">241</td>
               <td class="test-title">seneca --seneca.log aliases tests:  --seneca.log.level.standard
                   
               </td>
-              <td class="test-duration">21</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">242</td>
               <td class="test-title">seneca happy
                   
               </td>
-              <td class="test-duration">42</td>
+              <td class="test-duration">39</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">243</td>
               <td class="test-title">seneca require-abbrev
                   
               </td>
-              <td class="test-duration">254</td>
+              <td class="test-duration">248</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">244</td>
               <td class="test-title">seneca version
                   
               </td>
-              <td class="test-duration">21</td>
+              <td class="test-duration">39</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">245</td>
               <td class="test-title">seneca tag
                   
               </td>
-              <td class="test-duration">29</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">246</td>
               <td class="test-title">seneca json-inspect
                   
               </td>
-              <td class="test-duration">42</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">247</td>
               <td class="test-title">seneca quick
                   
               </td>
-              <td class="test-duration">61</td>
+              <td class="test-duration">32</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">248</td>
               <td class="test-title">seneca happy-error
                   
               </td>
-              <td class="test-duration">24</td>
+              <td class="test-duration">14</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">249</td>
               <td class="test-title">seneca errhandler
                   
               </td>
-              <td class="test-duration">121</td>
+              <td class="test-duration">115</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">250</td>
               <td class="test-title">seneca action-basic
                   
               </td>
-              <td class="test-duration">62</td>
+              <td class="test-duration">26</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">251</td>
               <td class="test-title">seneca action-callback-instance
                   
               </td>
-              <td class="test-duration">28</td>
+              <td class="test-duration">15</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">252</td>
               <td class="test-title">seneca action-act-invalid-args
                   
               </td>
-              <td class="test-duration">29</td>
+              <td class="test-duration">15</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">253</td>
               <td class="test-title">seneca action-default
                   
               </td>
-              <td class="test-duration">35</td>
+              <td class="test-duration">20</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">254</td>
               <td class="test-title">seneca action-override
                   
               </td>
-              <td class="test-duration">133</td>
+              <td class="test-duration">149</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">255</td>
               <td class="test-title">seneca action-callback-args
                   
               </td>
-              <td class="test-duration">23</td>
+              <td class="test-duration">24</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">256</td>
               <td class="test-title">seneca action-extend
                   
               </td>
-              <td class="test-duration">170</td>
+              <td class="test-duration">153</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">257</td>
               <td class="test-title">seneca prior-nocache
                   
               </td>
-              <td class="test-duration">379</td>
+              <td class="test-duration">360</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">258</td>
               <td class="test-title">seneca gating
                   
               </td>
-              <td class="test-duration">195</td>
+              <td class="test-duration">146</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">259</td>
               <td class="test-title">seneca act_if
                   
               </td>
-              <td class="test-duration">118</td>
+              <td class="test-duration">82</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">260</td>
               <td class="test-title">seneca loading-plugins
                   
               </td>
-              <td class="test-duration">163</td>
+              <td class="test-duration">213</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">261</td>
               <td class="test-title">seneca fire-and-forget
                   
               </td>
-              <td class="test-duration">19</td>
+              <td class="test-duration">17</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">262</td>
               <td class="test-title">seneca strargs
                   
               </td>
-              <td class="test-duration">90</td>
+              <td class="test-duration">88</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">263</td>
               <td class="test-title">seneca string-add
                   
               </td>
-              <td class="test-duration">22</td>
+              <td class="test-duration">29</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">264</td>
               <td class="test-title">seneca fix-basic
                   
               </td>
-              <td class="test-duration">10</td>
+              <td class="test-duration">9</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">265</td>
               <td class="test-title">seneca act-history
                   
               </td>
-              <td class="test-duration">59</td>
+              <td class="test-duration">56</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">266</td>
               <td class="test-title">seneca wrap
                   
               </td>
-              <td class="test-duration">53</td>
+              <td class="test-duration">60</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">267</td>
               <td class="test-title">seneca meta
                   
               </td>
-              <td class="test-duration">25</td>
+              <td class="test-duration">43</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">268</td>
               <td class="test-title">seneca strict-result
                   
               </td>
-              <td class="test-duration">11</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">269</td>
               <td class="test-title">seneca add-noop
                   
               </td>
-              <td class="test-duration">16</td>
+              <td class="test-duration">25</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">270</td>
               <td class="test-title">seneca supports jsonic params to has
                   
               </td>
-              <td class="test-duration">13</td>
+              <td class="test-duration">15</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">271</td>
               <td class="test-title">seneca supports a function to trace actions
                   
               </td>
-              <td class="test-duration">29</td>
+              <td class="test-duration">48</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">272</td>
               <td class="test-title">seneca supports true to be passed as trace action option
                   
               </td>
-              <td class="test-duration">25</td>
+              <td class="test-duration">15</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">273</td>
               <td class="test-title">seneca strict-find-false
                   
               </td>
-              <td class="test-duration">24</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">274</td>
               <td class="test-title">seneca strict-find-true
                   
               </td>
-              <td class="test-duration">18</td>
+              <td class="test-duration">14</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">275</td>
               <td class="test-title">seneca strict-find-default
                   
               </td>
-              <td class="test-duration">24</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">276</td>
               <td class="test-title">seneca catchall-pattern
                   
               </td>
-              <td class="test-duration">129</td>
+              <td class="test-duration">121</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">277</td>
               <td class="test-title">seneca memory
                   
               </td>
-              <td class="test-duration">515</td>
+              <td class="test-duration">503</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">278</td>
               <td class="test-title">seneca use-shortcut
                   
               </td>
-              <td class="test-duration">44</td>
+              <td class="test-duration">26</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">279</td>
               <td class="test-title">seneca status-log
                   
               </td>
-              <td class="test-duration">27</td>
+              <td class="test-duration">18</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">280</td>
               <td class="test-title">seneca reply-seneca
                   
               </td>
-              <td class="test-duration">133</td>
+              <td class="test-duration">123</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">281</td>
               <td class="test-title">seneca pattern-types
                   
               </td>
-              <td class="test-duration">153</td>
+              <td class="test-duration">146</td>
           </tr>
           <tr class="show seneca success">
               <td class="test-id">282</td>
               <td class="test-title">seneca order
                   
               </td>
-              <td class="test-duration">40</td>
+              <td class="test-duration">44</td>
           </tr>
           <tr class="show seneca #decorate success">
               <td class="test-id">283</td>
               <td class="test-title">seneca #decorate can add a property to seneca
                   
               </td>
-              <td class="test-duration">26</td>
+              <td class="test-duration">45</td>
           </tr>
           <tr class="show seneca #decorate success">
               <td class="test-id">284</td>
               <td class="test-title">seneca #decorate cannot override core property
                   
               </td>
-              <td class="test-duration">51</td>
+              <td class="test-duration">21</td>
           </tr>
           <tr class="show seneca #decorate success">
               <td class="test-id">285</td>
               <td class="test-title">seneca #decorate cannot overwrite a decorated property
                   
               </td>
-              <td class="test-duration">27</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show seneca #decorate success">
               <td class="test-id">286</td>
               <td class="test-title">seneca #decorate cannot prefix a property with an underscore
                   
               </td>
-              <td class="test-duration">17</td>
+              <td class="test-duration">12</td>
           </tr>
           <tr class="show seneca #intercept success">
               <td class="test-id">287</td>
               <td class="test-title">seneca #intercept intercept
                   
               </td>
-              <td class="test-duration">38</td>
+              <td class="test-duration">25</td>
           </tr>
           <tr class="show sequence success">
               <td class="test-id">288</td>
               <td class="test-title">sequence single-add-act
                   
               </td>
-              <td class="test-duration">23</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show sequence success">
               <td class="test-id">289</td>
               <td class="test-title">sequence double-add-act
                   
               </td>
-              <td class="test-duration">37</td>
+              <td class="test-duration">19</td>
           </tr>
           <tr class="show sequence success">
               <td class="test-id">290</td>
               <td class="test-title">sequence single-add-act-ready
                   
               </td>
-              <td class="test-duration">127</td>
+              <td class="test-duration">123</td>
           </tr>
           <tr class="show sequence success">
               <td class="test-id">291</td>
               <td class="test-title">sequence single-add-act-gate-action
                   
               </td>
-              <td class="test-duration">87</td>
+              <td class="test-duration">37</td>
           </tr>
           <tr class="show sequence success">
               <td class="test-id">292</td>
               <td class="test-title">sequence single-add-act-gate-instance
                   
               </td>
-              <td class="test-duration">67</td>
+              <td class="test-duration">23</td>
           </tr>
           <tr class="show smoke success">
               <td class="test-id">293</td>
               <td class="test-title">smoke seneca-smoke
                   
               </td>
-              <td class="test-duration">19</td>
+              <td class="test-duration">15</td>
           </tr>
           <tr class="show options success">
               <td class="test-id">294</td>
               <td class="test-title">options options-happy
                   
               </td>
-              <td class="test-duration">133</td>
+              <td class="test-duration">131</td>
           </tr>
           <tr class="show options success">
               <td class="test-id">295</td>
               <td class="test-title">options options-getset
                   
               </td>
-              <td class="test-duration">207</td>
+              <td class="test-duration">137</td>
           </tr>
           <tr class="show options success">
               <td class="test-id">296</td>
               <td class="test-title">options options-legacy
                   
               </td>
-              <td class="test-duration">168</td>
+              <td class="test-duration">130</td>
           </tr>
           <tr class="show options success">
               <td class="test-id">297</td>
               <td class="test-title">options options-file-js
                   
               </td>
-              <td class="test-duration">168</td>
+              <td class="test-duration">135</td>
           </tr>
           <tr class="show options success">
               <td class="test-id">298</td>
               <td class="test-title">options legacy-options-file-js
                   
               </td>
-              <td class="test-duration">160</td>
+              <td class="test-duration">133</td>
           </tr>
           <tr class="show options success">
               <td class="test-id">299</td>
               <td class="test-title">options options-file-json
                   
               </td>
-              <td class="test-duration">139</td>
+              <td class="test-duration">149</td>
           </tr>
           <tr class="show options success">
               <td class="test-id">300</td>
               <td class="test-title">options options-file-json-nomore
                   
               </td>
-              <td class="test-duration">146</td>
+              <td class="test-duration">143</td>
           </tr>
           <tr class="show options success">
               <td class="test-id">301</td>
               <td class="test-title">options options-env
                   
               </td>
-              <td class="test-duration">180</td>
+              <td class="test-duration">144</td>
           </tr>
           <tr class="show options success">
               <td class="test-id">302</td>
               <td class="test-title">options options-cmdline
                   
               </td>
-              <td class="test-duration">165</td>
+              <td class="test-duration">150</td>
           </tr>
           <tr class="show sub success">
               <td class="test-id">303</td>
               <td class="test-title">sub happy-sub
                   
               </td>
-              <td class="test-duration">111</td>
+              <td class="test-duration">39</td>
           </tr>
           <tr class="show sub success">
               <td class="test-id">304</td>
               <td class="test-title">sub inwards-outwards-sub
                   
               </td>
-              <td class="test-duration">36</td>
+              <td class="test-duration">30</td>
           </tr>
           <tr class="show sub success">
               <td class="test-id">305</td>
               <td class="test-title">sub specific-sub
                   
               </td>
-              <td class="test-duration">31</td>
+              <td class="test-duration">26</td>
           </tr>
           <tr class="show sub success">
               <td class="test-id">306</td>
               <td class="test-title">sub error-sub
                   
               </td>
-              <td class="test-duration">24</td>
+              <td class="test-duration">17</td>
           </tr>
           <tr class="show sub success">
               <td class="test-id">307</td>
               <td class="test-title">sub mixed-sub
                   
               </td>
-              <td class="test-duration">25</td>
+              <td class="test-duration">27</td>
           </tr>
           <tr class="show sub success">
               <td class="test-id">308</td>
@@ -2884,14 +2884,14 @@
               <td class="test-title">sub sub-close
                   
               </td>
-              <td class="test-duration">157</td>
+              <td class="test-duration">159</td>
           </tr>
           <tr class="show sub success">
               <td class="test-id">310</td>
               <td class="test-title">sub sub-fix
                   
               </td>
-              <td class="test-duration">37</td>
+              <td class="test-duration">32</td>
           </tr>
           <tr class="show timeout success">
               <td class="test-id">311</td>
@@ -2905,280 +2905,280 @@
               <td class="test-title">timeout error-handler
                   
               </td>
-              <td class="test-duration">144</td>
+              <td class="test-duration">146</td>
           </tr>
           <tr class="show timeout success">
               <td class="test-id">313</td>
               <td class="test-title">timeout should accept a timeout value from options
                   
               </td>
-              <td class="test-duration">261</td>
+              <td class="test-duration">262</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">314</td>
               <td class="test-title">transport happy-nextgen
                   
               </td>
-              <td class="test-duration">421</td>
+              <td class="test-duration">428</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">315</td>
               <td class="test-title">transport config-legacy-nextgen
                   
               </td>
-              <td class="test-duration">553</td>
+              <td class="test-duration">537</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">316</td>
               <td class="test-title">transport error-nextgen
                   
               </td>
-              <td class="test-duration">416</td>
+              <td class="test-duration">390</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">317</td>
               <td class="test-title">transport interop-nextgen
                   
               </td>
-              <td class="test-duration">392</td>
+              <td class="test-duration">330</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">318</td>
               <td class="test-title">transport config-nextgen
                   
               </td>
-              <td class="test-duration">619</td>
+              <td class="test-duration">544</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">319</td>
               <td class="test-title">transport nextgen-transport-local-override
                   
               </td>
-              <td class="test-duration">442</td>
+              <td class="test-duration">446</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">320</td>
               <td class="test-title">transport nextgen-meta
                   
               </td>
-              <td class="test-duration">423</td>
+              <td class="test-duration">444</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">321</td>
               <td class="test-title">transport nextgen-ordering
                   
               </td>
-              <td class="test-duration">563</td>
+              <td class="test-duration">579</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">322</td>
               <td class="test-title">transport transport-exact-single
                   
               </td>
-              <td class="test-duration">242</td>
+              <td class="test-duration">275</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">323</td>
               <td class="test-title">transport transport-local-override
                   
               </td>
-              <td class="test-duration">160</td>
+              <td class="test-duration">226</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">324</td>
               <td class="test-title">transport transport-star
                   
               </td>
-              <td class="test-duration">323</td>
+              <td class="test-duration">334</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">325</td>
               <td class="test-title">transport transport-star-pin-object
                   
               </td>
-              <td class="test-duration">374</td>
+              <td class="test-duration">355</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">326</td>
               <td class="test-title">transport transport-single-notdef
                   
               </td>
-              <td class="test-duration">200</td>
+              <td class="test-duration">216</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">327</td>
               <td class="test-title">transport transport-pins-notdef
                   
               </td>
-              <td class="test-duration">198</td>
+              <td class="test-duration">220</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">328</td>
               <td class="test-title">transport transport-single-wrap-and-star
                   
               </td>
-              <td class="test-duration">337</td>
+              <td class="test-duration">340</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">329</td>
               <td class="test-title">transport transport-local-single-and-star
                   
               </td>
-              <td class="test-duration">323</td>
+              <td class="test-duration">352</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">330</td>
               <td class="test-title">transport transport-local-over-wrap
                   
               </td>
-              <td class="test-duration">289</td>
+              <td class="test-duration">316</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">331</td>
               <td class="test-title">transport transport-local-prior-wrap
                   
               </td>
-              <td class="test-duration">208</td>
+              <td class="test-duration">301</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">332</td>
               <td class="test-title">transport transport-init-ordering
                   
               </td>
-              <td class="test-duration">239</td>
+              <td class="test-duration">248</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">333</td>
               <td class="test-title">transport transport-no-plugin-init
                   
               </td>
-              <td class="test-duration">307</td>
+              <td class="test-duration">309</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">334</td>
               <td class="test-title">transport transport-balance-exact
                   
               </td>
-              <td class="test-duration">1022</td>
+              <td class="test-duration">1104</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">335</td>
               <td class="test-title">transport multi-layer-error
                   
               </td>
-              <td class="test-duration">778</td>
+              <td class="test-duration">795</td>
           </tr>
           <tr class="show transport success">
               <td class="test-id">336</td>
               <td class="test-title">transport server can be restarted without issues to clients
                   
               </td>
-              <td class="test-duration">648</td>
+              <td class="test-duration">689</td>
           </tr>
           <tr class="show transport transport-listen success">
               <td class="test-id">337</td>
               <td class="test-title">transport transport-listen supports-null-options
                   
               </td>
-              <td class="test-duration">184</td>
+              <td class="test-duration">161</td>
           </tr>
           <tr class="show transport transport-listen success">
               <td class="test-id">338</td>
               <td class="test-title">transport transport-listen supports type as tcp option
                   
               </td>
-              <td class="test-duration">132</td>
+              <td class="test-duration">149</td>
           </tr>
           <tr class="show transport transport-listen success">
               <td class="test-id">339</td>
               <td class="test-title">transport transport-listen supports type as http option
                   
               </td>
-              <td class="test-duration">136</td>
+              <td class="test-duration">147</td>
           </tr>
           <tr class="show transport transport-listen success">
               <td class="test-id">340</td>
               <td class="test-title">transport transport-listen supports the port number as an argument
                   
               </td>
-              <td class="test-duration">141</td>
+              <td class="test-duration">130</td>
           </tr>
           <tr class="show transport transport-listen success">
               <td class="test-id">341</td>
               <td class="test-title">transport transport-listen supports the port number and host as an argument
                   
               </td>
-              <td class="test-duration">174</td>
+              <td class="test-duration">148</td>
           </tr>
           <tr class="show transport transport-listen success">
               <td class="test-id">342</td>
               <td class="test-title">transport transport-listen supports the port number, host, and path as an argument
                   
               </td>
-              <td class="test-duration">165</td>
+              <td class="test-duration">184</td>
           </tr>
           <tr class="show transport transport-listen success">
               <td class="test-id">343</td>
               <td class="test-title">transport transport-listen action-error
                   
               </td>
-              <td class="test-duration">159</td>
+              <td class="test-duration">157</td>
           </tr>
           <tr class="show transport client() success">
               <td class="test-id">344</td>
               <td class="test-title">transport client() supports null options
                   
               </td>
-              <td class="test-duration">132</td>
+              <td class="test-duration">167</td>
           </tr>
           <tr class="show util success">
               <td class="test-id">345</td>
               <td class="test-title">util seneca.util.deepextend.happy
                   
               </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">5</td>
           </tr>
           <tr class="show util success">
               <td class="test-id">346</td>
               <td class="test-title">util seneca.util.deepextend.types with new
                   
               </td>
-              <td class="test-duration">3</td>
+              <td class="test-duration">17</td>
           </tr>
           <tr class="show util success">
               <td class="test-id">347</td>
               <td class="test-title">util seneca.util.deepextend.types
                   
               </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">16</td>
           </tr>
           <tr class="show util success">
               <td class="test-id">348</td>
               <td class="test-title">util seneca.util.deepextend.mixed
                   
               </td>
-              <td class="test-duration">2</td>
+              <td class="test-duration">7</td>
           </tr>
           <tr class="show util success">
               <td class="test-id">349</td>
               <td class="test-title">util seneca.util.deepextend.entity
                   
               </td>
-              <td class="test-duration">0</td>
+              <td class="test-duration">2</td>
           </tr>
           <tr class="show xward success">
               <td class="test-id">350</td>
               <td class="test-title">xward happy-inward
                   
               </td>
-              <td class="test-duration">37</td>
+              <td class="test-duration">38</td>
           </tr>
           <tr class="show xward success">
               <td class="test-id">351</td>
               <td class="test-title">xward happy-outward
                   
               </td>
-              <td class="test-duration">28</td>
+              <td class="test-duration">35</td>
           </tr>
           </tbody>
       </table>
@@ -3186,10 +3186,10 @@
     </div>    <div id="coverage">
         <h1>Code Coverage Report</h1>
         <div class="stats high">
-            <div class="percentage">91.63%</div>
-            <div class="sloc">4817</div>
-            <div class="hits">4414</div>
-            <div class="misses">403</div>
+            <div class="percentage">91.66%</div>
+            <div class="sloc">4809</div>
+            <div class="hits">4408</div>
+            <div class="misses">401</div>
         </div>
         <div id="filters">
           <input type="checkbox" checked="" onchange="filter(this)" value="generated" id="show-generated">
@@ -12407,10 +12407,10 @@
             <div class="file ">
                 <h2 id="lib/api.js">lib/api.js </h2>
                 <div class="stats high">
-                    <div class="percentage">92.42%</div>
-                    <div class="sloc">673</div>
-                    <div class="hits">622</div>
-                    <div class="misses">51</div>
+                    <div class="percentage">92.63%</div>
+                    <div class="sloc">665</div>
+                    <div class="hits">616</div>
+                    <div class="misses">49</div>
                 </div>
                 <table>
                     <thead>
@@ -13459,7 +13459,7 @@
                           <td class="line" data-tooltip>173</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>5</td>
-                          <td class="source">    return mustFail(this, ...args)</td>
+                          <td class="source">    return failIf(this, true, ...args)</td>
                           
                         </tr>            <tr id="lib/api.js__174" class="hit">
                           <td class="line" data-tooltip>174</td>
@@ -13525,55 +13525,55 @@
                           <td class="line" data-tooltip>184</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  function mustFail(self, code, args) {</td>
+                          <td class="source">  function failIf(self, cond, code, args) {</td>
                           
                         </tr>            <tr id="lib/api.js__185" class="hit">
                           <td class="line" data-tooltip>185</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">    const error &#x3D; self.error(code, args)</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">    Assert(typeof cond &#x3D;&#x3D;&#x3D; &#x27;boolean&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__186" class="hit">
                           <td class="line" data-tooltip>186</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      &#x27;Expected the &#x60;cond&#x60; param to be a boolean.&#x27;)</td>
                           
-                        </tr>            <tr id="lib/api.js__187" class="chunks">
+                        </tr>            <tr id="lib/api.js__187" class="hit">
                           <td class="line" data-tooltip>187</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    if (</div><div class="miss true" data-tooltip>args</div><div> &amp;&amp; </div><div class="miss false" data-tooltip>false &#x3D;&#x3D;&#x3D; args.throw$</div><div>) {</div></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__188" class="miss">
+                        </tr>            <tr id="lib/api.js__188" class="hit">
                           <td class="line" data-tooltip>188</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>      return error</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">    if (!cond) {</td>
                           
                         </tr>            <tr id="lib/api.js__189" class="hit">
                           <td class="line" data-tooltip>189</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    } else {</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      return</td>
                           
                         </tr>            <tr id="lib/api.js__190" class="hit">
                           <td class="line" data-tooltip>190</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">      throw error</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__191" class="hit">
                           <td class="line" data-tooltip>191</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__192" class="hit">
                           <td class="line" data-tooltip>192</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">    const error &#x3D; self.error(code, args)</td>
                           
                         </tr>            <tr id="lib/api.js__193" class="hit">
                           <td class="line" data-tooltip>193</td>
@@ -13581,47 +13581,47 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__194" class="hit">
+                        </tr>            <tr id="lib/api.js__194" class="chunks">
                           <td class="line" data-tooltip>194</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  function failIf(self, cond, code, args) {</td>
+                          <td class="source"><div>    if (</div><div class="miss true" data-tooltip>args</div><div> &amp;&amp; </div><div class="miss false" data-tooltip>false &#x3D;&#x3D;&#x3D; args.throw$</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__195" class="hit">
+                        </tr>            <tr id="lib/api.js__195" class="miss">
                           <td class="line" data-tooltip>195</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    Assert(typeof cond &#x3D;&#x3D;&#x3D; &#x27;boolean&#x27;,</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source" data-tooltip>      return error</td>
                           
                         </tr>            <tr id="lib/api.js__196" class="hit">
                           <td class="line" data-tooltip>196</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      &#x27;Expected the &#x60;cond&#x60; param to be a boolean.&#x27;)</td>
+                          <td class="source">    } else {</td>
                           
                         </tr>            <tr id="lib/api.js__197" class="hit">
                           <td class="line" data-tooltip>197</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">      throw error</td>
                           
                         </tr>            <tr id="lib/api.js__198" class="hit">
                           <td class="line" data-tooltip>198</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    if (!cond) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__199" class="hit">
                           <td class="line" data-tooltip>199</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      return</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__200" class="hit">
                           <td class="line" data-tooltip>200</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__201" class="hit">
                           <td class="line" data-tooltip>201</td>
@@ -13633,325 +13633,325 @@
                           <td class="line" data-tooltip>202</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>1</td>
-                          <td class="source">    const error &#x3D; self.error(code, args)</td>
+                          <td class="source">exports.inward &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__203" class="hit">
                           <td class="line" data-tooltip>203</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  // TODO: norma should support f/x where x &#x3D; # args</td>
                           
-                        </tr>            <tr id="lib/api.js__204" class="chunks">
+                        </tr>            <tr id="lib/api.js__204" class="hit">
                           <td class="line" data-tooltip>204</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    if (</div><div class="miss true" data-tooltip>args</div><div> &amp;&amp; </div><div class="miss false" data-tooltip>false &#x3D;&#x3D;&#x3D; args.throw$</div><div>) {</div></td>
+                          <td class="source">  var args &#x3D; Norma(&#x27;inward:f&#x27;, arguments)</td>
                           
-                        </tr>            <tr id="lib/api.js__205" class="miss">
+                        </tr>            <tr id="lib/api.js__205" class="hit">
                           <td class="line" data-tooltip>205</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>      return error</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  this.private$.inward.add(args.inward)</td>
                           
                         </tr>            <tr id="lib/api.js__206" class="hit">
                           <td class="line" data-tooltip>206</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    } else {</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__207" class="hit">
                           <td class="line" data-tooltip>207</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      throw error</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__208" class="hit">
                           <td class="line" data-tooltip>208</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__209" class="hit">
                           <td class="line" data-tooltip>209</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.outward &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__210" class="hit">
                           <td class="line" data-tooltip>210</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  var args &#x3D; Norma(&#x27;outward:f&#x27;, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__211" class="hit">
                           <td class="line" data-tooltip>211</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  this.private$.outward.add(args.outward)</td>
                           
                         </tr>            <tr id="lib/api.js__212" class="hit">
                           <td class="line" data-tooltip>212</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.inward &#x3D; function () {</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__213" class="hit">
                           <td class="line" data-tooltip>213</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // TODO: norma should support f/x where x &#x3D; # args</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__214" class="hit">
                           <td class="line" data-tooltip>214</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var args &#x3D; Norma(&#x27;inward:f&#x27;, arguments)</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__215" class="hit">
                           <td class="line" data-tooltip>215</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>1</td>
-                          <td class="source">  this.private$.inward.add(args.inward)</td>
+                          <td class="source">exports.prior &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__216" class="hit">
                           <td class="line" data-tooltip>216</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  if (null &#x3D;&#x3D; this.private$.act) {</td>
                           
                         </tr>            <tr id="lib/api.js__217" class="hit">
                           <td class="line" data-tooltip>217</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    // TODO: should be a top level api method: seneca.fail</td>
                           
                         </tr>            <tr id="lib/api.js__218" class="hit">
                           <td class="line" data-tooltip>218</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    throw this.util.error(&#x27;no_prior_action&#x27;, { args: arguments })</td>
                           
                         </tr>            <tr id="lib/api.js__219" class="hit">
                           <td class="line" data-tooltip>219</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.outward &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__220" class="hit">
                           <td class="line" data-tooltip>220</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var args &#x3D; Norma(&#x27;outward:f&#x27;, arguments)</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__221" class="hit">
                           <td class="line" data-tooltip>221</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  this.private$.outward.add(args.outward)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // Get definition of prior action</td>
                           
                         </tr>            <tr id="lib/api.js__222" class="hit">
                           <td class="line" data-tooltip>222</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  var priordef &#x3D; this.private$.act.def.priordef</td>
                           
                         </tr>            <tr id="lib/api.js__223" class="hit">
                           <td class="line" data-tooltip>223</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__224" class="hit">
                           <td class="line" data-tooltip>224</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  var spec &#x3D; Common.build_message(this, arguments, &#x27;reply:f?&#x27;, this.fixedargs)</td>
                           
                         </tr>            <tr id="lib/api.js__225" class="hit">
                           <td class="line" data-tooltip>225</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.prior &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__226" class="hit">
                           <td class="line" data-tooltip>226</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  if (null &#x3D;&#x3D; this.private$.act) {</td>
+                          <td class="source">  // TODO: clean sufficiently so that seneca.util.clean not needed</td>
                           
                         </tr>            <tr id="lib/api.js__227" class="hit">
                           <td class="line" data-tooltip>227</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    // TODO: should be a top level api method: seneca.fail</td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  var msg &#x3D; spec.msg</td>
                           
                         </tr>            <tr id="lib/api.js__228" class="hit">
                           <td class="line" data-tooltip>228</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    throw this.util.error(&#x27;no_prior_action&#x27;, { args: arguments })</td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  var reply &#x3D; spec.reply</td>
                           
                         </tr>            <tr id="lib/api.js__229" class="hit">
                           <td class="line" data-tooltip>229</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__230" class="hit">
                           <td class="line" data-tooltip>230</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>128</td>
+                          <td class="source">  if (priordef) {</td>
                           
                         </tr>            <tr id="lib/api.js__231" class="hit">
                           <td class="line" data-tooltip>231</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // Get definition of prior action</td>
+                          <td class="hits" data-tooltip>103</td>
+                          <td class="source">    msg.prior$ &#x3D; priordef.id</td>
                           
                         </tr>            <tr id="lib/api.js__232" class="hit">
                           <td class="line" data-tooltip>232</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  var priordef &#x3D; this.private$.act.def.priordef</td>
+                          <td class="hits" data-tooltip>103</td>
+                          <td class="source">    this.act(msg, reply)</td>
                           
                         </tr>            <tr id="lib/api.js__233" class="hit">
                           <td class="line" data-tooltip>233</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  } else {</td>
                           
-                        </tr>            <tr id="lib/api.js__234" class="hit">
+                        </tr>            <tr id="lib/api.js__234" class="chunks">
                           <td class="line" data-tooltip>234</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  var spec &#x3D; Common.build_message(this, arguments, &#x27;reply:f?&#x27;, this.fixedargs)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>    var meta &#x3D; </div><div class="miss false" data-tooltip>msg.meta$</div><div> || {}</div></td>
                           
-                        </tr>            <tr id="lib/api.js__235" class="hit">
+                        </tr>            <tr id="lib/api.js__235" class="chunks">
                           <td class="line" data-tooltip>235</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>    var out &#x3D; msg.default$ || </div><div class="miss false" data-tooltip>meta.dflt</div><div> || null</div></td>
                           
                         </tr>            <tr id="lib/api.js__236" class="hit">
                           <td class="line" data-tooltip>236</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // TODO: clean sufficiently so that seneca.util.clean not needed</td>
+                          <td class="hits" data-tooltip>25</td>
+                          <td class="source">    out &#x3D; null &#x3D;&#x3D; out ? out : Object.assign({}, out)</td>
                           
                         </tr>            <tr id="lib/api.js__237" class="hit">
                           <td class="line" data-tooltip>237</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  var msg &#x3D; spec.msg</td>
+                          <td class="hits" data-tooltip>25</td>
+                          <td class="source">    return reply.call(this, null, out, meta)</td>
                           
                         </tr>            <tr id="lib/api.js__238" class="hit">
                           <td class="line" data-tooltip>238</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  var reply &#x3D; spec.reply</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__239" class="hit">
                           <td class="line" data-tooltip>239</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__240" class="hit">
                           <td class="line" data-tooltip>240</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>128</td>
-                          <td class="source">  if (priordef) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__241" class="hit">
                           <td class="line" data-tooltip>241</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>103</td>
-                          <td class="source">    msg.prior$ &#x3D; priordef.id</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">// TODO: rename fixedargs</td>
                           
                         </tr>            <tr id="lib/api.js__242" class="hit">
                           <td class="line" data-tooltip>242</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>103</td>
-                          <td class="source">    this.act(msg, reply)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.delegate &#x3D; function (fixedargs, fixedmeta) {</td>
                           
                         </tr>            <tr id="lib/api.js__243" class="hit">
                           <td class="line" data-tooltip>243</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="source">  var self &#x3D; this</td>
                           
-                        </tr>            <tr id="lib/api.js__244" class="chunks">
+                        </tr>            <tr id="lib/api.js__244" class="hit">
                           <td class="line" data-tooltip>244</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var meta &#x3D; </div><div class="miss false" data-tooltip>msg.meta$</div><div> || {}</div></td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var root &#x3D; this.root</td>
                           
-                        </tr>            <tr id="lib/api.js__245" class="chunks">
+                        </tr>            <tr id="lib/api.js__245" class="hit">
                           <td class="line" data-tooltip>245</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var out &#x3D; msg.default$ || </div><div class="miss false" data-tooltip>meta.dflt</div><div> || null</div></td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var opts &#x3D; this.options()</td>
                           
                         </tr>            <tr id="lib/api.js__246" class="hit">
                           <td class="line" data-tooltip>246</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>25</td>
-                          <td class="source">    out &#x3D; null &#x3D;&#x3D; out ? out : Object.assign({}, out)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__247" class="hit">
                           <td class="line" data-tooltip>247</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>25</td>
-                          <td class="source">    return reply.call(this, null, out, meta)</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  fixedargs &#x3D; fixedargs || {}</td>
                           
                         </tr>            <tr id="lib/api.js__248" class="hit">
                           <td class="line" data-tooltip>248</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  fixedmeta &#x3D; fixedmeta || {}</td>
                           
                         </tr>            <tr id="lib/api.js__249" class="hit">
                           <td class="line" data-tooltip>249</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__250" class="hit">
                           <td class="line" data-tooltip>250</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var delegate &#x3D; Object.create(self)</td>
                           
                         </tr>            <tr id="lib/api.js__251" class="hit">
                           <td class="line" data-tooltip>251</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// TODO: rename fixedargs</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__252" class="hit">
                           <td class="line" data-tooltip>252</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.delegate &#x3D; function (fixedargs, fixedmeta) {</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  delegate.private$ &#x3D; Object.create(self.private$)</td>
                           
                         </tr>            <tr id="lib/api.js__253" class="hit">
                           <td class="line" data-tooltip>253</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var self &#x3D; this</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__254" class="hit">
                           <td class="line" data-tooltip>254</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var root &#x3D; this.root</td>
+                          <td class="source">  delegate.did &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__255" class="hit">
                           <td class="line" data-tooltip>255</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var opts &#x3D; this.options()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    (delegate.did ? delegate.did + &#x27;/&#x27; : &#x27;&#x27;) + self.private$.didnid()</td>
                           
                         </tr>            <tr id="lib/api.js__256" class="hit">
                           <td class="line" data-tooltip>256</td>
@@ -13962,38 +13962,38 @@
                         </tr>            <tr id="lib/api.js__257" class="hit">
                           <td class="line" data-tooltip>257</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  fixedargs &#x3D; fixedargs || {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  function delegate_log() {</td>
                           
                         </tr>            <tr id="lib/api.js__258" class="hit">
                           <td class="line" data-tooltip>258</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  fixedmeta &#x3D; fixedmeta || {}</td>
+                          <td class="hits" data-tooltip>11974</td>
+                          <td class="source">    return root.log.apply(delegate, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__259" class="hit">
                           <td class="line" data-tooltip>259</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__260" class="hit">
                           <td class="line" data-tooltip>260</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var delegate &#x3D; Object.create(self)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__261" class="hit">
                           <td class="line" data-tooltip>261</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  Object.assign(delegate_log, root.log)</td>
                           
                         </tr>            <tr id="lib/api.js__262" class="hit">
                           <td class="line" data-tooltip>262</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  delegate.private$ &#x3D; Object.create(self.private$)</td>
+                          <td class="source">  delegate_log.self &#x3D; () &#x3D;&gt; delegate</td>
                           
                         </tr>            <tr id="lib/api.js__263" class="hit">
                           <td class="line" data-tooltip>263</td>
@@ -14005,187 +14005,187 @@
                           <td class="line" data-tooltip>264</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  delegate.did &#x3D;</td>
+                          <td class="source">  var strdesc</td>
                           
                         </tr>            <tr id="lib/api.js__265" class="hit">
                           <td class="line" data-tooltip>265</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    (delegate.did ? delegate.did + &#x27;/&#x27; : &#x27;&#x27;) + self.private$.didnid()</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__266" class="hit">
                           <td class="line" data-tooltip>266</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  function delegate_toString() {</td>
                           
                         </tr>            <tr id="lib/api.js__267" class="hit">
                           <td class="line" data-tooltip>267</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  function delegate_log() {</td>
+                          <td class="hits" data-tooltip>98</td>
+                          <td class="source">    if (strdesc) return strdesc</td>
                           
                         </tr>            <tr id="lib/api.js__268" class="hit">
                           <td class="line" data-tooltip>268</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11974</td>
-                          <td class="source">    return root.log.apply(delegate, arguments)</td>
+                          <td class="hits" data-tooltip>82</td>
+                          <td class="source">    var vfa &#x3D; {}</td>
                           
                         </tr>            <tr id="lib/api.js__269" class="hit">
                           <td class="line" data-tooltip>269</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>82</td>
+                          <td class="source">    Object.keys(fixedargs).forEach((k) &#x3D;&gt; {</td>
                           
                         </tr>            <tr id="lib/api.js__270" class="hit">
                           <td class="line" data-tooltip>270</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      var v &#x3D; fixedargs[k]</td>
                           
                         </tr>            <tr id="lib/api.js__271" class="hit">
                           <td class="line" data-tooltip>271</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  Object.assign(delegate_log, root.log)</td>
+                          <td class="hits" data-tooltip>209</td>
+                          <td class="source">      if (~k.indexOf(&#x27;$&#x27;)) return</td>
                           
                         </tr>            <tr id="lib/api.js__272" class="hit">
                           <td class="line" data-tooltip>272</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  delegate_log.self &#x3D; () &#x3D;&gt; delegate</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      vfa[k] &#x3D; v</td>
                           
                         </tr>            <tr id="lib/api.js__273" class="hit">
                           <td class="line" data-tooltip>273</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__274" class="hit">
                           <td class="line" data-tooltip>274</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var strdesc</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__275" class="hit">
                           <td class="line" data-tooltip>275</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>82</td>
+                          <td class="source">    strdesc &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__276" class="hit">
                           <td class="line" data-tooltip>276</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  function delegate_toString() {</td>
+                          <td class="source">      self.toString() +</td>
                           
                         </tr>            <tr id="lib/api.js__277" class="hit">
                           <td class="line" data-tooltip>277</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>98</td>
-                          <td class="source">    if (strdesc) return strdesc</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      (Object.keys(vfa).length ? &#x27;/&#x27; + Jsonic.stringify(vfa) : &#x27;&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__278" class="hit">
                           <td class="line" data-tooltip>278</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>82</td>
-                          <td class="source">    var vfa &#x3D; {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__279" class="hit">
                           <td class="line" data-tooltip>279</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>82</td>
-                          <td class="source">    Object.keys(fixedargs).forEach((k) &#x3D;&gt; {</td>
+                          <td class="source">    return strdesc</td>
                           
                         </tr>            <tr id="lib/api.js__280" class="hit">
                           <td class="line" data-tooltip>280</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      var v &#x3D; fixedargs[k]</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__281" class="hit">
                           <td class="line" data-tooltip>281</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>209</td>
-                          <td class="source">      if (~k.indexOf(&#x27;$&#x27;)) return</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__282" class="hit">
+                        </tr>            <tr id="lib/api.js__282" class="chunks">
                           <td class="line" data-tooltip>282</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      vfa[k] &#x3D; v</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>  var delegate_fixedargs &#x3D; </div><div class="miss true" data-tooltip>opts.strict.fixedargs</div></td>
                           
                         </tr>            <tr id="lib/api.js__283" class="hit">
                           <td class="line" data-tooltip>283</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source">    ? Object.assign({}, fixedargs, self.fixedargs)</td>
                           
-                        </tr>            <tr id="lib/api.js__284" class="hit">
+                        </tr>            <tr id="lib/api.js__284" class="chunks">
                           <td class="line" data-tooltip>284</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>    : </div><div class="miss never" data-tooltip>Object.assign({}, self.fixedargs, fixedargs)</div></td>
                           
                         </tr>            <tr id="lib/api.js__285" class="hit">
                           <td class="line" data-tooltip>285</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>82</td>
-                          <td class="source">    strdesc &#x3D;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__286" class="hit">
+                        </tr>            <tr id="lib/api.js__286" class="chunks">
                           <td class="line" data-tooltip>286</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      self.toString() +</td>
+                          <td class="source"><div>  var delegate_fixedmeta &#x3D; </div><div class="miss false" data-tooltip>opts.strict.fixedmeta</div></td>
                           
-                        </tr>            <tr id="lib/api.js__287" class="hit">
+                        </tr>            <tr id="lib/api.js__287" class="chunks">
                           <td class="line" data-tooltip>287</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      (Object.keys(vfa).length ? &#x27;/&#x27; + Jsonic.stringify(vfa) : &#x27;&#x27;)</td>
+                          <td class="source"><div>    ? </div><div class="miss never" data-tooltip>Object.assign({}, fixedmeta, self.fixedmeta)</div></td>
                           
                         </tr>            <tr id="lib/api.js__288" class="hit">
                           <td class="line" data-tooltip>288</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    : Object.assign({}, self.fixedmeta, fixedmeta)</td>
                           
                         </tr>            <tr id="lib/api.js__289" class="hit">
                           <td class="line" data-tooltip>289</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>82</td>
-                          <td class="source">    return strdesc</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__290" class="hit">
                           <td class="line" data-tooltip>290</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">  function delegate_delegate(further_fixedargs, further_fixedmeta) {</td>
                           
                         </tr>            <tr id="lib/api.js__291" class="hit">
                           <td class="line" data-tooltip>291</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>2131</td>
+                          <td class="source">    var args &#x3D; Object.assign({}, delegate.fixedargs, further_fixedargs || {})</td>
                           
-                        </tr>            <tr id="lib/api.js__292" class="chunks">
+                        </tr>            <tr id="lib/api.js__292" class="hit">
                           <td class="line" data-tooltip>292</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  var delegate_fixedargs &#x3D; </div><div class="miss true" data-tooltip>opts.strict.fixedargs</div></td>
+                          <td class="hits" data-tooltip>2131</td>
+                          <td class="source">    var meta &#x3D; Object.assign({}, delegate.fixedmeta, further_fixedmeta || {})</td>
                           
                         </tr>            <tr id="lib/api.js__293" class="hit">
                           <td class="line" data-tooltip>293</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    ? Object.assign({}, fixedargs, self.fixedargs)</td>
+                          <td class="hits" data-tooltip>2131</td>
+                          <td class="source">    return self.delegate.call(this, args, meta)</td>
                           
-                        </tr>            <tr id="lib/api.js__294" class="chunks">
+                        </tr>            <tr id="lib/api.js__294" class="hit">
                           <td class="line" data-tooltip>294</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    : </div><div class="miss never" data-tooltip>Object.assign({}, self.fixedargs, fixedargs)</div></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__295" class="hit">
                           <td class="line" data-tooltip>295</td>
@@ -14193,23 +14193,23 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__296" class="chunks">
+                        </tr>            <tr id="lib/api.js__296" class="hit">
                           <td class="line" data-tooltip>296</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  var delegate_fixedmeta &#x3D; </div><div class="miss false" data-tooltip>opts.strict.fixedmeta</div></td>
+                          <td class="source">  // Somewhere to put contextual data for this delegate.</td>
                           
-                        </tr>            <tr id="lib/api.js__297" class="chunks">
+                        </tr>            <tr id="lib/api.js__297" class="hit">
                           <td class="line" data-tooltip>297</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    ? </div><div class="miss never" data-tooltip>Object.assign({}, fixedmeta, self.fixedmeta)</div></td>
+                          <td class="source">  // For example, data for individual web requests.</td>
                           
                         </tr>            <tr id="lib/api.js__298" class="hit">
                           <td class="line" data-tooltip>298</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    : Object.assign({}, self.fixedmeta, fixedmeta)</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  var delegate_context &#x3D; Object.assign({}, self.context)</td>
                           
                         </tr>            <tr id="lib/api.js__299" class="hit">
                           <td class="line" data-tooltip>299</td>
@@ -14221,55 +14221,55 @@
                           <td class="line" data-tooltip>300</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  function delegate_delegate(further_fixedargs, further_fixedmeta) {</td>
+                          <td class="source">  // Prevents incorrect prototype properties in mocha test contexts</td>
                           
                         </tr>            <tr id="lib/api.js__301" class="hit">
                           <td class="line" data-tooltip>301</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2131</td>
-                          <td class="source">    var args &#x3D; Object.assign({}, delegate.fixedargs, further_fixedargs || {})</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  Object.defineProperties(delegate, {</td>
                           
                         </tr>            <tr id="lib/api.js__302" class="hit">
                           <td class="line" data-tooltip>302</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2131</td>
-                          <td class="source">    var meta &#x3D; Object.assign({}, delegate.fixedmeta, further_fixedmeta || {})</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    log: { value: delegate_log, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__303" class="hit">
                           <td class="line" data-tooltip>303</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2131</td>
-                          <td class="source">    return self.delegate.call(this, args, meta)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    toString: { value: delegate_toString, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__304" class="hit">
                           <td class="line" data-tooltip>304</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    fixedargs: { value: delegate_fixedargs, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__305" class="hit">
                           <td class="line" data-tooltip>305</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    fixedmeta: { value: delegate_fixedmeta, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__306" class="hit">
                           <td class="line" data-tooltip>306</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // Somewhere to put contextual data for this delegate.</td>
+                          <td class="source">    delegate: { value: delegate_delegate, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__307" class="hit">
                           <td class="line" data-tooltip>307</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // For example, data for individual web requests.</td>
+                          <td class="source">    context: { value: delegate_context, writable: true },</td>
                           
                         </tr>            <tr id="lib/api.js__308" class="hit">
                           <td class="line" data-tooltip>308</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  var delegate_context &#x3D; Object.assign({}, self.context)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  })</td>
                           
                         </tr>            <tr id="lib/api.js__309" class="hit">
                           <td class="line" data-tooltip>309</td>
@@ -14280,308 +14280,308 @@
                         </tr>            <tr id="lib/api.js__310" class="hit">
                           <td class="line" data-tooltip>310</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // Prevents incorrect prototype properties in mocha test contexts</td>
+                          <td class="hits" data-tooltip>3611</td>
+                          <td class="source">  return delegate</td>
                           
                         </tr>            <tr id="lib/api.js__311" class="hit">
                           <td class="line" data-tooltip>311</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  Object.defineProperties(delegate, {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__312" class="hit">
                           <td class="line" data-tooltip>312</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    log: { value: delegate_log, writable: true },</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__313" class="hit">
                           <td class="line" data-tooltip>313</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    toString: { value: delegate_toString, writable: true },</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.depends &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__314" class="hit">
                           <td class="line" data-tooltip>314</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    fixedargs: { value: delegate_fixedargs, writable: true },</td>
+                          <td class="source">  var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__315" class="hit">
                           <td class="line" data-tooltip>315</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    fixedmeta: { value: delegate_fixedmeta, writable: true },</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  var private$ &#x3D; this.private$</td>
                           
                         </tr>            <tr id="lib/api.js__316" class="hit">
                           <td class="line" data-tooltip>316</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    delegate: { value: delegate_delegate, writable: true },</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  var error &#x3D; this.util.error</td>
                           
                         </tr>            <tr id="lib/api.js__317" class="hit">
                           <td class="line" data-tooltip>317</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    context: { value: delegate_context, writable: true },</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  var args &#x3D; Norma(&#x27;{pluginname:s deps:a? moredeps:s*}&#x27;, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__318" class="hit">
                           <td class="line" data-tooltip>318</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  })</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__319" class="hit">
                           <td class="line" data-tooltip>319</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  var deps &#x3D; args.deps || args.moredeps || []</td>
                           
                         </tr>            <tr id="lib/api.js__320" class="hit">
                           <td class="line" data-tooltip>320</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3611</td>
-                          <td class="source">  return delegate</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__321" class="hit">
                           <td class="line" data-tooltip>321</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">  for (var i &#x3D; 0; i &lt; deps.length; i++) {</td>
                           
                         </tr>            <tr id="lib/api.js__322" class="hit">
                           <td class="line" data-tooltip>322</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>9</td>
+                          <td class="source">    var depname &#x3D; deps[i]</td>
                           
                         </tr>            <tr id="lib/api.js__323" class="hit">
                           <td class="line" data-tooltip>323</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.depends &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__324" class="hit">
                           <td class="line" data-tooltip>324</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var self &#x3D; this</td>
+                          <td class="hits" data-tooltip>9</td>
+                          <td class="source">    if (</td>
                           
                         </tr>            <tr id="lib/api.js__325" class="hit">
                           <td class="line" data-tooltip>325</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  var private$ &#x3D; this.private$</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      !private$.plugin_order.byname.includes(depname) &amp;&amp;</td>
                           
-                        </tr>            <tr id="lib/api.js__326" class="hit">
+                        </tr>            <tr id="lib/api.js__326" class="chunks">
                           <td class="line" data-tooltip>326</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  var error &#x3D; this.util.error</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>      </div><div class="miss true" data-tooltip>!private$.plugin_order.byname.includes(&#x27;seneca-&#x27; + depname)</div></td>
                           
                         </tr>            <tr id="lib/api.js__327" class="hit">
                           <td class="line" data-tooltip>327</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  var args &#x3D; Norma(&#x27;{pluginname:s deps:a? moredeps:s*}&#x27;, arguments)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    ) {</td>
                           
                         </tr>            <tr id="lib/api.js__328" class="hit">
                           <td class="line" data-tooltip>328</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">      self.die(</td>
                           
                         </tr>            <tr id="lib/api.js__329" class="hit">
                           <td class="line" data-tooltip>329</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  var deps &#x3D; args.deps || args.moredeps || []</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        error(&#x27;plugin_required&#x27;, {</td>
                           
                         </tr>            <tr id="lib/api.js__330" class="hit">
                           <td class="line" data-tooltip>330</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">          name: args.pluginname,</td>
                           
                         </tr>            <tr id="lib/api.js__331" class="hit">
                           <td class="line" data-tooltip>331</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">  for (var i &#x3D; 0; i &lt; deps.length; i++) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">          dependency: depname,</td>
                           
                         </tr>            <tr id="lib/api.js__332" class="hit">
                           <td class="line" data-tooltip>332</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
-                          <td class="source">    var depname &#x3D; deps[i]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        })</td>
                           
                         </tr>            <tr id="lib/api.js__333" class="hit">
                           <td class="line" data-tooltip>333</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      )</td>
                           
                         </tr>            <tr id="lib/api.js__334" class="hit">
                           <td class="line" data-tooltip>334</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
-                          <td class="source">    if (</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">      break</td>
                           
                         </tr>            <tr id="lib/api.js__335" class="hit">
                           <td class="line" data-tooltip>335</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      !private$.plugin_order.byname.includes(depname) &amp;&amp;</td>
+                          <td class="source">    }</td>
                           
-                        </tr>            <tr id="lib/api.js__336" class="chunks">
+                        </tr>            <tr id="lib/api.js__336" class="hit">
                           <td class="line" data-tooltip>336</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      </div><div class="miss true" data-tooltip>!private$.plugin_order.byname.includes(&#x27;seneca-&#x27; + depname)</div></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__337" class="hit">
                           <td class="line" data-tooltip>337</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    ) {</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__338" class="hit">
                           <td class="line" data-tooltip>338</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">      self.die(</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__339" class="hit">
                           <td class="line" data-tooltip>339</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        error(&#x27;plugin_required&#x27;, {</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.export &#x3D; function (key) {</td>
                           
                         </tr>            <tr id="lib/api.js__340" class="hit">
                           <td class="line" data-tooltip>340</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          name: args.pluginname,</td>
+                          <td class="source">  var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__341" class="hit">
                           <td class="line" data-tooltip>341</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">          dependency: depname,</td>
+                          <td class="hits" data-tooltip>76</td>
+                          <td class="source">  var private$ &#x3D; this.private$</td>
                           
                         </tr>            <tr id="lib/api.js__342" class="hit">
                           <td class="line" data-tooltip>342</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        })</td>
+                          <td class="hits" data-tooltip>76</td>
+                          <td class="source">  var error &#x3D; this.util.error</td>
                           
                         </tr>            <tr id="lib/api.js__343" class="hit">
                           <td class="line" data-tooltip>343</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      )</td>
+                          <td class="hits" data-tooltip>76</td>
+                          <td class="source">  var opts &#x3D; this.options()</td>
                           
                         </tr>            <tr id="lib/api.js__344" class="hit">
                           <td class="line" data-tooltip>344</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">      break</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__345" class="hit">
                           <td class="line" data-tooltip>345</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">  // Legacy aliases</td>
                           
-                        </tr>            <tr id="lib/api.js__346" class="hit">
+                        </tr>            <tr id="lib/api.js__346" class="chunks">
                           <td class="line" data-tooltip>346</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"><div>  if (</div><div class="miss false" data-tooltip>key &#x3D;&#x3D;&#x3D; &#x27;util&#x27;</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__347" class="hit">
+                        </tr>            <tr id="lib/api.js__347" class="miss">
                           <td class="line" data-tooltip>347</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source" data-tooltip>    key &#x3D; &#x27;basic&#x27;</td>
                           
                         </tr>            <tr id="lib/api.js__348" class="hit">
                           <td class="line" data-tooltip>348</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__349" class="hit">
                           <td class="line" data-tooltip>349</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.export &#x3D; function (key) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__350" class="hit">
                           <td class="line" data-tooltip>350</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var self &#x3D; this</td>
+                          <td class="hits" data-tooltip>76</td>
+                          <td class="source">  var exportval &#x3D; private$.exports[key]</td>
                           
                         </tr>            <tr id="lib/api.js__351" class="hit">
                           <td class="line" data-tooltip>351</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>76</td>
-                          <td class="source">  var private$ &#x3D; this.private$</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__352" class="hit">
+                        </tr>            <tr id="lib/api.js__352" class="chunks">
                           <td class="line" data-tooltip>352</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>76</td>
-                          <td class="source">  var error &#x3D; this.util.error</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>  if (!exportval &amp;&amp; </div><div class="miss true" data-tooltip>opts.strict.exports</div><div>) {</div></td>
                           
                         </tr>            <tr id="lib/api.js__353" class="hit">
                           <td class="line" data-tooltip>353</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>76</td>
-                          <td class="source">  var opts &#x3D; this.options()</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    return self.die(error(&#x27;export_not_found&#x27;, { key: key }))</td>
                           
                         </tr>            <tr id="lib/api.js__354" class="hit">
                           <td class="line" data-tooltip>354</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__355" class="hit">
                           <td class="line" data-tooltip>355</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // Legacy aliases</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__356" class="chunks">
+                        </tr>            <tr id="lib/api.js__356" class="hit">
                           <td class="line" data-tooltip>356</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  if (</div><div class="miss false" data-tooltip>key &#x3D;&#x3D;&#x3D; &#x27;util&#x27;</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>75</td>
+                          <td class="source">  return exportval</td>
                           
-                        </tr>            <tr id="lib/api.js__357" class="miss">
+                        </tr>            <tr id="lib/api.js__357" class="hit">
                           <td class="line" data-tooltip>357</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>    key &#x3D; &#x27;basic&#x27;</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__358" class="hit">
                           <td class="line" data-tooltip>358</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__359" class="hit">
                           <td class="line" data-tooltip>359</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.quiet &#x3D; function (flags) {</td>
                           
                         </tr>            <tr id="lib/api.js__360" class="hit">
                           <td class="line" data-tooltip>360</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>76</td>
-                          <td class="source">  var exportval &#x3D; private$.exports[key]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  flags &#x3D; flags || {}</td>
                           
                         </tr>            <tr id="lib/api.js__361" class="hit">
                           <td class="line" data-tooltip>361</td>
@@ -14589,41 +14589,41 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__362" class="chunks">
+                        </tr>            <tr id="lib/api.js__362" class="hit">
                           <td class="line" data-tooltip>362</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  if (!exportval &amp;&amp; </div><div class="miss true" data-tooltip>opts.strict.exports</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>39</td>
+                          <td class="source">  var quiet_opts &#x3D; {</td>
                           
                         </tr>            <tr id="lib/api.js__363" class="hit">
                           <td class="line" data-tooltip>363</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    return self.die(error(&#x27;export_not_found&#x27;, { key: key }))</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    test: false,</td>
                           
                         </tr>            <tr id="lib/api.js__364" class="hit">
                           <td class="line" data-tooltip>364</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    quiet: true,</td>
                           
                         </tr>            <tr id="lib/api.js__365" class="hit">
                           <td class="line" data-tooltip>365</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    log: &#x27;none&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__366" class="hit">
                           <td class="line" data-tooltip>366</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>75</td>
-                          <td class="source">  return exportval</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    reload$: true,</td>
                           
                         </tr>            <tr id="lib/api.js__367" class="hit">
                           <td class="line" data-tooltip>367</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__368" class="hit">
                           <td class="line" data-tooltip>368</td>
@@ -14634,134 +14634,134 @@
                         </tr>            <tr id="lib/api.js__369" class="hit">
                           <td class="line" data-tooltip>369</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.quiet &#x3D; function (flags) {</td>
+                          <td class="hits" data-tooltip>39</td>
+                          <td class="source">  var opts &#x3D; this.options(quiet_opts)</td>
                           
                         </tr>            <tr id="lib/api.js__370" class="hit">
                           <td class="line" data-tooltip>370</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  flags &#x3D; flags || {}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__371" class="hit">
                           <td class="line" data-tooltip>371</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  // An override from env or args is possible.</td>
                           
                         </tr>            <tr id="lib/api.js__372" class="hit">
                           <td class="line" data-tooltip>372</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>39</td>
-                          <td class="source">  var quiet_opts &#x3D; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // Only flip to test mode if called from test() method</td>
                           
-                        </tr>            <tr id="lib/api.js__373" class="hit">
+                        </tr>            <tr id="lib/api.js__373" class="chunks">
                           <td class="line" data-tooltip>373</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    test: false,</td>
+                          <td class="source"><div>  if (opts.test &amp;&amp; </div><div class="miss true" data-tooltip>&#x27;test&#x27; !&#x3D;&#x3D; flags.from</div><div>) {</div></td>
                           
                         </tr>            <tr id="lib/api.js__374" class="hit">
                           <td class="line" data-tooltip>374</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    quiet: true,</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    return this.test()</td>
                           
                         </tr>            <tr id="lib/api.js__375" class="hit">
                           <td class="line" data-tooltip>375</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    log: &#x27;none&#x27;,</td>
+                          <td class="source">  } else {</td>
                           
                         </tr>            <tr id="lib/api.js__376" class="hit">
                           <td class="line" data-tooltip>376</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    reload$: true,</td>
+                          <td class="hits" data-tooltip>37</td>
+                          <td class="source">    this.private$.logging.build_log(this)</td>
                           
                         </tr>            <tr id="lib/api.js__377" class="hit">
                           <td class="line" data-tooltip>377</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__378" class="hit">
                           <td class="line" data-tooltip>378</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>37</td>
+                          <td class="source">    return this</td>
                           
                         </tr>            <tr id="lib/api.js__379" class="hit">
                           <td class="line" data-tooltip>379</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>39</td>
-                          <td class="source">  var opts &#x3D; this.options(quiet_opts)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__380" class="hit">
                           <td class="line" data-tooltip>380</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__381" class="hit">
                           <td class="line" data-tooltip>381</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // An override from env or args is possible.</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__382" class="hit">
                           <td class="line" data-tooltip>382</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // Only flip to test mode if called from test() method</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.test &#x3D; function (errhandler, logspec) {</td>
                           
-                        </tr>            <tr id="lib/api.js__383" class="chunks">
+                        </tr>            <tr id="lib/api.js__383" class="hit">
                           <td class="line" data-tooltip>383</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  if (opts.test &amp;&amp; </div><div class="miss true" data-tooltip>&#x27;test&#x27; !&#x3D;&#x3D; flags.from</div><div>) {</div></td>
+                          <td class="source">  var opts &#x3D; this.options()</td>
                           
                         </tr>            <tr id="lib/api.js__384" class="hit">
                           <td class="line" data-tooltip>384</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    return this.test()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__385" class="hit">
                           <td class="line" data-tooltip>385</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  if (&#x27;-&#x27; !&#x3D; opts.tag) {</td>
                           
                         </tr>            <tr id="lib/api.js__386" class="hit">
                           <td class="line" data-tooltip>386</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>37</td>
-                          <td class="source">    this.private$.logging.build_log(this)</td>
+                          <td class="hits" data-tooltip>21</td>
+                          <td class="source">    this.root.id &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__387" class="hit">
                           <td class="line" data-tooltip>387</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      null &#x3D;&#x3D; opts.id$</td>
                           
                         </tr>            <tr id="lib/api.js__388" class="hit">
                           <td class="line" data-tooltip>388</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>37</td>
-                          <td class="source">    return this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        ? this.private$.actnid().substring(0, 4) + &#x27;/&#x27; + opts.tag</td>
                           
                         </tr>            <tr id="lib/api.js__389" class="hit">
                           <td class="line" data-tooltip>389</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">        : &#x27;&#x27; + opts.id$</td>
                           
                         </tr>            <tr id="lib/api.js__390" class="hit">
                           <td class="line" data-tooltip>390</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__391" class="hit">
                           <td class="line" data-tooltip>391</td>
@@ -14772,80 +14772,80 @@
                         </tr>            <tr id="lib/api.js__392" class="hit">
                           <td class="line" data-tooltip>392</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.test &#x3D; function (errhandler, logspec) {</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  if (&#x27;function&#x27; !&#x3D;&#x3D; typeof errhandler &amp;&amp; null !&#x3D;&#x3D; errhandler) {</td>
                           
                         </tr>            <tr id="lib/api.js__393" class="hit">
                           <td class="line" data-tooltip>393</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var opts &#x3D; this.options()</td>
+                          <td class="hits" data-tooltip>55</td>
+                          <td class="source">    logspec &#x3D; errhandler</td>
                           
                         </tr>            <tr id="lib/api.js__394" class="hit">
                           <td class="line" data-tooltip>394</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>55</td>
+                          <td class="source">    errhandler &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__395" class="hit">
                           <td class="line" data-tooltip>395</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  if (&#x27;-&#x27; !&#x3D; opts.tag) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__396" class="hit">
                           <td class="line" data-tooltip>396</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>21</td>
-                          <td class="source">    this.root.id &#x3D;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__397" class="hit">
+                        </tr>            <tr id="lib/api.js__397" class="chunks">
                           <td class="line" data-tooltip>397</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      null &#x3D;&#x3D; opts.id$</td>
+                          <td class="source"><div>  logspec &#x3D; </div><div class="miss false" data-tooltip>true &#x3D;&#x3D;&#x3D; logspec</div><div> || &#x27;true&#x27; &#x3D;&#x3D;&#x3D; logspec ? &#x27;test&#x27; : logspec</div></td>
                           
                         </tr>            <tr id="lib/api.js__398" class="hit">
                           <td class="line" data-tooltip>398</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        ? this.private$.actnid().substring(0, 4) + &#x27;/&#x27; + opts.tag</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__399" class="hit">
                           <td class="line" data-tooltip>399</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        : &#x27;&#x27; + opts.id$</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  var test_opts &#x3D; {</td>
                           
                         </tr>            <tr id="lib/api.js__400" class="hit">
                           <td class="line" data-tooltip>400</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    errhandler: null &#x3D;&#x3D; errhandler ? null : errhandler,</td>
                           
                         </tr>            <tr id="lib/api.js__401" class="hit">
                           <td class="line" data-tooltip>401</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    test: true,</td>
                           
                         </tr>            <tr id="lib/api.js__402" class="hit">
                           <td class="line" data-tooltip>402</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  if (&#x27;function&#x27; !&#x3D;&#x3D; typeof errhandler &amp;&amp; null !&#x3D;&#x3D; errhandler) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    quiet: false,</td>
                           
                         </tr>            <tr id="lib/api.js__403" class="hit">
                           <td class="line" data-tooltip>403</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>55</td>
-                          <td class="source">    logspec &#x3D; errhandler</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    reload$: true,</td>
                           
                         </tr>            <tr id="lib/api.js__404" class="hit">
                           <td class="line" data-tooltip>404</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>55</td>
-                          <td class="source">    errhandler &#x3D; null</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    log: logspec || &#x27;test&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__405" class="hit">
                           <td class="line" data-tooltip>405</td>
@@ -14859,11 +14859,11 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__407" class="chunks">
+                        </tr>            <tr id="lib/api.js__407" class="hit">
                           <td class="line" data-tooltip>407</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>  logspec &#x3D; </div><div class="miss false" data-tooltip>true &#x3D;&#x3D;&#x3D; logspec</div><div> || &#x27;true&#x27; &#x3D;&#x3D;&#x3D; logspec ? &#x27;test&#x27; : logspec</div></td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  var set_opts &#x3D; this.options(test_opts)</td>
                           
                         </tr>            <tr id="lib/api.js__408" class="hit">
                           <td class="line" data-tooltip>408</td>
@@ -14874,92 +14874,92 @@
                         </tr>            <tr id="lib/api.js__409" class="hit">
                           <td class="line" data-tooltip>409</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  var test_opts &#x3D; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // An override from env or args is possible.</td>
                           
                         </tr>            <tr id="lib/api.js__410" class="hit">
                           <td class="line" data-tooltip>410</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    errhandler: null &#x3D;&#x3D; errhandler ? null : errhandler,</td>
+                          <td class="hits" data-tooltip>203</td>
+                          <td class="source">  if (set_opts.quiet) {</td>
                           
                         </tr>            <tr id="lib/api.js__411" class="hit">
                           <td class="line" data-tooltip>411</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    test: true,</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    return this.quiet({ from: &#x27;test&#x27; })</td>
                           
                         </tr>            <tr id="lib/api.js__412" class="hit">
                           <td class="line" data-tooltip>412</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    quiet: false,</td>
+                          <td class="source">  } else {</td>
                           
                         </tr>            <tr id="lib/api.js__413" class="hit">
                           <td class="line" data-tooltip>413</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    reload$: true,</td>
+                          <td class="hits" data-tooltip>201</td>
+                          <td class="source">    this.private$.logging.build_log(this)</td>
                           
                         </tr>            <tr id="lib/api.js__414" class="hit">
                           <td class="line" data-tooltip>414</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    log: logspec || &#x27;test&#x27;,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__415" class="hit">
                           <td class="line" data-tooltip>415</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    // Manually set logger to test_logger (avoids infecting options structure),</td>
                           
                         </tr>            <tr id="lib/api.js__416" class="hit">
                           <td class="line" data-tooltip>416</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    // unless there was an external logger defined by the options</td>
                           
                         </tr>            <tr id="lib/api.js__417" class="hit">
                           <td class="line" data-tooltip>417</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  var set_opts &#x3D; this.options(test_opts)</td>
+                          <td class="hits" data-tooltip>201</td>
+                          <td class="source">    if (!this.private$.logger.from_options$) {</td>
                           
                         </tr>            <tr id="lib/api.js__418" class="hit">
                           <td class="line" data-tooltip>418</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>188</td>
+                          <td class="source">      this.root.private$.logger &#x3D; this.private$.logging.test_logger</td>
                           
                         </tr>            <tr id="lib/api.js__419" class="hit">
                           <td class="line" data-tooltip>419</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // An override from env or args is possible.</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__420" class="hit">
                           <td class="line" data-tooltip>420</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>203</td>
-                          <td class="source">  if (set_opts.quiet) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__421" class="hit">
                           <td class="line" data-tooltip>421</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    return this.quiet({ from: &#x27;test&#x27; })</td>
+                          <td class="hits" data-tooltip>201</td>
+                          <td class="source">    return this</td>
                           
                         </tr>            <tr id="lib/api.js__422" class="hit">
                           <td class="line" data-tooltip>422</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__423" class="hit">
                           <td class="line" data-tooltip>423</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>201</td>
-                          <td class="source">    this.private$.logging.build_log(this)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__424" class="hit">
                           <td class="line" data-tooltip>424</td>
@@ -14970,146 +14970,146 @@
                         </tr>            <tr id="lib/api.js__425" class="hit">
                           <td class="line" data-tooltip>425</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    // Manually set logger to test_logger (avoids infecting options structure),</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.ping &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__426" class="hit">
                           <td class="line" data-tooltip>426</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // unless there was an external logger defined by the options</td>
+                          <td class="source">  var now &#x3D; Date.now()</td>
                           
                         </tr>            <tr id="lib/api.js__427" class="hit">
                           <td class="line" data-tooltip>427</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>201</td>
-                          <td class="source">    if (!this.private$.logger.from_options$) {</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">  return {</td>
                           
                         </tr>            <tr id="lib/api.js__428" class="hit">
                           <td class="line" data-tooltip>428</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>188</td>
-                          <td class="source">      this.root.private$.logger &#x3D; this.private$.logging.test_logger</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    now: now,</td>
                           
                         </tr>            <tr id="lib/api.js__429" class="hit">
                           <td class="line" data-tooltip>429</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">    uptime: now - this.private$.stats.start,</td>
                           
                         </tr>            <tr id="lib/api.js__430" class="hit">
                           <td class="line" data-tooltip>430</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    id: this.id,</td>
                           
                         </tr>            <tr id="lib/api.js__431" class="hit">
                           <td class="line" data-tooltip>431</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>201</td>
-                          <td class="source">    return this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    cpu: process.cpuUsage(),</td>
                           
                         </tr>            <tr id="lib/api.js__432" class="hit">
                           <td class="line" data-tooltip>432</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    mem: process.memoryUsage(),</td>
                           
                         </tr>            <tr id="lib/api.js__433" class="hit">
                           <td class="line" data-tooltip>433</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    act: this.private$.stats.act,</td>
                           
                         </tr>            <tr id="lib/api.js__434" class="hit">
                           <td class="line" data-tooltip>434</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    tr: this.private$.transport.register.map(function (x) {</td>
                           
                         </tr>            <tr id="lib/api.js__435" class="hit">
                           <td class="line" data-tooltip>435</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.ping &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      return Object.assign({ when: x.when, err: x.err }, x.config)</td>
                           
                         </tr>            <tr id="lib/api.js__436" class="hit">
                           <td class="line" data-tooltip>436</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var now &#x3D; Date.now()</td>
+                          <td class="source">    }),</td>
                           
                         </tr>            <tr id="lib/api.js__437" class="hit">
                           <td class="line" data-tooltip>437</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">  return {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__438" class="hit">
                           <td class="line" data-tooltip>438</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    now: now,</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__439" class="hit">
                           <td class="line" data-tooltip>439</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    uptime: now - this.private$.stats.start,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__440" class="hit">
                           <td class="line" data-tooltip>440</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    id: this.id,</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.translate &#x3D; function (from_in, to_in, pick_in) {</td>
                           
                         </tr>            <tr id="lib/api.js__441" class="hit">
                           <td class="line" data-tooltip>441</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    cpu: process.cpuUsage(),</td>
+                          <td class="source">  var from &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof from_in ? Jsonic(from_in) : from_in</td>
                           
                         </tr>            <tr id="lib/api.js__442" class="hit">
                           <td class="line" data-tooltip>442</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    mem: process.memoryUsage(),</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  var to &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof to_in ? Jsonic(to_in) : to_in</td>
                           
                         </tr>            <tr id="lib/api.js__443" class="hit">
                           <td class="line" data-tooltip>443</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    act: this.private$.stats.act,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__444" class="hit">
                           <td class="line" data-tooltip>444</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    tr: this.private$.transport.register.map(function (x) {</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  var pick &#x3D; {}</td>
                           
                         </tr>            <tr id="lib/api.js__445" class="hit">
                           <td class="line" data-tooltip>445</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      return Object.assign({ when: x.when, err: x.err }, x.config)</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__446" class="hit">
                           <td class="line" data-tooltip>446</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }),</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  if (&#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pick_in) {</td>
                           
                         </tr>            <tr id="lib/api.js__447" class="hit">
                           <td class="line" data-tooltip>447</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>4</td>
+                          <td class="source">    pick_in &#x3D; pick_in.split(/\s*,\s*/)</td>
                           
                         </tr>            <tr id="lib/api.js__448" class="hit">
                           <td class="line" data-tooltip>448</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__449" class="hit">
                           <td class="line" data-tooltip>449</td>
@@ -15120,284 +15120,284 @@
                         </tr>            <tr id="lib/api.js__450" class="hit">
                           <td class="line" data-tooltip>450</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.translate &#x3D; function (from_in, to_in, pick_in) {</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  if (Array.isArray(pick_in)) {</td>
                           
                         </tr>            <tr id="lib/api.js__451" class="hit">
                           <td class="line" data-tooltip>451</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var from &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof from_in ? Jsonic(from_in) : from_in</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">    pick_in.forEach(function (prop) {</td>
                           
                         </tr>            <tr id="lib/api.js__452" class="hit">
                           <td class="line" data-tooltip>452</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  var to &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof to_in ? Jsonic(to_in) : to_in</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      if (prop.startsWith(&#x27;-&#x27;)) {</td>
                           
                         </tr>            <tr id="lib/api.js__453" class="hit">
                           <td class="line" data-tooltip>453</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">        pick[prop.substring(1)] &#x3D; false</td>
                           
                         </tr>            <tr id="lib/api.js__454" class="hit">
                           <td class="line" data-tooltip>454</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  var pick &#x3D; {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      } else {</td>
                           
                         </tr>            <tr id="lib/api.js__455" class="hit">
                           <td class="line" data-tooltip>455</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>7</td>
+                          <td class="source">        pick[prop] &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__456" class="hit">
                           <td class="line" data-tooltip>456</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  if (&#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pick_in) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__457" class="hit">
                           <td class="line" data-tooltip>457</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>4</td>
-                          <td class="source">    pick_in &#x3D; pick_in.split(/\s*,\s*/)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__458" class="hit">
                           <td class="line" data-tooltip>458</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">  } else if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof pick_in) {</td>
                           
                         </tr>            <tr id="lib/api.js__459" class="hit">
                           <td class="line" data-tooltip>459</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    pick &#x3D; Object.assign({}, pick_in)</td>
                           
                         </tr>            <tr id="lib/api.js__460" class="hit">
                           <td class="line" data-tooltip>460</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  if (Array.isArray(pick_in)) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  } else {</td>
                           
                         </tr>            <tr id="lib/api.js__461" class="hit">
                           <td class="line" data-tooltip>461</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">    pick_in.forEach(function (prop) {</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    pick &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__462" class="hit">
                           <td class="line" data-tooltip>462</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      if (prop.startsWith(&#x27;-&#x27;)) {</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__463" class="hit">
                           <td class="line" data-tooltip>463</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">        pick[prop.substring(1)] &#x3D; false</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__464" class="hit">
                           <td class="line" data-tooltip>464</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      } else {</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  this.add(from, function (msg, reply) {</td>
                           
                         </tr>            <tr id="lib/api.js__465" class="hit">
                           <td class="line" data-tooltip>465</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7</td>
-                          <td class="source">        pick[prop] &#x3D; true</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    var pick_msg</td>
                           
                         </tr>            <tr id="lib/api.js__466" class="hit">
                           <td class="line" data-tooltip>466</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__467" class="hit">
                           <td class="line" data-tooltip>467</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">    if (pick) {</td>
                           
                         </tr>            <tr id="lib/api.js__468" class="hit">
                           <td class="line" data-tooltip>468</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">  } else if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof pick_in) {</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">      pick_msg &#x3D; {}</td>
                           
                         </tr>            <tr id="lib/api.js__469" class="hit">
                           <td class="line" data-tooltip>469</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    pick &#x3D; Object.assign({}, pick_in)</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">      Object.keys(pick).forEach(function (prop) {</td>
                           
                         </tr>            <tr id="lib/api.js__470" class="hit">
                           <td class="line" data-tooltip>470</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  } else {</td>
+                          <td class="source">        if (pick[prop]) {</td>
                           
                         </tr>            <tr id="lib/api.js__471" class="hit">
                           <td class="line" data-tooltip>471</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    pick &#x3D; null</td>
+                          <td class="hits" data-tooltip>9</td>
+                          <td class="source">          pick_msg[prop] &#x3D; msg[prop]</td>
                           
                         </tr>            <tr id="lib/api.js__472" class="hit">
                           <td class="line" data-tooltip>472</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__473" class="hit">
                           <td class="line" data-tooltip>473</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      })</td>
                           
                         </tr>            <tr id="lib/api.js__474" class="hit">
                           <td class="line" data-tooltip>474</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  this.add(from, function (msg, reply) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    } else {</td>
                           
                         </tr>            <tr id="lib/api.js__475" class="hit">
                           <td class="line" data-tooltip>475</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    var pick_msg</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">      pick_msg &#x3D; this.util.clean(msg)</td>
                           
                         </tr>            <tr id="lib/api.js__476" class="hit">
                           <td class="line" data-tooltip>476</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__477" class="hit">
                           <td class="line" data-tooltip>477</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">    if (pick) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__478" class="hit">
                           <td class="line" data-tooltip>478</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">      pick_msg &#x3D; {}</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">    var transmsg &#x3D; Object.assign(pick_msg, to)</td>
                           
                         </tr>            <tr id="lib/api.js__479" class="hit">
                           <td class="line" data-tooltip>479</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">      Object.keys(pick).forEach(function (prop) {</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">    this.act(transmsg, reply)</td>
                           
                         </tr>            <tr id="lib/api.js__480" class="hit">
                           <td class="line" data-tooltip>480</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        if (pick[prop]) {</td>
+                          <td class="source">  })</td>
                           
                         </tr>            <tr id="lib/api.js__481" class="hit">
                           <td class="line" data-tooltip>481</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
-                          <td class="source">          pick_msg[prop] &#x3D; msg[prop]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__482" class="hit">
                           <td class="line" data-tooltip>482</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__483" class="hit">
                           <td class="line" data-tooltip>483</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      })</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__484" class="hit">
                           <td class="line" data-tooltip>484</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    } else {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__485" class="hit">
                           <td class="line" data-tooltip>485</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">      pick_msg &#x3D; this.util.clean(msg)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.gate &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__486" class="hit">
                           <td class="line" data-tooltip>486</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">  return this.delegate({ gate$: true })</td>
                           
                         </tr>            <tr id="lib/api.js__487" class="hit">
                           <td class="line" data-tooltip>487</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__488" class="hit">
                           <td class="line" data-tooltip>488</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">    var transmsg &#x3D; Object.assign(pick_msg, to)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__489" class="hit">
                           <td class="line" data-tooltip>489</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">    this.act(transmsg, reply)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.ungate &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__490" class="hit">
                           <td class="line" data-tooltip>490</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  })</td>
+                          <td class="source">  this.fixedargs.gate$ &#x3D; false</td>
                           
                         </tr>            <tr id="lib/api.js__491" class="hit">
                           <td class="line" data-tooltip>491</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__492" class="hit">
                           <td class="line" data-tooltip>492</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__493" class="hit">
                           <td class="line" data-tooltip>493</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__494" class="hit">
                           <td class="line" data-tooltip>494</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">// TODO this needs a better name</td>
                           
                         </tr>            <tr id="lib/api.js__495" class="hit">
                           <td class="line" data-tooltip>495</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.gate &#x3D; function () {</td>
+                          <td class="source">exports.list_plugins &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__496" class="hit">
                           <td class="line" data-tooltip>496</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return this.delegate({ gate$: true })</td>
+                          <td class="source">  return Object.assign({}, this.private$.plugins)</td>
                           
                         </tr>            <tr id="lib/api.js__497" class="hit">
                           <td class="line" data-tooltip>497</td>
@@ -15415,19 +15415,19 @@
                           <td class="line" data-tooltip>499</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.ungate &#x3D; function () {</td>
+                          <td class="source">exports.find_plugin &#x3D; function (plugindesc, tag) {</td>
                           
                         </tr>            <tr id="lib/api.js__500" class="hit">
                           <td class="line" data-tooltip>500</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  this.fixedargs.gate$ &#x3D; false</td>
+                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
                           
                         </tr>            <tr id="lib/api.js__501" class="hit">
                           <td class="line" data-tooltip>501</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip>4</td>
+                          <td class="source">  return this.private$.plugins[plugin_key]</td>
                           
                         </tr>            <tr id="lib/api.js__502" class="hit">
                           <td class="line" data-tooltip>502</td>
@@ -15444,20 +15444,20 @@
                         </tr>            <tr id="lib/api.js__504" class="hit">
                           <td class="line" data-tooltip>504</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// TODO this needs a better name</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.has_plugin &#x3D; function (plugindesc, tag) {</td>
                           
                         </tr>            <tr id="lib/api.js__505" class="hit">
                           <td class="line" data-tooltip>505</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.list_plugins &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
                           
                         </tr>            <tr id="lib/api.js__506" class="hit">
                           <td class="line" data-tooltip>506</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  return Object.assign({}, this.private$.plugins)</td>
+                          <td class="hits" data-tooltip>13</td>
+                          <td class="source">  return !!this.private$.plugins[plugin_key]</td>
                           
                         </tr>            <tr id="lib/api.js__507" class="hit">
                           <td class="line" data-tooltip>507</td>
@@ -15475,109 +15475,109 @@
                           <td class="line" data-tooltip>509</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.find_plugin &#x3D; function (plugindesc, tag) {</td>
+                          <td class="source">exports.ignore_plugin &#x3D; function (plugindesc, tag, ignore) {</td>
                           
                         </tr>            <tr id="lib/api.js__510" class="hit">
                           <td class="line" data-tooltip>510</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
+                          <td class="source">  if (&#x27;boolean&#x27; &#x3D;&#x3D;&#x3D; typeof tag) {</td>
                           
                         </tr>            <tr id="lib/api.js__511" class="hit">
                           <td class="line" data-tooltip>511</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>4</td>
-                          <td class="source">  return this.private$.plugins[plugin_key]</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">    ignore &#x3D; tag</td>
                           
                         </tr>            <tr id="lib/api.js__512" class="hit">
                           <td class="line" data-tooltip>512</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>5</td>
+                          <td class="source">    tag &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__513" class="hit">
                           <td class="line" data-tooltip>513</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__514" class="hit">
                           <td class="line" data-tooltip>514</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.has_plugin &#x3D; function (plugindesc, tag) {</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
                           
                         </tr>            <tr id="lib/api.js__515" class="hit">
                           <td class="line" data-tooltip>515</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">  var resolved_ignore &#x3D; (this.private$.ignore_plugins[plugin_key] &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__516" class="hit">
                           <td class="line" data-tooltip>516</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>13</td>
-                          <td class="source">  return !!this.private$.plugins[plugin_key]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    null &#x3D;&#x3D; ignore ? true : !!ignore)</td>
                           
                         </tr>            <tr id="lib/api.js__517" class="hit">
                           <td class="line" data-tooltip>517</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__518" class="hit">
                           <td class="line" data-tooltip>518</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>8</td>
+                          <td class="source">  this.log.info({</td>
                           
                         </tr>            <tr id="lib/api.js__519" class="hit">
                           <td class="line" data-tooltip>519</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.ignore_plugin &#x3D; function (plugindesc, tag, ignore) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    kind: &#x27;plugin&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__520" class="hit">
                           <td class="line" data-tooltip>520</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  if (&#x27;boolean&#x27; &#x3D;&#x3D;&#x3D; typeof tag) {</td>
+                          <td class="source">    case: &#x27;ignore&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__521" class="hit">
                           <td class="line" data-tooltip>521</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">    ignore &#x3D; tag</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    full: plugin_key,</td>
                           
                         </tr>            <tr id="lib/api.js__522" class="hit">
                           <td class="line" data-tooltip>522</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>5</td>
-                          <td class="source">    tag &#x3D; null</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    ignore: resolved_ignore,</td>
                           
                         </tr>            <tr id="lib/api.js__523" class="hit">
                           <td class="line" data-tooltip>523</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">  })</td>
                           
                         </tr>            <tr id="lib/api.js__524" class="hit">
                           <td class="line" data-tooltip>524</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">  var plugin_key &#x3D; Common.make_plugin_key(plugindesc, tag)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__525" class="hit">
                           <td class="line" data-tooltip>525</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>8</td>
-                          <td class="source">  var resolved_ignore &#x3D; (this.private$.ignore_plugins[plugin_key] &#x3D;</td>
+                          <td class="source">  return this</td>
                           
                         </tr>            <tr id="lib/api.js__526" class="hit">
                           <td class="line" data-tooltip>526</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    null &#x3D;&#x3D; ignore ? true : !!ignore)</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__527" class="hit">
                           <td class="line" data-tooltip>527</td>
@@ -15588,56 +15588,56 @@
                         </tr>            <tr id="lib/api.js__528" class="hit">
                           <td class="line" data-tooltip>528</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">  this.log.info({</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">// Find the action metadata for a given pattern, if it exists.</td>
                           
                         </tr>            <tr id="lib/api.js__529" class="hit">
                           <td class="line" data-tooltip>529</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    kind: &#x27;plugin&#x27;,</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.find &#x3D; function (pattern, flags) {</td>
                           
                         </tr>            <tr id="lib/api.js__530" class="hit">
                           <td class="line" data-tooltip>530</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    case: &#x27;ignore&#x27;,</td>
+                          <td class="source">  var seneca &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__531" class="hit">
                           <td class="line" data-tooltip>531</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    full: plugin_key,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__532" class="hit">
                           <td class="line" data-tooltip>532</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    ignore: resolved_ignore,</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  var pat &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pattern ? Jsonic(pattern) : pattern</td>
                           
                         </tr>            <tr id="lib/api.js__533" class="hit">
                           <td class="line" data-tooltip>533</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  })</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  pat &#x3D; seneca.util.clean(pat)</td>
                           
                         </tr>            <tr id="lib/api.js__534" class="hit">
                           <td class="line" data-tooltip>534</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  pat &#x3D; pat || {}</td>
                           
                         </tr>            <tr id="lib/api.js__535" class="hit">
                           <td class="line" data-tooltip>535</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>8</td>
-                          <td class="source">  return this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__536" class="hit">
                           <td class="line" data-tooltip>536</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  var actdef &#x3D; seneca.private$.actrouter.find(pat, flags &amp;&amp; flags.exact)</td>
                           
                         </tr>            <tr id="lib/api.js__537" class="hit">
                           <td class="line" data-tooltip>537</td>
@@ -15648,20 +15648,20 @@
                         </tr>            <tr id="lib/api.js__538" class="hit">
                           <td class="line" data-tooltip>538</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// Find the action metadata for a given pattern, if it exists.</td>
+                          <td class="hits" data-tooltip>10274</td>
+                          <td class="source">  if (!actdef) {</td>
                           
                         </tr>            <tr id="lib/api.js__539" class="hit">
                           <td class="line" data-tooltip>539</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.find &#x3D; function (pattern, flags) {</td>
+                          <td class="hits" data-tooltip>7692</td>
+                          <td class="source">    actdef &#x3D; seneca.private$.actrouter.find({})</td>
                           
                         </tr>            <tr id="lib/api.js__540" class="hit">
                           <td class="line" data-tooltip>540</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var seneca &#x3D; this</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__541" class="hit">
                           <td class="line" data-tooltip>541</td>
@@ -15673,319 +15673,319 @@
                           <td class="line" data-tooltip>542</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  var pat &#x3D; &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pattern ? Jsonic(pattern) : pattern</td>
+                          <td class="source">  return actdef</td>
                           
                         </tr>            <tr id="lib/api.js__543" class="hit">
                           <td class="line" data-tooltip>543</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  pat &#x3D; seneca.util.clean(pat)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__544" class="hit">
                           <td class="line" data-tooltip>544</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  pat &#x3D; pat || {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__545" class="hit">
                           <td class="line" data-tooltip>545</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">// True if an action matching the pattern exists.</td>
                           
                         </tr>            <tr id="lib/api.js__546" class="hit">
                           <td class="line" data-tooltip>546</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  var actdef &#x3D; seneca.private$.actrouter.find(pat, flags &amp;&amp; flags.exact)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.has &#x3D; function (pattern) {</td>
                           
                         </tr>            <tr id="lib/api.js__547" class="hit">
                           <td class="line" data-tooltip>547</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  return !!this.find(pattern, { exact: true })</td>
                           
                         </tr>            <tr id="lib/api.js__548" class="hit">
                           <td class="line" data-tooltip>548</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  if (!actdef) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__549" class="hit">
                           <td class="line" data-tooltip>549</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>7692</td>
-                          <td class="source">    actdef &#x3D; seneca.private$.actrouter.find({})</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__550" class="hit">
                           <td class="line" data-tooltip>550</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">// List all actions that match the pattern.</td>
                           
                         </tr>            <tr id="lib/api.js__551" class="hit">
                           <td class="line" data-tooltip>551</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.list &#x3D; function (pattern) {</td>
                           
                         </tr>            <tr id="lib/api.js__552" class="hit">
                           <td class="line" data-tooltip>552</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10274</td>
-                          <td class="source">  return actdef</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  return this.private$.actrouter</td>
                           
                         </tr>            <tr id="lib/api.js__553" class="hit">
                           <td class="line" data-tooltip>553</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    .list(null &#x3D;&#x3D; pattern ? {} : Jsonic(pattern))</td>
                           
                         </tr>            <tr id="lib/api.js__554" class="hit">
                           <td class="line" data-tooltip>554</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    .map((x) &#x3D;&gt; x.match)</td>
                           
                         </tr>            <tr id="lib/api.js__555" class="hit">
                           <td class="line" data-tooltip>555</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// True if an action matching the pattern exists.</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__556" class="hit">
                           <td class="line" data-tooltip>556</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.has &#x3D; function (pattern) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  /*</td>
                           
                         </tr>            <tr id="lib/api.js__557" class="hit">
                           <td class="line" data-tooltip>557</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return !!this.find(pattern, { exact: true })</td>
+                          <td class="source">  return _.map(</td>
                           
                         </tr>            <tr id="lib/api.js__558" class="hit">
                           <td class="line" data-tooltip>558</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    this.private$.actrouter.list(null &#x3D;&#x3D; pattern ? {} : Jsonic(pattern)),</td>
                           
                         </tr>            <tr id="lib/api.js__559" class="hit">
                           <td class="line" data-tooltip>559</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    &#x27;match&#x27;</td>
                           
                         </tr>            <tr id="lib/api.js__560" class="hit">
                           <td class="line" data-tooltip>560</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// List all actions that match the pattern.</td>
+                          <td class="source">  )</td>
                           
                         </tr>            <tr id="lib/api.js__561" class="hit">
                           <td class="line" data-tooltip>561</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.list &#x3D; function (pattern) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  */</td>
                           
                         </tr>            <tr id="lib/api.js__562" class="hit">
                           <td class="line" data-tooltip>562</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return this.private$.actrouter</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__563" class="hit">
                           <td class="line" data-tooltip>563</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    .list(null &#x3D;&#x3D; pattern ? {} : Jsonic(pattern))</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__564" class="hit">
                           <td class="line" data-tooltip>564</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    .map((x) &#x3D;&gt; x.match)</td>
+                          <td class="source">// Get the current status of the instance.</td>
                           
                         </tr>            <tr id="lib/api.js__565" class="hit">
                           <td class="line" data-tooltip>565</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.status &#x3D; function (flags) {</td>
                           
                         </tr>            <tr id="lib/api.js__566" class="hit">
                           <td class="line" data-tooltip>566</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  /*</td>
+                          <td class="source">  flags &#x3D; flags || {}</td>
                           
                         </tr>            <tr id="lib/api.js__567" class="hit">
                           <td class="line" data-tooltip>567</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return _.map(</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__568" class="hit">
                           <td class="line" data-tooltip>568</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    this.private$.actrouter.list(null &#x3D;&#x3D; pattern ? {} : Jsonic(pattern)),</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  var hist &#x3D; this.private$.history.stats()</td>
                           
                         </tr>            <tr id="lib/api.js__569" class="hit">
                           <td class="line" data-tooltip>569</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;match&#x27;</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  hist.log &#x3D; this.private$.history.list()</td>
                           
                         </tr>            <tr id="lib/api.js__570" class="hit">
                           <td class="line" data-tooltip>570</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  )</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__571" class="hit">
                           <td class="line" data-tooltip>571</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  */</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  var status &#x3D; {</td>
                           
                         </tr>            <tr id="lib/api.js__572" class="hit">
                           <td class="line" data-tooltip>572</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    stats: this.stats(flags.stats),</td>
                           
                         </tr>            <tr id="lib/api.js__573" class="hit">
                           <td class="line" data-tooltip>573</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    history: hist,</td>
                           
                         </tr>            <tr id="lib/api.js__574" class="hit">
                           <td class="line" data-tooltip>574</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Get the current status of the instance.</td>
+                          <td class="source">    transport: this.private$.transport,</td>
                           
                         </tr>            <tr id="lib/api.js__575" class="hit">
                           <td class="line" data-tooltip>575</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.status &#x3D; function (flags) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__576" class="hit">
                           <td class="line" data-tooltip>576</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  flags &#x3D; flags || {}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__577" class="hit">
                           <td class="line" data-tooltip>577</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  return status</td>
                           
                         </tr>            <tr id="lib/api.js__578" class="hit">
                           <td class="line" data-tooltip>578</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  var hist &#x3D; this.private$.history.stats()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__579" class="hit">
                           <td class="line" data-tooltip>579</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  hist.log &#x3D; this.private$.history.list()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__580" class="hit">
                           <td class="line" data-tooltip>580</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">// Reply to an action that is waiting for a result.</td>
                           
                         </tr>            <tr id="lib/api.js__581" class="hit">
                           <td class="line" data-tooltip>581</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  var status &#x3D; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">// Used by transports to decouple sending messages from receiving responses.</td>
                           
                         </tr>            <tr id="lib/api.js__582" class="hit">
                           <td class="line" data-tooltip>582</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    stats: this.stats(flags.stats),</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.reply &#x3D; function (spec) {</td>
                           
                         </tr>            <tr id="lib/api.js__583" class="hit">
                           <td class="line" data-tooltip>583</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    history: hist,</td>
+                          <td class="source">  var instance &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__584" class="hit">
                           <td class="line" data-tooltip>584</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    transport: this.private$.transport,</td>
+                          <td class="hits" data-tooltip>34</td>
+                          <td class="source">  var actctxt &#x3D; null</td>
                           
                         </tr>            <tr id="lib/api.js__585" class="hit">
                           <td class="line" data-tooltip>585</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__586" class="hit">
                           <td class="line" data-tooltip>586</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>34</td>
+                          <td class="source">  if (spec &amp;&amp; spec.meta) {</td>
                           
                         </tr>            <tr id="lib/api.js__587" class="hit">
                           <td class="line" data-tooltip>587</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  return status</td>
+                          <td class="hits" data-tooltip>32</td>
+                          <td class="source">    actctxt &#x3D; instance.private$.history.get(spec.meta.id)</td>
                           
                         </tr>            <tr id="lib/api.js__588" class="hit">
                           <td class="line" data-tooltip>588</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>32</td>
+                          <td class="source">    if (actctxt) {</td>
                           
                         </tr>            <tr id="lib/api.js__589" class="hit">
                           <td class="line" data-tooltip>589</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>31</td>
+                          <td class="source">      actctxt.reply(spec.err, spec.out, spec.meta)</td>
                           
                         </tr>            <tr id="lib/api.js__590" class="hit">
                           <td class="line" data-tooltip>590</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Reply to an action that is waiting for a result.</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__591" class="hit">
                           <td class="line" data-tooltip>591</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Used by transports to decouple sending messages from receiving responses.</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__592" class="hit">
                           <td class="line" data-tooltip>592</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.reply &#x3D; function (spec) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__593" class="hit">
                           <td class="line" data-tooltip>593</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var instance &#x3D; this</td>
+                          <td class="hits" data-tooltip>34</td>
+                          <td class="source">  return !!actctxt</td>
                           
                         </tr>            <tr id="lib/api.js__594" class="hit">
                           <td class="line" data-tooltip>594</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>34</td>
-                          <td class="source">  var actctxt &#x3D; null</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__595" class="hit">
                           <td class="line" data-tooltip>595</td>
@@ -15996,134 +15996,134 @@
                         </tr>            <tr id="lib/api.js__596" class="hit">
                           <td class="line" data-tooltip>596</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>34</td>
-                          <td class="source">  if (spec &amp;&amp; spec.meta) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">// Listen for inbound messages.</td>
                           
                         </tr>            <tr id="lib/api.js__597" class="hit">
                           <td class="line" data-tooltip>597</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>32</td>
-                          <td class="source">    actctxt &#x3D; instance.private$.history.get(spec.meta.id)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.listen &#x3D; function (callpoint) {</td>
                           
                         </tr>            <tr id="lib/api.js__598" class="hit">
                           <td class="line" data-tooltip>598</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>32</td>
-                          <td class="source">    if (actctxt) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  return function api_listen(...argsarr) {</td>
                           
                         </tr>            <tr id="lib/api.js__599" class="hit">
                           <td class="line" data-tooltip>599</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>31</td>
-                          <td class="source">      actctxt.reply(spec.err, spec.out, spec.meta)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    var private$ &#x3D; this.private$</td>
                           
                         </tr>            <tr id="lib/api.js__600" class="hit">
                           <td class="line" data-tooltip>600</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__601" class="hit">
                           <td class="line" data-tooltip>601</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__602" class="hit">
                           <td class="line" data-tooltip>602</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    var done &#x3D; argsarr[argsarr.length - 1]</td>
                           
                         </tr>            <tr id="lib/api.js__603" class="hit">
                           <td class="line" data-tooltip>603</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>34</td>
-                          <td class="source">  return !!actctxt</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    if (typeof done &#x3D;&#x3D;&#x3D; &#x27;function&#x27;) {</td>
                           
                         </tr>            <tr id="lib/api.js__604" class="hit">
                           <td class="line" data-tooltip>604</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      argsarr.pop()</td>
                           
                         </tr>            <tr id="lib/api.js__605" class="hit">
                           <td class="line" data-tooltip>605</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    } else {</td>
                           
                         </tr>            <tr id="lib/api.js__606" class="hit">
                           <td class="line" data-tooltip>606</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// Listen for inbound messages.</td>
+                          <td class="hits" data-tooltip>46</td>
+                          <td class="source">      done &#x3D; () &#x3D;&gt; {}</td>
                           
                         </tr>            <tr id="lib/api.js__607" class="hit">
                           <td class="line" data-tooltip>607</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.listen &#x3D; function (callpoint) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__608" class="hit">
                           <td class="line" data-tooltip>608</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return function api_listen(...argsarr) {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__609" class="hit">
                           <td class="line" data-tooltip>609</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    var private$ &#x3D; this.private$</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    self.log.info({</td>
                           
                         </tr>            <tr id="lib/api.js__610" class="hit">
                           <td class="line" data-tooltip>610</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    var self &#x3D; this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      kind: &#x27;listen&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__611" class="hit">
                           <td class="line" data-tooltip>611</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      case: &#x27;INIT&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__612" class="hit">
                           <td class="line" data-tooltip>612</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    var done &#x3D; argsarr[argsarr.length - 1]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      data: argsarr,</td>
                           
                         </tr>            <tr id="lib/api.js__613" class="hit">
                           <td class="line" data-tooltip>613</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    if (typeof done &#x3D;&#x3D;&#x3D; &#x27;function&#x27;) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      callpoint: callpoint(true),</td>
                           
                         </tr>            <tr id="lib/api.js__614" class="hit">
                           <td class="line" data-tooltip>614</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      argsarr.pop()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__615" class="hit">
                           <td class="line" data-tooltip>615</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    } else {</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__616" class="hit">
+                        </tr>            <tr id="lib/api.js__616" class="chunks">
                           <td class="line" data-tooltip>616</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>46</td>
-                          <td class="source">      done &#x3D; () &#x3D;&gt; {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>    var opts &#x3D; </div><div class="miss true" data-tooltip>self.options().transport</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
                           
                         </tr>            <tr id="lib/api.js__617" class="hit">
                           <td class="line" data-tooltip>617</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    var config &#x3D; intern.resolve_config(intern.parse_config(argsarr), opts)</td>
                           
                         </tr>            <tr id="lib/api.js__618" class="hit">
                           <td class="line" data-tooltip>618</td>
@@ -16135,199 +16135,199 @@
                           <td class="line" data-tooltip>619</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>47</td>
-                          <td class="source">    self.log.info({</td>
+                          <td class="source">    self.act(</td>
                           
                         </tr>            <tr id="lib/api.js__620" class="hit">
                           <td class="line" data-tooltip>620</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      kind: &#x27;listen&#x27;,</td>
+                          <td class="source">      &#x27;role:transport,cmd:listen&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__621" class="hit">
                           <td class="line" data-tooltip>621</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      case: &#x27;INIT&#x27;,</td>
+                          <td class="source">      { config: config, gate$: true },</td>
                           
                         </tr>            <tr id="lib/api.js__622" class="hit">
                           <td class="line" data-tooltip>622</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      data: argsarr,</td>
+                          <td class="source">      function (err, result) {</td>
                           
-                        </tr>            <tr id="lib/api.js__623" class="hit">
+                        </tr>            <tr id="lib/api.js__623" class="chunks">
                           <td class="line" data-tooltip>623</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      callpoint: callpoint(true),</td>
+                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>err</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__624" class="hit">
+                        </tr>            <tr id="lib/api.js__624" class="miss">
                           <td class="line" data-tooltip>624</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source" data-tooltip>          return self.die(private$.error(err, &#x27;transport_listen&#x27;, config))</td>
                           
                         </tr>            <tr id="lib/api.js__625" class="hit">
                           <td class="line" data-tooltip>625</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">        }</td>
                           
-                        </tr>            <tr id="lib/api.js__626" class="chunks">
+                        </tr>            <tr id="lib/api.js__626" class="hit">
                           <td class="line" data-tooltip>626</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var opts &#x3D; </div><div class="miss true" data-tooltip>self.options().transport</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__627" class="hit">
                           <td class="line" data-tooltip>627</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>47</td>
-                          <td class="source">    var config &#x3D; intern.resolve_config(intern.parse_config(argsarr), opts)</td>
+                          <td class="source">        done(null, result)</td>
                           
                         </tr>            <tr id="lib/api.js__628" class="hit">
                           <td class="line" data-tooltip>628</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">        done &#x3D; () &#x3D;&gt; {}</td>
                           
                         </tr>            <tr id="lib/api.js__629" class="hit">
                           <td class="line" data-tooltip>629</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    self.act(</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__630" class="hit">
                           <td class="line" data-tooltip>630</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      &#x27;role:transport,cmd:listen&#x27;,</td>
+                          <td class="source">    )</td>
                           
                         </tr>            <tr id="lib/api.js__631" class="hit">
                           <td class="line" data-tooltip>631</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      { config: config, gate$: true },</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__632" class="hit">
                           <td class="line" data-tooltip>632</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      function (err, result) {</td>
+                          <td class="hits" data-tooltip>47</td>
+                          <td class="source">    return self</td>
                           
-                        </tr>            <tr id="lib/api.js__633" class="chunks">
+                        </tr>            <tr id="lib/api.js__633" class="hit">
                           <td class="line" data-tooltip>633</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>err</div><div>) {</div></td>
+                          <td class="source">  }</td>
                           
-                        </tr>            <tr id="lib/api.js__634" class="miss">
+                        </tr>            <tr id="lib/api.js__634" class="hit">
                           <td class="line" data-tooltip>634</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>          return self.die(private$.error(err, &#x27;transport_listen&#x27;, config))</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__635" class="hit">
                           <td class="line" data-tooltip>635</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__636" class="hit">
                           <td class="line" data-tooltip>636</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">// Send outbound messages.</td>
                           
                         </tr>            <tr id="lib/api.js__637" class="hit">
                           <td class="line" data-tooltip>637</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">        done(null, result)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.client &#x3D; function (callpoint) {</td>
                           
                         </tr>            <tr id="lib/api.js__638" class="hit">
                           <td class="line" data-tooltip>638</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">        done &#x3D; () &#x3D;&gt; {}</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  return function api_client() {</td>
                           
                         </tr>            <tr id="lib/api.js__639" class="hit">
                           <td class="line" data-tooltip>639</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">    var private$ &#x3D; this.private$</td>
                           
                         </tr>            <tr id="lib/api.js__640" class="hit">
                           <td class="line" data-tooltip>640</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    )</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var argsarr &#x3D; Array.prototype.slice.call(arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__641" class="hit">
                           <td class="line" data-tooltip>641</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var self &#x3D; this</td>
                           
                         </tr>            <tr id="lib/api.js__642" class="hit">
                           <td class="line" data-tooltip>642</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>47</td>
-                          <td class="source">    return self</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__643" class="hit">
                           <td class="line" data-tooltip>643</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    self.log.info({</td>
                           
                         </tr>            <tr id="lib/api.js__644" class="hit">
                           <td class="line" data-tooltip>644</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">      kind: &#x27;client&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__645" class="hit">
                           <td class="line" data-tooltip>645</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      case: &#x27;INIT&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__646" class="hit">
                           <td class="line" data-tooltip>646</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Send outbound messages.</td>
+                          <td class="source">      data: argsarr,</td>
                           
                         </tr>            <tr id="lib/api.js__647" class="hit">
                           <td class="line" data-tooltip>647</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.client &#x3D; function (callpoint) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      callpoint: callpoint(true),</td>
                           
                         </tr>            <tr id="lib/api.js__648" class="hit">
                           <td class="line" data-tooltip>648</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  return function api_client() {</td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__649" class="hit">
                           <td class="line" data-tooltip>649</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    var private$ &#x3D; this.private$</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__650" class="hit">
+                        </tr>            <tr id="lib/api.js__650" class="chunks">
                           <td class="line" data-tooltip>650</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var argsarr &#x3D; Array.prototype.slice.call(arguments)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>    var legacy &#x3D; </div><div class="miss true" data-tooltip>self.options().legacy</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
                           
-                        </tr>            <tr id="lib/api.js__651" class="hit">
+                        </tr>            <tr id="lib/api.js__651" class="chunks">
                           <td class="line" data-tooltip>651</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var self &#x3D; this</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>    var opts &#x3D; </div><div class="miss true" data-tooltip>self.options().transport</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
                           
                         </tr>            <tr id="lib/api.js__652" class="hit">
                           <td class="line" data-tooltip>652</td>
@@ -16339,37 +16339,37 @@
                           <td class="line" data-tooltip>653</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>43</td>
-                          <td class="source">    self.log.info({</td>
+                          <td class="source">    var raw_config &#x3D; intern.parse_config(argsarr)</td>
                           
                         </tr>            <tr id="lib/api.js__654" class="hit">
                           <td class="line" data-tooltip>654</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      kind: &#x27;client&#x27;,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__655" class="hit">
                           <td class="line" data-tooltip>655</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      case: &#x27;INIT&#x27;,</td>
+                          <td class="source">    // pg: pin group</td>
                           
                         </tr>            <tr id="lib/api.js__656" class="hit">
                           <td class="line" data-tooltip>656</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      data: argsarr,</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    raw_config.pg &#x3D; Common.pincanon(raw_config.pin || raw_config.pins)</td>
                           
                         </tr>            <tr id="lib/api.js__657" class="hit">
                           <td class="line" data-tooltip>657</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      callpoint: callpoint(true),</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__658" class="hit">
                           <td class="line" data-tooltip>658</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var config &#x3D; intern.resolve_config(raw_config, opts)</td>
                           
                         </tr>            <tr id="lib/api.js__659" class="hit">
                           <td class="line" data-tooltip>659</td>
@@ -16377,59 +16377,59 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__660" class="chunks">
+                        </tr>            <tr id="lib/api.js__660" class="hit">
                           <td class="line" data-tooltip>660</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var legacy &#x3D; </div><div class="miss true" data-tooltip>self.options().legacy</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    config.id &#x3D; config.id || Common.pattern(raw_config)</td>
                           
-                        </tr>            <tr id="lib/api.js__661" class="chunks">
+                        </tr>            <tr id="lib/api.js__661" class="hit">
                           <td class="line" data-tooltip>661</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    var opts &#x3D; </div><div class="miss true" data-tooltip>self.options().transport</div><div> || </div><div class="miss never" data-tooltip>{}</div></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__662" class="hit">
                           <td class="line" data-tooltip>662</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var pins &#x3D;</td>
                           
                         </tr>            <tr id="lib/api.js__663" class="hit">
                           <td class="line" data-tooltip>663</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var raw_config &#x3D; intern.parse_config(argsarr)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      config.pins ||</td>
                           
-                        </tr>            <tr id="lib/api.js__664" class="hit">
+                        </tr>            <tr id="lib/api.js__664" class="chunks">
                           <td class="line" data-tooltip>664</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>      (</div><div class="miss false" data-tooltip>Array.isArray(config.pin)</div><div> ? </div><div class="miss never" data-tooltip>config.pin</div><div> : [config.pin || &#x27;&#x27;])</div></td>
                           
                         </tr>            <tr id="lib/api.js__665" class="hit">
                           <td class="line" data-tooltip>665</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // pg: pin group</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__666" class="hit">
                           <td class="line" data-tooltip>666</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>43</td>
-                          <td class="source">    raw_config.pg &#x3D; Common.pincanon(raw_config.pin || raw_config.pins)</td>
+                          <td class="source">    pins &#x3D; pins.map((pin) &#x3D;&gt; {</td>
                           
                         </tr>            <tr id="lib/api.js__667" class="hit">
                           <td class="line" data-tooltip>667</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      return &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pin ? Jsonic(pin) : pin</td>
                           
                         </tr>            <tr id="lib/api.js__668" class="hit">
                           <td class="line" data-tooltip>668</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var config &#x3D; intern.resolve_config(raw_config, opts)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__669" class="hit">
                           <td class="line" data-tooltip>669</td>
@@ -16440,356 +16440,356 @@
                         </tr>            <tr id="lib/api.js__670" class="hit">
                           <td class="line" data-tooltip>670</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    config.id &#x3D; config.id || Common.pattern(raw_config)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    //var sd &#x3D; Plugins.make_delegate(self, {</td>
                           
                         </tr>            <tr id="lib/api.js__671" class="hit">
                           <td class="line" data-tooltip>671</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    // TODO: review - this feels like a hack</td>
                           
                         </tr>            <tr id="lib/api.js__672" class="hit">
                           <td class="line" data-tooltip>672</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var pins &#x3D;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    // perhaps we should instantiate a virtual plugin to represent the client?</td>
                           
                         </tr>            <tr id="lib/api.js__673" class="hit">
                           <td class="line" data-tooltip>673</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      config.pins ||</td>
+                          <td class="source">    // ... but is this necessary at all?</td>
                           
-                        </tr>            <tr id="lib/api.js__674" class="chunks">
+                        </tr>            <tr id="lib/api.js__674" class="hit">
                           <td class="line" data-tooltip>674</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      (</div><div class="miss false" data-tooltip>Array.isArray(config.pin)</div><div> ? </div><div class="miss never" data-tooltip>config.pin</div><div> : [config.pin || &#x27;&#x27;])</div></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var task_res &#x3D; self.order.plugin.task.delegate.exec({</td>
                           
                         </tr>            <tr id="lib/api.js__675" class="hit">
                           <td class="line" data-tooltip>675</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      ctx: {</td>
                           
                         </tr>            <tr id="lib/api.js__676" class="hit">
                           <td class="line" data-tooltip>676</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    pins &#x3D; pins.map((pin) &#x3D;&gt; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        seneca: self,</td>
                           
                         </tr>            <tr id="lib/api.js__677" class="hit">
                           <td class="line" data-tooltip>677</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      return &#x27;string&#x27; &#x3D;&#x3D;&#x3D; typeof pin ? Jsonic(pin) : pin</td>
+                          <td class="source">      },</td>
                           
                         </tr>            <tr id="lib/api.js__678" class="hit">
                           <td class="line" data-tooltip>678</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source">      data: {</td>
                           
                         </tr>            <tr id="lib/api.js__679" class="hit">
                           <td class="line" data-tooltip>679</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">        plugin: {</td>
                           
                         </tr>            <tr id="lib/api.js__680" class="hit">
                           <td class="line" data-tooltip>680</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    //var sd &#x3D; Plugins.make_delegate(self, {</td>
+                          <td class="source">          // TODO: make this unique with a counter</td>
                           
                         </tr>            <tr id="lib/api.js__681" class="hit">
                           <td class="line" data-tooltip>681</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // TODO: review - this feels like a hack</td>
+                          <td class="source">          name: &#x27;seneca_internal_client&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__682" class="hit">
                           <td class="line" data-tooltip>682</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // perhaps we should instantiate a virtual plugin to represent the client?</td>
+                          <td class="source">          tag: void 0,</td>
                           
                         </tr>            <tr id="lib/api.js__683" class="hit">
                           <td class="line" data-tooltip>683</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // ... but is this necessary at all?</td>
+                          <td class="source">        },</td>
                           
                         </tr>            <tr id="lib/api.js__684" class="hit">
                           <td class="line" data-tooltip>684</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var task_res &#x3D; self.order.plugin.task.delegate.exec({</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      },</td>
                           
                         </tr>            <tr id="lib/api.js__685" class="hit">
                           <td class="line" data-tooltip>685</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      ctx: {</td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__686" class="hit">
                           <td class="line" data-tooltip>686</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        seneca: self,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__687" class="hit">
                           <td class="line" data-tooltip>687</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      },</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var sd &#x3D; task_res.out.delegate</td>
                           
                         </tr>            <tr id="lib/api.js__688" class="hit">
                           <td class="line" data-tooltip>688</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      data: {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__689" class="hit">
                           <td class="line" data-tooltip>689</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        plugin: {</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var sendclient</td>
                           
                         </tr>            <tr id="lib/api.js__690" class="hit">
                           <td class="line" data-tooltip>690</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          // TODO: make this unique with a counter</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__691" class="hit">
                           <td class="line" data-tooltip>691</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">          name: &#x27;seneca_internal_client&#x27;,</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    var transport_client &#x3D; function transport_client(msg, reply, meta) {</td>
                           
-                        </tr>            <tr id="lib/api.js__692" class="hit">
+                        </tr>            <tr id="lib/api.js__692" class="chunks">
                           <td class="line" data-tooltip>692</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          tag: void 0,</td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>legacy.meta</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__693" class="hit">
+                        </tr>            <tr id="lib/api.js__693" class="miss">
                           <td class="line" data-tooltip>693</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        },</td>
+                          <td class="source" data-tooltip>        meta &#x3D; meta || msg.meta$</td>
                           
                         </tr>            <tr id="lib/api.js__694" class="hit">
                           <td class="line" data-tooltip>694</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      },</td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__695" class="hit">
                           <td class="line" data-tooltip>695</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__696" class="hit">
                           <td class="line" data-tooltip>696</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      // Undefined plugin init actions pass through here when</td>
                           
                         </tr>            <tr id="lib/api.js__697" class="hit">
                           <td class="line" data-tooltip>697</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var sd &#x3D; task_res.out.delegate</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      // there&#x27;s a catchall client, as they have local$:true</td>
                           
                         </tr>            <tr id="lib/api.js__698" class="hit">
                           <td class="line" data-tooltip>698</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>69</td>
+                          <td class="source">      if (meta.local) {</td>
                           
                         </tr>            <tr id="lib/api.js__699" class="hit">
                           <td class="line" data-tooltip>699</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var sendclient</td>
+                          <td class="hits" data-tooltip>11</td>
+                          <td class="source">        this.prior(msg, reply)</td>
                           
-                        </tr>            <tr id="lib/api.js__700" class="hit">
+                        </tr>            <tr id="lib/api.js__700" class="chunks">
                           <td class="line" data-tooltip>700</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>      } else if (</div><div class="miss true" data-tooltip>sendclient</div><div> &amp;&amp; </div><div class="miss true" data-tooltip>sendclient.send</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__701" class="hit">
+                        </tr>            <tr id="lib/api.js__701" class="chunks">
                           <td class="line" data-tooltip>701</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    var transport_client &#x3D; function transport_client(msg, reply, meta) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>legacy.meta</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__702" class="chunks">
+                        </tr>            <tr id="lib/api.js__702" class="miss">
                           <td class="line" data-tooltip>702</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>legacy.meta</div><div>) {</div></td>
+                          <td class="source" data-tooltip>          msg.meta$ &#x3D; meta</td>
                           
-                        </tr>            <tr id="lib/api.js__703" class="miss">
+                        </tr>            <tr id="lib/api.js__703" class="hit">
                           <td class="line" data-tooltip>703</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        meta &#x3D; meta || msg.meta$</td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__704" class="hit">
                           <td class="line" data-tooltip>704</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__705" class="hit">
                           <td class="line" data-tooltip>705</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>58</td>
+                          <td class="source">        sendclient.send.call(this, msg, reply, meta)</td>
                           
                         </tr>            <tr id="lib/api.js__706" class="hit">
                           <td class="line" data-tooltip>706</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      // Undefined plugin init actions pass through here when</td>
+                          <td class="source">      } else {</td>
                           
-                        </tr>            <tr id="lib/api.js__707" class="hit">
+                        </tr>            <tr id="lib/api.js__707" class="miss">
                           <td class="line" data-tooltip>707</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      // there&#x27;s a catchall client, as they have local$:true</td>
+                          <td class="source" data-tooltip>        this.log.error(&#x27;no-transport-client&#x27;, { config: config, msg: msg })</td>
                           
                         </tr>            <tr id="lib/api.js__708" class="hit">
                           <td class="line" data-tooltip>708</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>69</td>
-                          <td class="source">      if (meta.local) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__709" class="hit">
                           <td class="line" data-tooltip>709</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>11</td>
-                          <td class="source">        this.prior(msg, reply)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
-                        </tr>            <tr id="lib/api.js__710" class="chunks">
+                        </tr>            <tr id="lib/api.js__710" class="hit">
                           <td class="line" data-tooltip>710</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      } else if (</div><div class="miss true" data-tooltip>sendclient</div><div> &amp;&amp; </div><div class="miss true" data-tooltip>sendclient.send</div><div>) {</div></td>
-                          
-                        </tr>            <tr id="lib/api.js__711" class="chunks">
-                          <td class="line" data-tooltip>711</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>legacy.meta</div><div>) {</div></td>
-                          
-                        </tr>            <tr id="lib/api.js__712" class="miss">
-                          <td class="line" data-tooltip>712</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>          msg.meta$ &#x3D; meta</td>
-                          
-                        </tr>            <tr id="lib/api.js__713" class="hit">
-                          <td class="line" data-tooltip>713</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
-                          
-                        </tr>            <tr id="lib/api.js__714" class="hit">
-                          <td class="line" data-tooltip>714</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
+                        </tr>            <tr id="lib/api.js__711" class="hit">
+                          <td class="line" data-tooltip>711</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    transport_client.id &#x3D; config.id</td>
+                          
+                        </tr>            <tr id="lib/api.js__712" class="hit">
+                          <td class="line" data-tooltip>712</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
+                          
+                        </tr>            <tr id="lib/api.js__713" class="hit">
+                          <td class="line" data-tooltip>713</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    if (config.makehandle) {</td>
+                          
+                        </tr>            <tr id="lib/api.js__714" class="hit">
+                          <td class="line" data-tooltip>714</td>
+                          <td class="lint empty"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">      transport_client.handle &#x3D; config.makehandle(config)</td>
+                          
                         </tr>            <tr id="lib/api.js__715" class="hit">
                           <td class="line" data-tooltip>715</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>58</td>
-                          <td class="source">        sendclient.send.call(this, msg, reply, meta)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__716" class="hit">
                           <td class="line" data-tooltip>716</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      } else {</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__717" class="miss">
+                        </tr>            <tr id="lib/api.js__717" class="hit">
                           <td class="line" data-tooltip>717</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        this.log.error(&#x27;no-transport-client&#x27;, { config: config, msg: msg })</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    pins.forEach((pin) &#x3D;&gt; {</td>
                           
                         </tr>            <tr id="lib/api.js__718" class="hit">
                           <td class="line" data-tooltip>718</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">      pin &#x3D; Object.assign({}, pin)</td>
                           
                         </tr>            <tr id="lib/api.js__719" class="hit">
                           <td class="line" data-tooltip>719</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__720" class="hit">
                           <td class="line" data-tooltip>720</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      // Override local actions, including those more specific than</td>
                           
                         </tr>            <tr id="lib/api.js__721" class="hit">
                           <td class="line" data-tooltip>721</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    transport_client.id &#x3D; config.id</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      // the client pattern</td>
                           
-                        </tr>            <tr id="lib/api.js__722" class="hit">
+                        </tr>            <tr id="lib/api.js__722" class="chunks">
                           <td class="line" data-tooltip>722</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>config.override</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__723" class="hit">
+                        </tr>            <tr id="lib/api.js__723" class="miss">
                           <td class="line" data-tooltip>723</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    if (config.makehandle) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source" data-tooltip>        sd.wrap(</td>
                           
                         </tr>            <tr id="lib/api.js__724" class="hit">
                           <td class="line" data-tooltip>724</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      transport_client.handle &#x3D; config.makehandle(config)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">          sd.util.clean(pin),</td>
                           
                         </tr>            <tr id="lib/api.js__725" class="hit">
                           <td class="line" data-tooltip>725</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">          { client_pattern: sd.util.pattern(pin) },</td>
                           
                         </tr>            <tr id="lib/api.js__726" class="hit">
                           <td class="line" data-tooltip>726</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">          transport_client</td>
                           
                         </tr>            <tr id="lib/api.js__727" class="hit">
                           <td class="line" data-tooltip>727</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    pins.forEach((pin) &#x3D;&gt; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        )</td>
                           
                         </tr>            <tr id="lib/api.js__728" class="hit">
                           <td class="line" data-tooltip>728</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      pin &#x3D; Object.assign({}, pin)</td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__729" class="hit">
                           <td class="line" data-tooltip>729</td>
@@ -16800,146 +16800,146 @@
                         </tr>            <tr id="lib/api.js__730" class="hit">
                           <td class="line" data-tooltip>730</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      // Override local actions, including those more specific than</td>
+                          <td class="hits" data-tooltip>44</td>
+                          <td class="source">      pin.client$ &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__731" class="hit">
                           <td class="line" data-tooltip>731</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      // the client pattern</td>
+                          <td class="hits" data-tooltip>44</td>
+                          <td class="source">      pin.strict$ &#x3D; { add: true }</td>
                           
-                        </tr>            <tr id="lib/api.js__732" class="chunks">
+                        </tr>            <tr id="lib/api.js__732" class="hit">
                           <td class="line" data-tooltip>732</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>config.override</div><div>) {</div></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__733" class="miss">
+                        </tr>            <tr id="lib/api.js__733" class="hit">
                           <td class="line" data-tooltip>733</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        sd.wrap(</td>
+                          <td class="hits" data-tooltip>44</td>
+                          <td class="source">      sd.add(pin, transport_client)</td>
                           
                         </tr>            <tr id="lib/api.js__734" class="hit">
                           <td class="line" data-tooltip>734</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          sd.util.clean(pin),</td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__735" class="hit">
                           <td class="line" data-tooltip>735</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          { client_pattern: sd.util.pattern(pin) },</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__736" class="hit">
                           <td class="line" data-tooltip>736</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          transport_client</td>
+                          <td class="source">    // Create client.</td>
                           
                         </tr>            <tr id="lib/api.js__737" class="hit">
                           <td class="line" data-tooltip>737</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">        )</td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    sd.act(</td>
                           
                         </tr>            <tr id="lib/api.js__738" class="hit">
                           <td class="line" data-tooltip>738</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">      &#x27;role:transport,cmd:client&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__739" class="hit">
                           <td class="line" data-tooltip>739</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      { config: config, gate$: true },</td>
                           
                         </tr>            <tr id="lib/api.js__740" class="hit">
                           <td class="line" data-tooltip>740</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>44</td>
-                          <td class="source">      pin.client$ &#x3D; true</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      function (err, liveclient) {</td>
                           
-                        </tr>            <tr id="lib/api.js__741" class="hit">
+                        </tr>            <tr id="lib/api.js__741" class="chunks">
                           <td class="line" data-tooltip>741</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>44</td>
-                          <td class="source">      pin.strict$ &#x3D; { add: true }</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>err</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__742" class="hit">
+                        </tr>            <tr id="lib/api.js__742" class="miss">
                           <td class="line" data-tooltip>742</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source" data-tooltip>          return sd.die(private$.error(err, &#x27;transport_client&#x27;, config))</td>
                           
                         </tr>            <tr id="lib/api.js__743" class="hit">
                           <td class="line" data-tooltip>743</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>44</td>
-                          <td class="source">      sd.add(pin, transport_client)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__744" class="hit">
                           <td class="line" data-tooltip>744</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__745" class="hit">
+                        </tr>            <tr id="lib/api.js__745" class="chunks">
                           <td class="line" data-tooltip>745</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>null &#x3D;&#x3D; liveclient</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__746" class="hit">
+                        </tr>            <tr id="lib/api.js__746" class="miss">
                           <td class="line" data-tooltip>746</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // Create client.</td>
+                          <td class="source" data-tooltip>          return sd.die(</td>
                           
                         </tr>            <tr id="lib/api.js__747" class="hit">
                           <td class="line" data-tooltip>747</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    sd.act(</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">            private$.error(&#x27;transport_client_null&#x27;, Common.clean(config))</td>
                           
                         </tr>            <tr id="lib/api.js__748" class="hit">
                           <td class="line" data-tooltip>748</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      &#x27;role:transport,cmd:client&#x27;,</td>
+                          <td class="source">          )</td>
                           
                         </tr>            <tr id="lib/api.js__749" class="hit">
                           <td class="line" data-tooltip>749</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      { config: config, gate$: true },</td>
+                          <td class="source">        }</td>
                           
                         </tr>            <tr id="lib/api.js__750" class="hit">
                           <td class="line" data-tooltip>750</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      function (err, liveclient) {</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__751" class="chunks">
+                        </tr>            <tr id="lib/api.js__751" class="hit">
                           <td class="line" data-tooltip>751</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>err</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">        sendclient &#x3D; liveclient</td>
                           
-                        </tr>            <tr id="lib/api.js__752" class="miss">
+                        </tr>            <tr id="lib/api.js__752" class="hit">
                           <td class="line" data-tooltip>752</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>          return sd.die(private$.error(err, &#x27;transport_client&#x27;, config))</td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__753" class="hit">
                           <td class="line" data-tooltip>753</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="source">    )</td>
                           
                         </tr>            <tr id="lib/api.js__754" class="hit">
                           <td class="line" data-tooltip>754</td>
@@ -16947,179 +16947,179 @@
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__755" class="chunks">
+                        </tr>            <tr id="lib/api.js__755" class="hit">
                           <td class="line" data-tooltip>755</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>        if (</div><div class="miss false" data-tooltip>null &#x3D;&#x3D; liveclient</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>43</td>
+                          <td class="source">    return self</td>
                           
-                        </tr>            <tr id="lib/api.js__756" class="miss">
+                        </tr>            <tr id="lib/api.js__756" class="hit">
                           <td class="line" data-tooltip>756</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>          return sd.die(</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__757" class="hit">
                           <td class="line" data-tooltip>757</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">            private$.error(&#x27;transport_client_null&#x27;, Common.clean(config))</td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__758" class="hit">
                           <td class="line" data-tooltip>758</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">          )</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__759" class="hit">
                           <td class="line" data-tooltip>759</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">        }</td>
+                          <td class="source">// Inspired by https://github.com/hapijs/hapi/blob/master/lib/plugin.js decorate</td>
                           
                         </tr>            <tr id="lib/api.js__760" class="hit">
                           <td class="line" data-tooltip>760</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">// TODO: convert to plugin configuration, with standard errors</td>
                           
                         </tr>            <tr id="lib/api.js__761" class="hit">
                           <td class="line" data-tooltip>761</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">        sendclient &#x3D; liveclient</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">exports.decorate &#x3D; function () {</td>
                           
                         </tr>            <tr id="lib/api.js__762" class="hit">
                           <td class="line" data-tooltip>762</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">  var args &#x3D; Norma(&#x27;property:s value:.&#x27;, arguments)</td>
                           
                         </tr>            <tr id="lib/api.js__763" class="hit">
                           <td class="line" data-tooltip>763</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    )</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__764" class="hit">
                           <td class="line" data-tooltip>764</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>32</td>
+                          <td class="source">  var property &#x3D; args.property</td>
                           
                         </tr>            <tr id="lib/api.js__765" class="hit">
                           <td class="line" data-tooltip>765</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>43</td>
-                          <td class="source">    return self</td>
+                          <td class="hits" data-tooltip>32</td>
+                          <td class="source">  Assert(property[0] !&#x3D;&#x3D; &#x27;_&#x27;, &#x27;property cannot start with _&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__766" class="hit">
                           <td class="line" data-tooltip>766</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>31</td>
+                          <td class="source">  Assert(</td>
                           
                         </tr>            <tr id="lib/api.js__767" class="hit">
                           <td class="line" data-tooltip>767</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source">    this.private$.decorations[property] &#x3D;&#x3D;&#x3D; undefined,</td>
                           
                         </tr>            <tr id="lib/api.js__768" class="hit">
                           <td class="line" data-tooltip>768</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    &#x27;seneca is already decorated with the property: &#x27; + property</td>
                           
                         </tr>            <tr id="lib/api.js__769" class="hit">
                           <td class="line" data-tooltip>769</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">// Inspired by https://github.com/hapijs/hapi/blob/master/lib/plugin.js decorate</td>
+                          <td class="source">  )</td>
                           
                         </tr>            <tr id="lib/api.js__770" class="hit">
                           <td class="line" data-tooltip>770</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">// TODO: convert to plugin configuration, with standard errors</td>
+                          <td class="hits" data-tooltip>30</td>
+                          <td class="source">  Assert(</td>
                           
                         </tr>            <tr id="lib/api.js__771" class="hit">
                           <td class="line" data-tooltip>771</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">exports.decorate &#x3D; function () {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    this.root[property] &#x3D;&#x3D;&#x3D; undefined,</td>
                           
                         </tr>            <tr id="lib/api.js__772" class="hit">
                           <td class="line" data-tooltip>772</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var args &#x3D; Norma(&#x27;property:s value:.&#x27;, arguments)</td>
+                          <td class="source">    &#x27;cannot override a core seneca property: &#x27; + property</td>
                           
                         </tr>            <tr id="lib/api.js__773" class="hit">
                           <td class="line" data-tooltip>773</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  )</td>
                           
                         </tr>            <tr id="lib/api.js__774" class="hit">
                           <td class="line" data-tooltip>774</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>32</td>
-                          <td class="source">  var property &#x3D; args.property</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__775" class="hit">
                           <td class="line" data-tooltip>775</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>32</td>
-                          <td class="source">  Assert(property[0] !&#x3D;&#x3D; &#x27;_&#x27;, &#x27;property cannot start with _&#x27;)</td>
+                          <td class="hits" data-tooltip>29</td>
+                          <td class="source">  this.root[property] &#x3D; this.private$.decorations[property] &#x3D; args.value</td>
                           
                         </tr>            <tr id="lib/api.js__776" class="hit">
                           <td class="line" data-tooltip>776</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>31</td>
-                          <td class="source">  Assert(</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__777" class="hit">
                           <td class="line" data-tooltip>777</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    this.private$.decorations[property] &#x3D;&#x3D;&#x3D; undefined,</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__778" class="hit">
                           <td class="line" data-tooltip>778</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;seneca is already decorated with the property: &#x27; + property</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">intern.parse_config &#x3D; function (args) {</td>
                           
                         </tr>            <tr id="lib/api.js__779" class="hit">
                           <td class="line" data-tooltip>779</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  )</td>
+                          <td class="source">  var out &#x3D; {}</td>
                           
                         </tr>            <tr id="lib/api.js__780" class="hit">
                           <td class="line" data-tooltip>780</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>30</td>
-                          <td class="source">  Assert(</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__781" class="hit">
                           <td class="line" data-tooltip>781</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    this.root[property] &#x3D;&#x3D;&#x3D; undefined,</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  var config &#x3D; args.filter((x) &#x3D;&gt; null !&#x3D; x)</td>
                           
                         </tr>            <tr id="lib/api.js__782" class="hit">
                           <td class="line" data-tooltip>782</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    &#x27;cannot override a core seneca property: &#x27; + property</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__783" class="hit">
                           <td class="line" data-tooltip>783</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  )</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  var arglen &#x3D; config.length</td>
                           
                         </tr>            <tr id="lib/api.js__784" class="hit">
                           <td class="line" data-tooltip>784</td>
@@ -17130,242 +17130,242 @@
                         </tr>            <tr id="lib/api.js__785" class="hit">
                           <td class="line" data-tooltip>785</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>29</td>
-                          <td class="source">  this.root[property] &#x3D; this.private$.decorations[property] &#x3D; args.value</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // TODO: use Joi for better error msgs</td>
                           
                         </tr>            <tr id="lib/api.js__786" class="hit">
                           <td class="line" data-tooltip>786</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__787" class="hit">
                           <td class="line" data-tooltip>787</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  if (arglen &#x3D;&#x3D;&#x3D; 1) {</td>
                           
-                        </tr>            <tr id="lib/api.js__788" class="hit">
+                        </tr>            <tr id="lib/api.js__788" class="chunks">
                           <td class="line" data-tooltip>788</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">intern.parse_config &#x3D; function (args) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>    if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof config[0] &amp;&amp; </div><div class="miss true" data-tooltip>null !&#x3D; config[0]</div><div>) {</div></td>
                           
                         </tr>            <tr id="lib/api.js__789" class="hit">
                           <td class="line" data-tooltip>789</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var out &#x3D; {}</td>
+                          <td class="hits" data-tooltip>63</td>
+                          <td class="source">      out &#x3D; Object.assign({}, config[0])</td>
                           
                         </tr>            <tr id="lib/api.js__790" class="hit">
                           <td class="line" data-tooltip>790</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    } else {</td>
                           
                         </tr>            <tr id="lib/api.js__791" class="hit">
                           <td class="line" data-tooltip>791</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  var config &#x3D; args.filter((x) &#x3D;&gt; null !&#x3D; x)</td>
+                          <td class="hits" data-tooltip>17</td>
+                          <td class="source">      out.port &#x3D; parseInt(config[0], 10)</td>
                           
                         </tr>            <tr id="lib/api.js__792" class="hit">
                           <td class="line" data-tooltip>792</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__793" class="hit">
                           <td class="line" data-tooltip>793</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  var arglen &#x3D; config.length</td>
+                          <td class="hits" data-tooltip>10</td>
+                          <td class="source">  } else if (arglen &#x3D;&#x3D;&#x3D; 2) {</td>
                           
                         </tr>            <tr id="lib/api.js__794" class="hit">
                           <td class="line" data-tooltip>794</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    out.port &#x3D; parseInt(config[0], 10)</td>
                           
                         </tr>            <tr id="lib/api.js__795" class="hit">
                           <td class="line" data-tooltip>795</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // TODO: use Joi for better error msgs</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    out.host &#x3D; config[1]</td>
                           
                         </tr>            <tr id="lib/api.js__796" class="hit">
                           <td class="line" data-tooltip>796</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>9</td>
+                          <td class="source">  } else if (arglen &#x3D;&#x3D;&#x3D; 3) {</td>
                           
                         </tr>            <tr id="lib/api.js__797" class="hit">
                           <td class="line" data-tooltip>797</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  if (arglen &#x3D;&#x3D;&#x3D; 1) {</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    out.port &#x3D; parseInt(config[0], 10)</td>
                           
-                        </tr>            <tr id="lib/api.js__798" class="chunks">
+                        </tr>            <tr id="lib/api.js__798" class="hit">
                           <td class="line" data-tooltip>798</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof config[0] &amp;&amp; </div><div class="miss true" data-tooltip>null !&#x3D; config[0]</div><div>) {</div></td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    out.host &#x3D; config[1]</td>
                           
                         </tr>            <tr id="lib/api.js__799" class="hit">
                           <td class="line" data-tooltip>799</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>63</td>
-                          <td class="source">      out &#x3D; Object.assign({}, config[0])</td>
+                          <td class="hits" data-tooltip>3</td>
+                          <td class="source">    out.path &#x3D; config[2]</td>
                           
                         </tr>            <tr id="lib/api.js__800" class="hit">
                           <td class="line" data-tooltip>800</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    } else {</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__801" class="hit">
                           <td class="line" data-tooltip>801</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>17</td>
-                          <td class="source">      out.port &#x3D; parseInt(config[0], 10)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__802" class="hit">
                           <td class="line" data-tooltip>802</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  return out</td>
                           
                         </tr>            <tr id="lib/api.js__803" class="hit">
                           <td class="line" data-tooltip>803</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>10</td>
-                          <td class="source">  } else if (arglen &#x3D;&#x3D;&#x3D; 2) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__804" class="hit">
                           <td class="line" data-tooltip>804</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">    out.port &#x3D; parseInt(config[0], 10)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__805" class="hit">
                           <td class="line" data-tooltip>805</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>1</td>
-                          <td class="source">    out.host &#x3D; config[1]</td>
+                          <td class="source">intern.resolve_config &#x3D; function (config, options) {</td>
                           
                         </tr>            <tr id="lib/api.js__806" class="hit">
                           <td class="line" data-tooltip>806</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>9</td>
-                          <td class="source">  } else if (arglen &#x3D;&#x3D;&#x3D; 3) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var out &#x3D; Object.assign({}, config)</td>
                           
                         </tr>            <tr id="lib/api.js__807" class="hit">
                           <td class="line" data-tooltip>807</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    out.port &#x3D; parseInt(config[0], 10)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__808" class="hit">
                           <td class="line" data-tooltip>808</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    out.host &#x3D; config[1]</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  Object.keys(options).forEach((key) &#x3D;&gt; {</td>
                           
                         </tr>            <tr id="lib/api.js__809" class="hit">
                           <td class="line" data-tooltip>809</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>3</td>
-                          <td class="source">    out.path &#x3D; config[2]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    var value &#x3D; options[key]</td>
                           
                         </tr>            <tr id="lib/api.js__810" class="hit">
                           <td class="line" data-tooltip>810</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>241</td>
+                          <td class="source">    if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof value) {</td>
                           
                         </tr>            <tr id="lib/api.js__811" class="hit">
                           <td class="line" data-tooltip>811</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>13</td>
+                          <td class="source">      return</td>
                           
                         </tr>            <tr id="lib/api.js__812" class="hit">
                           <td class="line" data-tooltip>812</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  return out</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__813" class="hit">
                           <td class="line" data-tooltip>813</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>228</td>
+                          <td class="source">    out[key] &#x3D; out[key] &#x3D;&#x3D;&#x3D; void 0 ? value : out[key]</td>
                           
                         </tr>            <tr id="lib/api.js__814" class="hit">
                           <td class="line" data-tooltip>814</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">  })</td>
                           
                         </tr>            <tr id="lib/api.js__815" class="hit">
                           <td class="line" data-tooltip>815</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">intern.resolve_config &#x3D; function (config, options) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__816" class="hit">
                           <td class="line" data-tooltip>816</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var out &#x3D; Object.assign({}, config)</td>
+                          <td class="source">  // Default transport is web</td>
                           
                         </tr>            <tr id="lib/api.js__817" class="hit">
                           <td class="line" data-tooltip>817</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  out.type &#x3D; out.type || &#x27;web&#x27;</td>
                           
                         </tr>            <tr id="lib/api.js__818" class="hit">
                           <td class="line" data-tooltip>818</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  Object.keys(options).forEach((key) &#x3D;&gt; {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__819" class="hit">
                           <td class="line" data-tooltip>819</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    var value &#x3D; options[key]</td>
+                          <td class="source">  // DEPRECATED: Remove in 4.0</td>
                           
                         </tr>            <tr id="lib/api.js__820" class="hit">
                           <td class="line" data-tooltip>820</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>241</td>
-                          <td class="source">    if (&#x27;object&#x27; &#x3D;&#x3D;&#x3D; typeof value) {</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  if (out.type &#x3D;&#x3D;&#x3D; &#x27;direct&#x27; || out.type &#x3D;&#x3D;&#x3D; &#x27;http&#x27;) {</td>
                           
                         </tr>            <tr id="lib/api.js__821" class="hit">
                           <td class="line" data-tooltip>821</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>13</td>
-                          <td class="source">      return</td>
+                          <td class="hits" data-tooltip>2</td>
+                          <td class="source">    out.type &#x3D; &#x27;web&#x27;</td>
                           
                         </tr>            <tr id="lib/api.js__822" class="hit">
                           <td class="line" data-tooltip>822</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__823" class="hit">
                           <td class="line" data-tooltip>823</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>228</td>
-                          <td class="source">    out[key] &#x3D; out[key] &#x3D;&#x3D;&#x3D; void 0 ? value : out[key]</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__824" class="hit">
                           <td class="line" data-tooltip>824</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  })</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  var base &#x3D; options[out.type] || {}</td>
                           
                         </tr>            <tr id="lib/api.js__825" class="hit">
                           <td class="line" data-tooltip>825</td>
@@ -17376,38 +17376,38 @@
                         </tr>            <tr id="lib/api.js__826" class="hit">
                           <td class="line" data-tooltip>826</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  // Default transport is web</td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  out &#x3D; Object.assign({}, base, out)</td>
                           
                         </tr>            <tr id="lib/api.js__827" class="hit">
                           <td class="line" data-tooltip>827</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  out.type &#x3D; out.type || &#x27;web&#x27;</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__828" class="hit">
                           <td class="line" data-tooltip>828</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>90</td>
+                          <td class="source">  if (out.type &#x3D;&#x3D;&#x3D; &#x27;web&#x27; || out.type &#x3D;&#x3D;&#x3D; &#x27;tcp&#x27;) {</td>
                           
-                        </tr>            <tr id="lib/api.js__829" class="hit">
+                        </tr>            <tr id="lib/api.js__829" class="chunks">
                           <td class="line" data-tooltip>829</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // DEPRECATED: Remove in 4.0</td>
+                          <td class="source"><div>    out.port &#x3D; </div><div class="miss false" data-tooltip>out.port &#x3D;&#x3D; null</div><div> ? </div><div class="miss never" data-tooltip>base.port</div><div> : out.port</div></td>
                           
                         </tr>            <tr id="lib/api.js__830" class="hit">
                           <td class="line" data-tooltip>830</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  if (out.type &#x3D;&#x3D;&#x3D; &#x27;direct&#x27; || out.type &#x3D;&#x3D;&#x3D; &#x27;http&#x27;) {</td>
+                          <td class="hits" data-tooltip>53</td>
+                          <td class="source">    out.host &#x3D; out.host &#x3D;&#x3D; null ? base.host : out.host</td>
                           
                         </tr>            <tr id="lib/api.js__831" class="hit">
                           <td class="line" data-tooltip>831</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2</td>
-                          <td class="source">    out.type &#x3D; &#x27;web&#x27;</td>
+                          <td class="hits" data-tooltip>53</td>
+                          <td class="source">    out.path &#x3D; out.path &#x3D;&#x3D; null ? base.path : out.path</td>
                           
                         </tr>            <tr id="lib/api.js__832" class="hit">
                           <td class="line" data-tooltip>832</td>
@@ -17425,175 +17425,175 @@
                           <td class="line" data-tooltip>834</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>90</td>
-                          <td class="source">  var base &#x3D; options[out.type] || {}</td>
+                          <td class="source">  return out</td>
                           
                         </tr>            <tr id="lib/api.js__835" class="hit">
                           <td class="line" data-tooltip>835</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__836" class="hit">
                           <td class="line" data-tooltip>836</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  out &#x3D; Object.assign({}, base, out)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__837" class="hit">
                           <td class="line" data-tooltip>837</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">intern.close &#x3D; function (callpoint, done) {</td>
                           
                         </tr>            <tr id="lib/api.js__838" class="hit">
                           <td class="line" data-tooltip>838</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  if (out.type &#x3D;&#x3D;&#x3D; &#x27;web&#x27; || out.type &#x3D;&#x3D;&#x3D; &#x27;tcp&#x27;) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  var seneca &#x3D; this</td>
                           
-                        </tr>            <tr id="lib/api.js__839" class="chunks">
+                        </tr>            <tr id="lib/api.js__839" class="hit">
                           <td class="line" data-tooltip>839</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"><div>    out.port &#x3D; </div><div class="miss false" data-tooltip>out.port &#x3D;&#x3D; null</div><div> ? </div><div class="miss never" data-tooltip>base.port</div><div> : out.port</div></td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">  var options &#x3D; seneca.options()</td>
                           
                         </tr>            <tr id="lib/api.js__840" class="hit">
                           <td class="line" data-tooltip>840</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>53</td>
-                          <td class="source">    out.host &#x3D; out.host &#x3D;&#x3D; null ? base.host : out.host</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__841" class="hit">
                           <td class="line" data-tooltip>841</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>53</td>
-                          <td class="source">    out.path &#x3D; out.path &#x3D;&#x3D; null ? base.path : out.path</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">  var done_called &#x3D; false</td>
                           
                         </tr>            <tr id="lib/api.js__842" class="hit">
                           <td class="line" data-tooltip>842</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">  var safe_done &#x3D; function safe_done(err) {</td>
                           
                         </tr>            <tr id="lib/api.js__843" class="hit">
                           <td class="line" data-tooltip>843</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    if (!done_called &amp;&amp; &#x27;function&#x27; &#x3D;&#x3D;&#x3D; typeof done) {</td>
                           
                         </tr>            <tr id="lib/api.js__844" class="hit">
                           <td class="line" data-tooltip>844</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>90</td>
-                          <td class="source">  return out</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      done_called &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__845" class="hit">
                           <td class="line" data-tooltip>845</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      return done.call(seneca, err)</td>
                           
                         </tr>            <tr id="lib/api.js__846" class="hit">
                           <td class="line" data-tooltip>846</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__847" class="hit">
                           <td class="line" data-tooltip>847</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">intern.close &#x3D; function (callpoint, done) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__848" class="hit">
                           <td class="line" data-tooltip>848</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  var seneca &#x3D; this</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__849" class="hit">
                           <td class="line" data-tooltip>849</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">  var options &#x3D; seneca.options()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  // don&#x27;t try to close twice</td>
                           
                         </tr>            <tr id="lib/api.js__850" class="hit">
                           <td class="line" data-tooltip>850</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">  if (seneca.flags.closed) {</td>
                           
                         </tr>            <tr id="lib/api.js__851" class="hit">
                           <td class="line" data-tooltip>851</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">  var done_called &#x3D; false</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">    return safe_done()</td>
                           
                         </tr>            <tr id="lib/api.js__852" class="hit">
                           <td class="line" data-tooltip>852</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">  var safe_done &#x3D; function safe_done(err) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__853" class="hit">
                           <td class="line" data-tooltip>853</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    if (!done_called &amp;&amp; &#x27;function&#x27; &#x3D;&#x3D;&#x3D; typeof done) {</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__854" class="hit">
                           <td class="line" data-tooltip>854</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">      done_called &#x3D; true</td>
+                          <td class="source">  seneca.ready(do_close)</td>
                           
                         </tr>            <tr id="lib/api.js__855" class="hit">
                           <td class="line" data-tooltip>855</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">      return done.call(seneca, err)</td>
+                          <td class="source">  var close_timeout &#x3D; setTimeout(do_close, options.close_delay)</td>
                           
                         </tr>            <tr id="lib/api.js__856" class="hit">
                           <td class="line" data-tooltip>856</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__857" class="hit">
                           <td class="line" data-tooltip>857</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">  function do_close() {</td>
                           
                         </tr>            <tr id="lib/api.js__858" class="hit">
                           <td class="line" data-tooltip>858</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>78</td>
+                          <td class="source">    clearTimeout(close_timeout)</td>
                           
                         </tr>            <tr id="lib/api.js__859" class="hit">
                           <td class="line" data-tooltip>859</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  // don&#x27;t try to close twice</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__860" class="hit">
                           <td class="line" data-tooltip>860</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>78</td>
-                          <td class="source">  if (seneca.flags.closed) {</td>
+                          <td class="source">    if (seneca.flags.closed) {</td>
                           
                         </tr>            <tr id="lib/api.js__861" class="hit">
                           <td class="line" data-tooltip>861</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>1</td>
-                          <td class="source">    return safe_done()</td>
+                          <td class="source">      return safe_done()</td>
                           
                         </tr>            <tr id="lib/api.js__862" class="hit">
                           <td class="line" data-tooltip>862</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">    }</td>
                           
                         </tr>            <tr id="lib/api.js__863" class="hit">
                           <td class="line" data-tooltip>863</td>
@@ -17604,14 +17604,14 @@
                         </tr>            <tr id="lib/api.js__864" class="hit">
                           <td class="line" data-tooltip>864</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">  seneca.ready(do_close)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    // TODO: remove in 4.x</td>
                           
                         </tr>            <tr id="lib/api.js__865" class="hit">
                           <td class="line" data-tooltip>865</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">  var close_timeout &#x3D; setTimeout(do_close, options.close_delay)</td>
+                          <td class="source">    seneca.closed &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__866" class="hit">
                           <td class="line" data-tooltip>866</td>
@@ -17622,146 +17622,146 @@
                         </tr>            <tr id="lib/api.js__867" class="hit">
                           <td class="line" data-tooltip>867</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  function do_close() {</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">    seneca.flags.closed &#x3D; true</td>
                           
                         </tr>            <tr id="lib/api.js__868" class="hit">
                           <td class="line" data-tooltip>868</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">    clearTimeout(close_timeout)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__869" class="hit">
                           <td class="line" data-tooltip>869</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    // cleanup process event listeners</td>
                           
                         </tr>            <tr id="lib/api.js__870" class="hit">
                           <td class="line" data-tooltip>870</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>78</td>
-                          <td class="source">    if (seneca.flags.closed) {</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">    Common.each(options.system.close_signals, function (active, signal) {</td>
                           
-                        </tr>            <tr id="lib/api.js__871" class="hit">
+                        </tr>            <tr id="lib/api.js__871" class="chunks">
                           <td class="line" data-tooltip>871</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">      return safe_done()</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>active</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__872" class="hit">
+                        </tr>            <tr id="lib/api.js__872" class="miss">
                           <td class="line" data-tooltip>872</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    }</td>
+                          <td class="source" data-tooltip>        process.removeListener(signal, seneca.private$.exit_close)</td>
                           
                         </tr>            <tr id="lib/api.js__873" class="hit">
                           <td class="line" data-tooltip>873</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__874" class="hit">
                           <td class="line" data-tooltip>874</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // TODO: remove in 4.x</td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__875" class="hit">
                           <td class="line" data-tooltip>875</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">    seneca.closed &#x3D; true</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__876" class="hit">
                           <td class="line" data-tooltip>876</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">    seneca.log.debug({</td>
                           
                         </tr>            <tr id="lib/api.js__877" class="hit">
                           <td class="line" data-tooltip>877</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">    seneca.flags.closed &#x3D; true</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      kind: &#x27;close&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__878" class="hit">
                           <td class="line" data-tooltip>878</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">      notice: &#x27;start&#x27;,</td>
                           
                         </tr>            <tr id="lib/api.js__879" class="hit">
                           <td class="line" data-tooltip>879</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    // cleanup process event listeners</td>
+                          <td class="source">      callpoint: callpoint(true),</td>
                           
                         </tr>            <tr id="lib/api.js__880" class="hit">
                           <td class="line" data-tooltip>880</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">    Common.each(options.system.close_signals, function (active, signal) {</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
-                        </tr>            <tr id="lib/api.js__881" class="chunks">
+                        </tr>            <tr id="lib/api.js__881" class="hit">
                           <td class="line" data-tooltip>881</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>active</div><div>) {</div></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__882" class="miss">
+                        </tr>            <tr id="lib/api.js__882" class="hit">
                           <td class="line" data-tooltip>882</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        process.removeListener(signal, seneca.private$.exit_close)</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">    seneca.act(&#x27;role:seneca,cmd:close,closing$:true&#x27;, function (err) {</td>
                           
                         </tr>            <tr id="lib/api.js__883" class="hit">
                           <td class="line" data-tooltip>883</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">      seneca.log.debug(errlog(err, { kind: &#x27;close&#x27;, notice: &#x27;end&#x27; }))</td>
                           
                         </tr>            <tr id="lib/api.js__884" class="hit">
                           <td class="line" data-tooltip>884</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__885" class="hit">
                           <td class="line" data-tooltip>885</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;act-in&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__886" class="hit">
                           <td class="line" data-tooltip>886</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">    seneca.log.debug({</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;act-out&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__887" class="hit">
                           <td class="line" data-tooltip>887</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      kind: &#x27;close&#x27;,</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;act-err&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__888" class="hit">
                           <td class="line" data-tooltip>888</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      notice: &#x27;start&#x27;,</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;pin&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__889" class="hit">
                           <td class="line" data-tooltip>889</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      callpoint: callpoint(true),</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;after-pin&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__890" class="hit">
                           <td class="line" data-tooltip>890</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="hits" data-tooltip>77</td>
+                          <td class="source">      seneca.removeAllListeners(&#x27;ready&#x27;)</td>
                           
                         </tr>            <tr id="lib/api.js__891" class="hit">
                           <td class="line" data-tooltip>891</td>
@@ -17773,55 +17773,55 @@
                           <td class="line" data-tooltip>892</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">    seneca.act(&#x27;role:seneca,cmd:close,closing$:true&#x27;, function (err) {</td>
+                          <td class="source">      seneca.private$.history.close()</td>
                           
                         </tr>            <tr id="lib/api.js__893" class="hit">
                           <td class="line" data-tooltip>893</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      seneca.log.debug(errlog(err, { kind: &#x27;close&#x27;, notice: &#x27;end&#x27; }))</td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__894" class="hit">
+                        </tr>            <tr id="lib/api.js__894" class="chunks">
                           <td class="line" data-tooltip>894</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>seneca.private$.status_interval</div><div>) {</div></td>
                           
-                        </tr>            <tr id="lib/api.js__895" class="hit">
+                        </tr>            <tr id="lib/api.js__895" class="miss">
                           <td class="line" data-tooltip>895</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;act-in&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source" data-tooltip>        clearInterval(seneca.private$.status_interval)</td>
                           
                         </tr>            <tr id="lib/api.js__896" class="hit">
                           <td class="line" data-tooltip>896</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;act-out&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">      }</td>
                           
                         </tr>            <tr id="lib/api.js__897" class="hit">
                           <td class="line" data-tooltip>897</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;act-err&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source"></td>
                           
                         </tr>            <tr id="lib/api.js__898" class="hit">
                           <td class="line" data-tooltip>898</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;pin&#x27;)</td>
+                          <td class="source">      return safe_done(err)</td>
                           
                         </tr>            <tr id="lib/api.js__899" class="hit">
                           <td class="line" data-tooltip>899</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;after-pin&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__900" class="hit">
                           <td class="line" data-tooltip>900</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.removeAllListeners(&#x27;ready&#x27;)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">  }</td>
                           
                         </tr>            <tr id="lib/api.js__901" class="hit">
                           <td class="line" data-tooltip>901</td>
@@ -17833,142 +17833,82 @@
                           <td class="line" data-tooltip>902</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip>77</td>
-                          <td class="source">      seneca.private$.history.close()</td>
+                          <td class="source">  return seneca</td>
                           
                         </tr>            <tr id="lib/api.js__903" class="hit">
                           <td class="line" data-tooltip>903</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
-                        </tr>            <tr id="lib/api.js__904" class="chunks">
+                        </tr>            <tr id="lib/api.js__904" class="hit">
                           <td class="line" data-tooltip>904</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"><div>      if (</div><div class="miss false" data-tooltip>seneca.private$.status_interval</div><div>) {</div></td>
+                          <td class="source"></td>
                           
-                        </tr>            <tr id="lib/api.js__905" class="miss">
+                        </tr>            <tr id="lib/api.js__905" class="hit">
                           <td class="line" data-tooltip>905</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source" data-tooltip>        clearInterval(seneca.private$.status_interval)</td>
+                          <td class="hits" data-tooltip>1</td>
+                          <td class="source">intern.fix_args &#x3D; function (origargs, patargs, msgargs, custom) {</td>
                           
                         </tr>            <tr id="lib/api.js__906" class="hit">
                           <td class="line" data-tooltip>906</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">      }</td>
+                          <td class="source">  var args &#x3D; Common.parsePattern(this, origargs, &#x27;rest:.*&#x27;, patargs)</td>
                           
                         </tr>            <tr id="lib/api.js__907" class="hit">
                           <td class="line" data-tooltip>907</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  var fixargs &#x3D; [args.pattern]</td>
                           
                         </tr>            <tr id="lib/api.js__908" class="hit">
                           <td class="line" data-tooltip>908</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">      return safe_done(err)</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    .concat({</td>
                           
                         </tr>            <tr id="lib/api.js__909" class="hit">
                           <td class="line" data-tooltip>909</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
+                          <td class="source">      fixed$: Object.assign({}, msgargs, args.pattern.fixed$),</td>
                           
                         </tr>            <tr id="lib/api.js__910" class="hit">
                           <td class="line" data-tooltip>910</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source">  }</td>
+                          <td class="source">      custom$: Object.assign({}, custom, args.pattern.custom$),</td>
                           
                         </tr>            <tr id="lib/api.js__911" class="hit">
                           <td class="line" data-tooltip>911</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">    })</td>
                           
                         </tr>            <tr id="lib/api.js__912" class="hit">
                           <td class="line" data-tooltip>912</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>77</td>
-                          <td class="source">  return seneca</td>
+                          <td class="hits" data-tooltip></td>
+                          <td class="source">    .concat(args.rest)</td>
                           
                         </tr>            <tr id="lib/api.js__913" class="hit">
                           <td class="line" data-tooltip>913</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
+                          <td class="hits" data-tooltip>6</td>
+                          <td class="source">  return fixargs</td>
                           
                         </tr>            <tr id="lib/api.js__914" class="hit">
                           <td class="line" data-tooltip>914</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
-                          <td class="source"></td>
+                          <td class="source">}</td>
                           
                         </tr>            <tr id="lib/api.js__915" class="hit">
                           <td class="line" data-tooltip>915</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1</td>
-                          <td class="source">intern.fix_args &#x3D; function (origargs, patargs, msgargs, custom) {</td>
-                          
-                        </tr>            <tr id="lib/api.js__916" class="hit">
-                          <td class="line" data-tooltip>916</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">  var args &#x3D; Common.parsePattern(this, origargs, &#x27;rest:.*&#x27;, patargs)</td>
-                          
-                        </tr>            <tr id="lib/api.js__917" class="hit">
-                          <td class="line" data-tooltip>917</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  var fixargs &#x3D; [args.pattern]</td>
-                          
-                        </tr>            <tr id="lib/api.js__918" class="hit">
-                          <td class="line" data-tooltip>918</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    .concat({</td>
-                          
-                        </tr>            <tr id="lib/api.js__919" class="hit">
-                          <td class="line" data-tooltip>919</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      fixed$: Object.assign({}, msgargs, args.pattern.fixed$),</td>
-                          
-                        </tr>            <tr id="lib/api.js__920" class="hit">
-                          <td class="line" data-tooltip>920</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">      custom$: Object.assign({}, custom, args.pattern.custom$),</td>
-                          
-                        </tr>            <tr id="lib/api.js__921" class="hit">
-                          <td class="line" data-tooltip>921</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    })</td>
-                          
-                        </tr>            <tr id="lib/api.js__922" class="hit">
-                          <td class="line" data-tooltip>922</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">    .concat(args.rest)</td>
-                          
-                        </tr>            <tr id="lib/api.js__923" class="hit">
-                          <td class="line" data-tooltip>923</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>6</td>
-                          <td class="source">  return fixargs</td>
-                          
-                        </tr>            <tr id="lib/api.js__924" class="hit">
-                          <td class="line" data-tooltip>924</td>
-                          <td class="lint empty"></td>
-                          <td class="hits" data-tooltip></td>
-                          <td class="source">}</td>
-                          
-                        </tr>            <tr id="lib/api.js__925" class="hit">
-                          <td class="line" data-tooltip>925</td>
                           <td class="lint empty"></td>
                           <td class="hits" data-tooltip></td>
                           <td class="source"></td>
@@ -22042,13 +21982,13 @@
                         </tr>            <tr id="lib/common.js__675" class="hit">
                           <td class="line" data-tooltip>675</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>66857</td>
+                          <td class="hits" data-tooltip>67697</td>
                           <td class="source">  var s &#x3D; 0</td>
                           
                         </tr>            <tr id="lib/common.js__676" class="hit">
                           <td class="line" data-tooltip>676</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>66857</td>
+                          <td class="hits" data-tooltip>67697</td>
                           <td class="source">  var e &#x3D; i</td>
                           
                         </tr>            <tr id="lib/common.js__677" class="hit">
@@ -22060,13 +22000,13 @@
                         </tr>            <tr id="lib/common.js__678" class="hit">
                           <td class="line" data-tooltip>678</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>66857</td>
+                          <td class="hits" data-tooltip>67697</td>
                           <td class="source">  if (0 &#x3D;&#x3D;&#x3D; this._list.length) {</td>
                           
                         </tr>            <tr id="lib/common.js__679" class="hit">
                           <td class="line" data-tooltip>679</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>15751</td>
+                          <td class="hits" data-tooltip>16806</td>
                           <td class="source">    return 0</td>
                           
                         </tr>            <tr id="lib/common.js__680" class="hit">
@@ -22084,13 +22024,13 @@
                         </tr>            <tr id="lib/common.js__682" class="hit">
                           <td class="line" data-tooltip>682</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>51106</td>
+                          <td class="hits" data-tooltip>50891</td>
                           <td class="source">  do {</td>
                           
                         </tr>            <tr id="lib/common.js__683" class="hit">
                           <td class="line" data-tooltip>683</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>105748</td>
+                          <td class="hits" data-tooltip>105433</td>
                           <td class="source">    i &#x3D; Math.floor((s + e) / 2)</td>
                           
                         </tr>            <tr id="lib/common.js__684" class="hit">
@@ -22102,31 +22042,31 @@
                         </tr>            <tr id="lib/common.js__685" class="hit">
                           <td class="line" data-tooltip>685</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>105748</td>
+                          <td class="hits" data-tooltip>105433</td>
                           <td class="source">    if (timelimit &gt; this._list[i].timelimit) {</td>
                           
                         </tr>            <tr id="lib/common.js__686" class="hit">
                           <td class="line" data-tooltip>686</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>260</td>
+                          <td class="hits" data-tooltip>270</td>
                           <td class="source">      s &#x3D; i + 1</td>
                           
                         </tr>            <tr id="lib/common.js__687" class="hit">
                           <td class="line" data-tooltip>687</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>260</td>
+                          <td class="hits" data-tooltip>270</td>
                           <td class="source">      i &#x3D; s</td>
                           
                         </tr>            <tr id="lib/common.js__688" class="hit">
                           <td class="line" data-tooltip>688</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>105488</td>
+                          <td class="hits" data-tooltip>105163</td>
                           <td class="source">    } else if (timelimit &lt; this._list[i].timelimit) {</td>
                           
                         </tr>            <tr id="lib/common.js__689" class="hit">
                           <td class="line" data-tooltip>689</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>105475</td>
+                          <td class="hits" data-tooltip>105153</td>
                           <td class="source">      e &#x3D; i</td>
                           
                         </tr>            <tr id="lib/common.js__690" class="hit">
@@ -22138,13 +22078,13 @@
                         </tr>            <tr id="lib/common.js__691" class="hit">
                           <td class="line" data-tooltip>691</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>13</td>
+                          <td class="hits" data-tooltip>10</td>
                           <td class="source">      i++</td>
                           
                         </tr>            <tr id="lib/common.js__692" class="hit">
                           <td class="line" data-tooltip>692</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>13</td>
+                          <td class="hits" data-tooltip>10</td>
                           <td class="source">      break</td>
                           
                         </tr>            <tr id="lib/common.js__693" class="hit">
@@ -22168,7 +22108,7 @@
                         </tr>            <tr id="lib/common.js__696" class="hit">
                           <td class="line" data-tooltip>696</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>51106</td>
+                          <td class="hits" data-tooltip>50891</td>
                           <td class="source">  return i</td>
                           
                         </tr>            <tr id="lib/common.js__697" class="hit">
@@ -22204,13 +22144,13 @@
                         </tr>            <tr id="lib/common.js__702" class="hit">
                           <td class="line" data-tooltip>702</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>66847</td>
+                          <td class="hits" data-tooltip>67687</td>
                           <td class="source">    for (var j &#x3D; 0; j &lt; i; j++) {</td>
                           
                         </tr>            <tr id="lib/common.js__703" class="hit">
                           <td class="line" data-tooltip>703</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>493</td>
+                          <td class="hits" data-tooltip>499</td>
                           <td class="source">      delete this._map[this._list[j].id]</td>
                           
                         </tr>            <tr id="lib/common.js__704" class="hit">
@@ -22222,7 +22162,7 @@
                         </tr>            <tr id="lib/common.js__705" class="hit">
                           <td class="line" data-tooltip>705</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>66847</td>
+                          <td class="hits" data-tooltip>67687</td>
                           <td class="source">    this._list &#x3D; this._list.slice(i)</td>
                           
                         </tr>            <tr id="lib/common.js__706" class="hit">
@@ -31624,7 +31564,7 @@
                         </tr>            <tr id="lib/outward.js__56" class="hit">
                           <td class="line" data-tooltip>56</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>2380</td>
+                          <td class="hits" data-tooltip>2379</td>
                           <td class="source">      actdetails.result.push({ when: Date.now(), res: res })</td>
                           
                         </tr>            <tr id="lib/outward.js__57" class="hit">
@@ -38338,7 +38278,7 @@
                         </tr>            <tr id="lib/ready.js__48" class="hit">
                           <td class="line" data-tooltip>48</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>608</td>
+                          <td class="hits" data-tooltip>604</td>
                           <td class="source">        execute_ready(self, ready_call)</td>
                           
                         </tr>            <tr id="lib/ready.js__49" class="hit">
@@ -38350,7 +38290,7 @@
                         </tr>            <tr id="lib/ready.js__50" class="hit">
                           <td class="line" data-tooltip>50</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>25</td>
+                          <td class="hits" data-tooltip>29</td>
                           <td class="source">        private$.ready_list.push(ready_call)</td>
                           
                         </tr>            <tr id="lib/ready.js__51" class="hit">
@@ -38446,7 +38386,7 @@
                         </tr>            <tr id="lib/ready.js__66" class="hit">
                           <td class="line" data-tooltip>66</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>544</td>
+                          <td class="hits" data-tooltip>545</td>
                           <td class="source">    while (0 &lt; private$.ready_list.length) {</td>
                           
                         </tr>            <tr id="lib/ready.js__67" class="hit">
@@ -38488,7 +38428,7 @@
                         </tr>            <tr id="lib/ready.js__73" class="hit">
                           <td class="line" data-tooltip>73</td>
                           <td class="lint empty"></td>
-                          <td class="hits" data-tooltip>1683</td>
+                          <td class="hits" data-tooltip>1675</td>
                           <td class="source">  if (null &#x3D;&#x3D; ready_func) return</td>
                           
                         </tr>            <tr id="lib/ready.js__74" class="hit">


### PR DESCRIPTION
#781 

Ave, guys. Thank you for your hard work on Seneca!

This PR implements the optional `cond` argument, as requested in #781, that only causes the method to throw if it's `true`.

Q: Should the automatically updated `./test/coverage.html` file be committed as well?
Q: Where may I update documentation? The `package.json` file does not seem to have the `annotate` script as suggested by the readme file.

