### PR TITLE
Fixes issues in typescript projects that causes builds to fail cuz of linting errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "seneca",
   "description": "A Microservices Framework for Node.js",
   "version": "3.35.2",
+  "types": "seneca.d.ts",
   "license": "MIT",
   "homepage": "http://senecajs.org",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "seneca",
   "description": "A Microservices Framework for Node.js",
-  "version": "3.35.2",
+  "version": "3.35.3",
   "types": "seneca.d.ts",
   "license": "MIT",
   "homepage": "http://senecajs.org",


### PR DESCRIPTION
When running a build script that uses the typescript compiler some errors are thrown. Errors like "possibly undefined", "variable is declared but its value is never read", "undefined cannot be used as an index type", etc...

This behavior forces us to be stuck at version `3.25.0` which doesn't rely on these ts files. Version `3.25.0` does have some vulnerabilities that can't easily be fixed, exposing us to malicious stuff.

The fix is easy and it requires to add the following line to the `package.json`:
```json
"types": "seneca.d.ts",
```

Thus, the typescript compiler won't throw an error when building.

<details>
  <summary>Open me to see errors</summary>

```bash
node_modules/seneca/lib/common.ts:173:26 - error TS6133: 'opts' is declared but its value is never read.

173 function clean(obj: any, opts?: any) {
                             ~~~~

node_modules/seneca/lib/common.ts:182:16 - error TS18048: 'p' is possibly 'undefined'.

182     if ('$' != p[p.length - 1]) {
                   ~

node_modules/seneca/lib/common.ts:182:18 - error TS18048: 'p' is possibly 'undefined'.

182     if ('$' != p[p.length - 1]) {
                     ~

node_modules/seneca/lib/common.ts:183:11 - error TS2538: Type 'undefined' cannot be used as an index type.

183       out[p] = obj[p]
              ~

node_modules/seneca/lib/common.ts:183:20 - error TS2538: Type 'undefined' cannot be used as an index type.

183       out[p] = obj[p]
                       ~

node_modules/seneca/lib/common.ts:336:21 - error TS4111: Property 'PWD' comes from an index signature, so it must be accessed with ['PWD'].

336         process.env.PWD
                        ~~~

node_modules/seneca/lib/inward.ts:38:10 - error TS7030: Not all code paths return a value.

38 function inward_limit_msg(spec: any) {
            ~~~~~~~~~~~~~~~~

node_modules/seneca/lib/inward.ts:81:10 - error TS7030: Not all code paths return a value.

81 function inward_closed(spec: any) {
            ~~~~~~~~~~~~~

node_modules/seneca/lib/inward.ts:119:10 - error TS7030: Not all code paths return a value.

119 function inward_act_default(spec: any) {
             ~~~~~~~~~~~~~~~~~~

node_modules/seneca/lib/inward.ts:166:10 - error TS7030: Not all code paths return a value.

166 function inward_act_not_found(spec: any) {
             ~~~~~~~~~~~~~~~~~~~~

node_modules/seneca/lib/inward.ts:195:10 - error TS7030: Not all code paths return a value.

195 function inward_validate_msg(spec: any) {
             ~~~~~~~~~~~~~~~~~~~

node_modules/seneca/lib/inward.ts:251:10 - error TS7030: Not all code paths return a value.

251 function inward_act_cache(spec: any) {
             ~~~~~~~~~~~~~~~~

node_modules/seneca/lib/inward.ts:404:10 - error TS7030: Not all code paths return a value.

404 function inward_sub(spec: any) {
             ~~~~~~~~~~

node_modules/seneca/lib/outward.ts:237:10 - error TS7030: Not all code paths return a value.

237 function outward_sub(spec: any) {
             ~~~~~~~~~~~

node_modules/seneca/lib/prior.ts:6:10 - error TS6133: 'Gubu' is declared but its value is never read.

6 import { Gubu, MakeArgu, Open, Skip, One, Empty } from 'gubu'
           ~~~~

node_modules/seneca/lib/prior.ts:6:26 - error TS6133: 'Open' is declared but its value is never read.

6 import { Gubu, MakeArgu, Open, Skip, One, Empty } from 'gubu'
                           ~~~~

node_modules/seneca/seneca.ts:45:17 - error TS2732: Cannot find module './package.json'. Consider using '--resolveJsonModule' to import module with '.json' extension.

45 import Pkg from './package.json'
                   ~~~~~~~~~~~~~~~~

node_modules/seneca/seneca.ts:487:38 - error TS2538: Type 'undefined' cannot be used as an index type.

487     var plugindesc = options.plugins[pluginkey]
                                         ~~~~~~~~~

node_modules/seneca/seneca.ts:490:38 - error TS2538: Type 'undefined' cannot be used as an index type.

490       seneca.private$.ignore_plugins[pluginkey] = true
```

</details>